### PR TITLE
Topicモデルを追加

### DIFF
--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -1,3 +1,4 @@
 class Minute < ApplicationRecord
   belongs_to :course
+  has_many :topics, dependent: :destroy
 end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,3 @@
+class Topic < ApplicationRecord
+  belongs_to :minute
+end

--- a/db/migrate/20241001102235_create_topics.rb
+++ b/db/migrate/20241001102235_create_topics.rb
@@ -1,0 +1,10 @@
+class CreateTopics < ActiveRecord::Migration[7.2]
+  def change
+    create_table :topics do |t|
+      t.string :content, null: false
+      t.references :minute, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_01_093422) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_01_102235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,5 +34,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_01_093422) do
     t.index ["course_id"], name: "index_minutes_on_course_id"
   end
 
+  create_table "topics", force: :cascade do |t|
+    t.string "content", null: false
+    t.bigint "minute_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["minute_id"], name: "index_topics_on_minute_id"
+  end
+
   add_foreign_key "minutes", "courses"
+  add_foreign_key "topics", "minutes"
 end


### PR DESCRIPTION
## Issue
- #54 
## 概要
議事録のTopicモデルを追加した。

## 備考
本来であれば、Topicモデルはポリモーフィック関連付けで作者の情報を取得できる。
まだメンバー・管理者モデルを追加していないので、メンバー・管理者モデルを追加した際にポリモーフィック関連付けのカラムを追加する。
