### PR TITLE
fetchAPIで送信するパラメーターを修正

### DIFF
--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -38,8 +38,8 @@ function EditForm({ minuteId, description, content, setIsEditing }) {
     e.preventDefault()
     const parameter =
       description === 'branch'
-        ? { release_branch: inputValue }
-        : { release_note: inputValue }
+        ? { minute: { release_branch: inputValue } }
+        : { minute: { release_note: inputValue } }
     const csrfToken = document.head.querySelector(
       'meta[name=csrf-token]'
     )?.content


### PR DESCRIPTION
## Issue
なし。

## 概要
`ReleaseInformationForm.jsx`内からAPIコントローラーに送信されるJSONが、モデル名(`minute`)をキーとして明示していなかった為、明示するように修正した。

## Screenshot
### 変更前
![2B265CA6-7AB8-4371-9B8D-6BC028A13EC9](https://github.com/user-attachments/assets/37cfb9aa-065a-42cb-b140-dcec37f495b4)

※ パラメーターの後半に`"minute"=>{"release_branch"=>"https://github/fjordlc/bootcamp/pull/xyzyz"}`というパラメーターが追加されているが、自分で設定したものではないため謎。

### 変更後
![1AB20C10-C3ED-44F1-91BE-53541A7092E5](https://github.com/user-attachments/assets/c39ea8f8-75c5-482d-b99a-0f55e3890488)


