### PR TITLE
erb_lintを追加

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,11 @@
+---
+glob: "**/*.{html,text,js}{+*,}.erb"
+exclude:
+  - '**/vendor/**/*'
+  - '**/node_modules/**/*'
+EnableDefaultLinters: true
+linters:
+  ErbSafety:
+    enabled: true
+  SelfClosingTag:
+    enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
   gem "rubocop-performance", require: false
+  gem "erb_lint", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,13 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
     bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.4)
@@ -99,6 +106,13 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.1)
+    erb_lint (0.6.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop (>= 1)
+      smart_properties
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -244,6 +258,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -290,6 +305,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  erb_lint
   jbuilder
   jsbundling-rails
   pg (~> 1.1)


### PR DESCRIPTION
## Issue

- #35 

## 概要
erb_lintを追加し、erb_lintの設定ファイルを追加した。

## 備考

erb_lint gemは今、[命名の統一作業](https://github.com/Shopify/erb_lint/pull/360)を行なっている模様。
将来のバージョンでは、コマンドの実行や設定ファイルが`erb_lint`(アンダースコアで区切る)に変更されるようなので、留意すること。