### PR TITLE
その他編集フォームを追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
-@layer components {
-  .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
-  }
+@layer utilities {
+    .field-sizing-content {
+        /*field-sizingはまだ実験的機能でTailwindに実装されていないため、カスタムCSSという形で追加する*/
+        field-sizing: content;
+    }
 }
-
-*/

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -12,6 +12,6 @@ class API::MinutesController < API::BaseController
   private
 
   def minute_params
-    params.require(:minute).permit(:release_branch, :release_note)
+    params.require(:minute).permit(:release_branch, :release_note, :other)
   end
 end

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -1,5 +1,7 @@
 import mountComponent from './mountComponent.jsx'
 import ReleaseInformationForm from './components/ReleaseInformationForm.jsx'
+import OtherForm from './components/OtherForm.jsx'
 
 mountComponent('release_branch_form', ReleaseInformationForm)
 mountComponent('release_note_form', ReleaseInformationForm)
+mountComponent('other_form', OtherForm)

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+
+export default function OtherForm({ minuteId, content }) {
+  const [inputValue, setInputValue] = useState(content)
+
+  const handleChange = function (e) {
+    setInputValue(e.target.value)
+  }
+
+  const handleClick = async function (e) {
+    e.preventDefault()
+    const parameter = { minute: { other: inputValue } }
+    const csrfToken = document.head.querySelector(
+      'meta[name=csrf-token]'
+    )?.content
+
+    const response = await fetch(`/api/minutes/${minuteId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(parameter),
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': csrfToken,
+      },
+    })
+
+    if (response.status !== 200) {
+      const errorData = await response.json()
+      console.error(errorData.errors.join(','))
+    }
+  }
+
+  return (
+    <>
+      <textarea
+        value={inputValue}
+        onChange={handleChange}
+        className="w-[400px] resize-y align-middle field-sizing-content"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        className="ml-2 py-1 px-2 border border-black"
+      >
+        更新
+      </button>
+    </>
+  )
+}
+
+OtherForm.propTypes = {
+  minuteId: PropTypes.number,
+  content: PropTypes.string,
+}

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -6,6 +6,11 @@
   <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch}.to_json do %><% end %>
   <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note}.to_json do %><% end %>
 
+  <h3 class="font-bold text-xl">デモ</h3>
+  <p>
+    今回のイテレーションで実装した機能をプロダクトオーナーに向けてデモします。（画面共有使用） 「お客様」相手にデモをするという設定なので、MTG前に事前に準備をしておくといいかもしれません。 テストデータなどは事前に準備しておいてください。
+  </p>
+
   <div class="mt-16">
     <%= link_to "Back to minutes", minutes_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <%= link_to "Show this minute", @minute, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -11,6 +11,9 @@
     今回のイテレーションで実装した機能をプロダクトオーナーに向けてデモします。（画面共有使用） 「お客様」相手にデモをするという設定なので、MTG前に事前に準備をしておくといいかもしれません。 テストデータなどは事前に準備しておいてください。
   </p>
 
+  <h3 class="font-bold text-xl">その他</h3>
+  <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other}.to_json do %><% end %>
+
   <div class="mt-16">
     <%= link_to "Back to minutes", minutes_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <%= link_to "Show this minute", @minute, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>


### PR DESCRIPTION
## Issue
- #54 

## 概要
以下の変更を行った。

- 議事録編集ページに、`デモ`の項目を追加(文字列のみ追加)
- 議事録の「その他」を編集するフォームを追加

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/96ff93e37b7c30fe74067d1e499a026e.gif)](https://gyazo.com/96ff93e37b7c30fe74067d1e499a026e)


## 備考
テキストエリアは入力された値に応じて高さが調整されるようになっているが、これは`field-content`プロパティを利用しているためである。

https://developer.mozilla.org/ja/docs/Web/CSS/field-sizing

現時点(2024/10/05)では次のような対応状況になっている。
![20D4E3CE-AC19-429A-91E5-EEB3C61DF3CF](https://github.com/user-attachments/assets/c597508a-98db-47af-9b97-5eaedb04d7bc)

「その他」編集テキストエリアは駒形さん町田さんしか利用せず、お二方はChromeを利用していると想定されるので、`field-content`プロパティを採用しても大丈夫だと判断した。
