### PR TITLE
Tailwind CSSを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
+gem "tailwindcss-rails", "~> 2.7"
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,18 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
+    tailwindcss-rails (2.7.6)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.6-aarch64-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.6-arm-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.6-arm64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.6-x86_64-darwin)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.7.6-x86_64-linux)
+      railties (>= 7.0.0)
     thor (1.3.2)
     timeout (0.4.1)
     turbo-rails (2.0.10)
@@ -318,6 +330,7 @@ DEPENDENCIES
   selenium-webdriver
   sprockets-rails
   stimulus-rails
+  tailwindcss-rails (~> 2.7)
   turbo-rails
   tzinfo-data
   web-console

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
+css: bin/rails tailwindcss:watch

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/*
+
+@layer components {
+  .btn-primary {
+    @apply py-2 px-4 bg-blue-200;
+  }
+}
+
+*/

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,11 +13,14 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
   <body>
-    <%= yield %>
+    <main class="container mx-auto mt-28 px-5 flex">
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/bin/dev
+++ b/bin/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-if gem list --no-installed --exact --silent foreman; then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
@@ -8,4 +8,9 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
-exec foreman start -f Procfile.dev --env /dev/null "$@"
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,22 @@
+const defaultTheme = require('tailwindcss/defaultTheme')
+
+module.exports = {
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.{js,jsx}',
+    './app/views/**/*.{erb,haml,html,slim}',
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+      },
+    },
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ],
+}


### PR DESCRIPTION
## Issue
- #47 

## 概要
tailwindcss-rails gemと設定ファイルを追加し、アプリ内でTailwind CSSが利用できるようにした。

## 備考
Reactを利用するため、以下を参考に設定ファイルにパスを追加した。
https://tailwindcss.com/docs/guides/create-react-app