### PR TITLE
Herokuにデプロイするための設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+ruby file: '.ruby-version'
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.1"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.7)
     minitest (5.25.1)
     msgpack (1.7.2)
     net-imap (0.4.16)
@@ -153,6 +154,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.16.7-arm-linux)
@@ -308,6 +312,7 @@ PLATFORMS
   aarch64-linux
   arm-linux
   arm64-darwin
+  ruby
   x86-linux
   x86_64-darwin
   x86_64-linux

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bundle exec rake db:migrate
 web: bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## Issue
- #40 

## 概要
Herokuにデプロイを行うための設定をアプリに追加した。


## 備考
### 自動デプロイ
HerokuのAutomatic deploys機能を利用し、mainブランチにコードがpushされるとHerokuに自動でデプロイされるようにした。
CI環境を整えたら、以下のページの`Automatic deploys` → `Wait for CI to pass before deploy`にチェックを入れる。

https://dashboard.heroku.com/apps/fjord-minutes/deploy/github

### pumaの設定
Herokuがpumaの推奨設定を公開している。
https://devcenter.heroku.com/ja/articles/deploying-rails-applications-with-the-puma-web-server#config

ただ、現時点で設定を十分に理解することができないため、Railsがデフォルトで生成するファイルをそのまま利用することにした。

将来的にはpumaの推奨設定を利用したいと考えている。