### PR TITLE
Herokuでビルドを通すために、Gemfile.lock内でRubyのバージョンを指定

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,5 +340,8 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
+RUBY VERSION
+   ruby 3.3.5p100
+
 BUNDLED WITH
    2.5.16


### PR DESCRIPTION
## Issue
- #40 

## 概要
#52 をマージし本番環境でデプロイを行ったところ、ビルドでエラーが発生した。
エラーを解消するために、Gemfile.lock内でRubyのバージョンを指定した。

エラー文
```
-----> Building on the Heroku-22 stack
-----> Determining which buildpack to use for this app
 !     Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
			Detected buildpacks: Ruby,Node.js
			See https://devcenter.heroku.com/articles/buildpacks#buildpack-detect-order
-----> Ruby app detected
-----> Installing bundler 2.5.6
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rails
###### WARNING:
       No ruby version specified in the Gemfile.lock
       
       We could not determine the version of Ruby from your Gemfile.lock.
       
         $ bundle platform --ruby
         No ruby version specified
       
         $ bundle -v
         Bundler version 2.5.6
       
       
       Ensure the above command outputs the version of Ruby you expect. If you have a ruby version specified in your Gemfile, you can update the Gemfile.lock by running the following command:
       
         $ bundle update --ruby
       
       Make sure you commit the results to git before attempting to deploy again:
       
         $ git add Gemfile.lock
         $ git commit -m "update ruby version"
-----> Using Ruby version: ruby-3.1.6
-----> Installing dependencies using bundler 2.5.6
       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       Your Ruby version is 3.1.6, but your Gemfile specified 3.3.5
       Bundler Output: Your Ruby version is 3.1.6, but your Gemfile specified 3.3.5

 !
 !     Failed to install gems via Bundler.
 !     Detected a mismatch between your Ruby version installed and
 !     Ruby version specified in Gemfile or Gemfile.lock. You can
 !     correct this by running:
 !     
 !     $ bundle update --ruby
 !     $ git add Gemfile.lock
 !     $ git commit -m "update ruby version"
 !     
 !     If this does not solve the issue please see this documentation:
 !     
 !     https://devcenter.heroku.com/articles/ruby-versions#your-ruby-version-is-x-but-your-gemfile-specified-y
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed
```
