### PR TITLE
Prettierの追加

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "trailingComma": "es5",
   "semi": false,
   "singleQuote": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": true
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
-import "./controllers"
+import '@hotwired/turbo-rails'
+import './controllers'

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,9 @@
-import { Application } from "@hotwired/stimulus"
+import { Application } from '@hotwired/stimulus'
 
 const application = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
-window.Stimulus   = application
+window.Stimulus = application
 
 export { application }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,7 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   connect() {
-    this.element.textContent = "Hello World!"
+    this.element.textContent = 'Hello World!'
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,7 +2,7 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application"
+import { application } from './application'
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import HelloController from './hello_controller'
+application.register('hello', HelloController)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,14 +1,16 @@
 import js from "@eslint/js";
 import react from "eslint-plugin-react"
 import reactHooks from "eslint-plugin-react-hooks"
+import prettier from "eslint-config-prettier"
 import jsxA11y from "eslint-plugin-jsx-a11y"
 import globals from "globals";
 
 export default [
-    js.configs.recommended,
-    react.configs.flat.recommended,
-    react.configs.flat['jsx-runtime'], /* React 17+ で必要 */
-    jsxA11y.flatConfigs.recommended,
+  js.configs.recommended,
+  react.configs.flat.recommended,
+  react.configs.flat['jsx-runtime'], /* React 17+ で必要 */
+  jsxA11y.flatConfigs.recommended,
+  prettier /* eslint-config-prettierは、上書きしたいプラグインより後に記述する必要がある */,
 
     {
         files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,44 +1,44 @@
-import js from "@eslint/js";
-import react from "eslint-plugin-react"
-import reactHooks from "eslint-plugin-react-hooks"
-import prettier from "eslint-config-prettier"
-import jsxA11y from "eslint-plugin-jsx-a11y"
-import globals from "globals";
+import js from '@eslint/js'
+import react from 'eslint-plugin-react'
+import reactHooks from 'eslint-plugin-react-hooks'
+import prettier from 'eslint-config-prettier'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
+import globals from 'globals'
 
 export default [
   js.configs.recommended,
   react.configs.flat.recommended,
-  react.configs.flat['jsx-runtime'], /* React 17+ で必要 */
+  react.configs.flat['jsx-runtime'] /* React 17+ で必要 */,
   jsxA11y.flatConfigs.recommended,
   prettier /* eslint-config-prettierは、上書きしたいプラグインより後に記述する必要がある */,
 
-    {
-        files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
-        settings: {
-            react: {
-                version: "detect",
-            },
+  {
+    files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+    plugins: {
+      react,
+      'react-hooks': reactHooks,
+      jsxA11y,
+    },
+    rules: {
+      'no-unused-vars': 'warn',
+      'no-undef': 'warn',
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
         },
-        plugins: {
-            react,
-            "react-hooks": reactHooks,
-            jsxA11y,
-        },
-        rules: {
-            "no-unused-vars": "warn",
-            "no-undef": "warn",
-            "react-hooks/rules-of-hooks": "error",
-            "react-hooks/exhaustive-deps": "warn",
-        },
-        languageOptions: {
-            parserOptions: {
-                ecmaFeatures: {
-                    jsx: true,
-                },
-            },
-            globals: {
-                ...globals.browser
-            }
-        }
-    }
-];
+      },
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
+]

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.0",
         "eslint-plugin-react-hooks": "^4.6.2",
-        "globals": "^15.9.0"
+        "globals": "^15.9.0",
+        "prettier": "3.3.3"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -2521,6 +2522,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@eslint/js": "^9.11.1",
         "esbuild": "^0.24.0",
         "eslint": "^8.57.1",
+        "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.0",
         "eslint-plugin-react-hooks": "^4.6.2",
@@ -1068,6 +1069,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "globals": "^15.9.0"
+    "globals": "^15.9.0",
+    "prettier": "3.3.3"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@eslint/js": "^9.11.1",
     "esbuild": "^0.24.0",
     "eslint": "^8.57.1",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-react": "^7.37.0",
     "eslint-plugin-react-hooks": "^4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -589,6 +589,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz"
+  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+
 eslint-plugin-jsx-a11y@^6.10.0:
   version "6.10.0"
   resolved "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz"
@@ -653,7 +658,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-"eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^8.57.1:
+"eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9", "eslint@^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7", "eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^8.57.1, eslint@>=7.0.0:
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==


### PR DESCRIPTION
## Issue
- #35 

## 概要
Prettierを追加し、設定を行った。

ESLintと競合する可能性があるため、eslint-config-prettierを追加している。
eslint-config-prettierは以下のプラグインも一部のルールをオフにしている模様。

https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#plugins

## Screenshot
[eslint-config-prettierのコマンドラインヘルパー](https://github.com/prettier/eslint-config-prettier?tab=readme-ov-file#cli-helper-tool)で不要なルールや競合するルールがないかを確認。

![5C455443-74FA-4A70-AADC-BDD8D9D5FF5E_4_5005_c](https://github.com/user-attachments/assets/67c66377-f681-48ae-9b35-7080572774bc)


## 備考
Prettierの各ルール詳細。

https://prettier.io/docs/en/options
