### PR TITLE
LinterとFormatterをまとめて実行するコマンドを追加した

### DIFF
--- a/bin/run_lint
+++ b/bin/run_lint
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+bundle exec rubocop
+bundle exec erblint --lint-all
+npm run lint:eslint
+npm run lint:prettier

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "prettier": "3.3.3"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
+    "lint:eslint": "eslint app/javascript/",
+    "lint:prettier": "prettier -c app/javascript/"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",


### PR DESCRIPTION
## Issue
- #35 

## 概要
以下の順番でLinter/Formatterが実行されるスクリプトを追加した。

1. rubocop
2. erb_lint
3. eslint
4. prettier

## Screenshot
`bin/run_lint`でコマンドを実行可能。

![8EDDB9C6-CF63-4DD1-A6B6-147D53D82CBF](https://github.com/user-attachments/assets/2bba2b84-f389-4066-941f-0004822363b4)


## 備考
`set -e`に関する記事。

[シェルスクリプトを書く時には set \-e をつけた方がいいのかな\.\.\.どうなんだろう \- ようへいの日々精進XP](https://inokara.hateblo.jp/entry/2020/06/27/084149)
