### PR TITLE
「話題にしたいこと・心配事」を一覧表示し、編集フォームを追加

### DIFF
--- a/app/controllers/api/minutes/application_controller.rb
+++ b/app/controllers/api/minutes/application_controller.rb
@@ -1,0 +1,9 @@
+class API::Minutes::ApplicationController < API::BaseController
+  before_action :set_minute
+
+  private
+
+  def set_minute
+    @minute = Minute.find(params[:minute_id])
+  end
+end

--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -1,0 +1,15 @@
+class API::Minutes::TopicsController < API::Minutes::ApplicationController
+  def create
+    if @minute.topics.create(topic_params)
+      render json: @minute, status: :created
+    else
+      render json: { errors: @minute.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def topic_params
+    params.require(:topic).permit(:content)
+  end
+end

--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -17,6 +17,13 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     end
   end
 
+  def destroy
+    topic = @minute.topics.find(params[:id])
+    topic.destroy!
+
+    head :no_content
+  end
+
   private
 
   def topic_params

--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -8,6 +8,15 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     end
   end
 
+  def update
+    topic = @minute.topics.find(params[:id])
+    if topic.update(topic_params)
+      render json: topic, status: :ok
+    else
+      render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def topic_params

--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -1,9 +1,10 @@
 class API::Minutes::TopicsController < API::Minutes::ApplicationController
   def create
-    if @minute.topics.create(topic_params)
+    topic = @minute.topics.new(topic_params)
+    if topic.save
       render json: @minute, status: :created
     else
-      render json: { errors: @minute.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -1,9 +1,11 @@
 import mountComponent from './mountComponent.jsx'
 import ReleaseInformationForm from './components/ReleaseInformationForm.jsx'
+import TopicList from './components/TopicList.jsx'
 import OtherForm from './components/OtherForm.jsx'
 import NextMeetingDateForm from './components/NextMeetingDateForm.jsx'
 
 mountComponent('release_branch_form', ReleaseInformationForm)
 mountComponent('release_note_form', ReleaseInformationForm)
+mountComponent('topics', TopicList)
 mountComponent('other_form', OtherForm)
 mountComponent('next_meeting_date_form', NextMeetingDateForm)

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -17,6 +17,29 @@ export default function TopicList({ minuteId, topics }) {
 function Topic({ minuteId, topic }) {
   const [isEditing, setIsEditing] = useState(false)
 
+  const handleDelete = async function (e) {
+    e.preventDefault()
+    const csrfToken = document.head.querySelector(
+      'meta[name=csrf-token]'
+    )?.content
+
+    const response = await fetch(
+      `/api/minutes/${minuteId}/topics/${topic.id}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+          'X-CSRF-Token': csrfToken,
+        },
+      }
+    )
+
+    if (response.status !== 204) {
+      const errorData = await response.json()
+      console.error(errorData.errors.join(','))
+    }
+  }
+
   return (
     <>
       {isEditing ? (
@@ -35,6 +58,13 @@ function Topic({ minuteId, topic }) {
             className="ml-2 py-1 px-2 border border-black"
           >
             編集
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="ml-2 py-1 px-2 border border-black"
+          >
+            削除
           </button>
         </li>
       )}

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -6,16 +6,95 @@ export default function TopicList({ minuteId, topics }) {
     <>
       <ul>
         {topics.map((topic) => (
-          <li
-            key={topic.id}
-            className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle"
-          >
-            {topic.content}
-          </li>
+          <Topic key={topic.id} minuteId={minuteId} topic={topic} />
         ))}
       </ul>
       <CreateForm minuteId={minuteId} />
     </>
+  )
+}
+
+function Topic({ minuteId, topic }) {
+  const [isEditing, setIsEditing] = useState(false)
+
+  return (
+    <>
+      {isEditing ? (
+        <EditForm
+          minuteId={minuteId}
+          topicId={topic.id}
+          content={topic.content}
+          setIsEditing={setIsEditing}
+        />
+      ) : (
+        <li className="pl-8 mb-2 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+          <span>{topic.content}</span>
+          <button
+            type="button"
+            onClick={() => setIsEditing(true)}
+            className="ml-2 py-1 px-2 border border-black"
+          >
+            編集
+          </button>
+        </li>
+      )}
+    </>
+  )
+}
+
+function EditForm({ minuteId, topicId, content, setIsEditing }) {
+  const [inputValue, setInputValue] = useState(content)
+  const isEmpty = inputValue === ''
+
+  const handleInput = function (e) {
+    setInputValue(e.target.value)
+  }
+
+  const handleClick = async function (e) {
+    e.preventDefault()
+    if (isEmpty) {
+      return null
+    }
+
+    const parameter = { topic: { content: inputValue } }
+    const csrfToken = document.head.querySelector(
+      'meta[name=csrf-token]'
+    )?.content
+
+    const response = await fetch(`/api/minutes/${minuteId}/topics/${topicId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(parameter),
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': csrfToken,
+      },
+    })
+
+    if (response.status === 200) {
+      setIsEditing(false)
+    } else {
+      const errorData = await response.json()
+      console.error(errorData.errors.join(','))
+    }
+  }
+
+  return (
+    <div className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
+      <input
+        type="text"
+        value={inputValue}
+        onChange={handleInput}
+        className="field-sizing-content max-w-[600px]"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isEmpty}
+        className="ml-2 py-1 px-2 border border-black disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200"
+      >
+        更新
+      </button>
+    </div>
   )
 }
 
@@ -78,6 +157,18 @@ function CreateForm({ minuteId }) {
 TopicList.propTypes = {
   minuteId: PropTypes.number,
   topics: PropTypes.array,
+}
+
+Topic.propTypes = {
+  minuteId: PropTypes.number,
+  topic: PropTypes.object,
+}
+
+EditForm.propTypes = {
+  minuteId: PropTypes.number,
+  topicId: PropTypes.number,
+  content: PropTypes.string,
+  setIsEditing: PropTypes.func,
 }
 
 CreateForm.propTypes = {

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -1,21 +1,79 @@
+import { useState } from 'react'
 import PropTypes from 'prop-types'
 
-export default function TopicList({ topics }) {
+export default function TopicList({ minuteId, topics }) {
   return (
-    <ul>
-      {topics.map((topic) => (
-        <li
-          key={topic.id}
-          className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle"
-        >
-          {topic.content}
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul>
+        {topics.map((topic) => (
+          <li
+            key={topic.id}
+            className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle"
+          >
+            {topic.content}
+          </li>
+        ))}
+      </ul>
+      <CreateForm minuteId={minuteId} />
+    </>
+  )
+}
+
+function CreateForm({ minuteId }) {
+  const [inputValue, setInputValue] = useState('')
+
+  const handleInput = function (e) {
+    setInputValue(e.target.value)
+  }
+
+  const handleClick = async function (e) {
+    e.preventDefault()
+    const parameter = { topic: { content: inputValue } }
+    const csrfToken = document.head.querySelector(
+      'meta[name=csrf-token]'
+    )?.content
+
+    const response = await fetch(`/api/minutes/${minuteId}/topics`, {
+      method: 'POST',
+      body: JSON.stringify(parameter),
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': csrfToken,
+      },
+    })
+
+    if (response.status === 201) {
+      setInputValue('')
+    } else {
+      const errorData = await response.json()
+      console.error(errorData.errors.join(','))
+    }
+  }
+
+  return (
+    <>
+      <input
+        type="text"
+        value={inputValue}
+        onChange={handleInput}
+        className="w-[400px]"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        className="ml-2 py-1 px-2 border border-black"
+      >
+        作成
+      </button>
+    </>
   )
 }
 
 TopicList.propTypes = {
   minuteId: PropTypes.number,
   topics: PropTypes.array,
+}
+
+CreateForm.propTypes = {
+  minuteId: PropTypes.number,
 }

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -21,6 +21,7 @@ export default function TopicList({ minuteId, topics }) {
 
 function CreateForm({ minuteId }) {
   const [inputValue, setInputValue] = useState('')
+  const isEmpty = inputValue === ''
 
   const handleInput = function (e) {
     setInputValue(e.target.value)
@@ -28,6 +29,10 @@ function CreateForm({ minuteId }) {
 
   const handleClick = async function (e) {
     e.preventDefault()
+    if (isEmpty) {
+      return null
+    }
+
     const parameter = { topic: { content: inputValue } }
     const csrfToken = document.head.querySelector(
       'meta[name=csrf-token]'
@@ -61,7 +66,8 @@ function CreateForm({ minuteId }) {
       <button
         type="button"
         onClick={handleClick}
-        className="ml-2 py-1 px-2 border border-black"
+        disabled={isEmpty}
+        className="ml-2 py-1 px-2 border border-black disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200"
       >
         作成
       </button>

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types'
+
+export default function TopicList({ topics }) {
+  return (
+    <ul>
+      {topics.map((topic) => (
+        <li
+          key={topic.id}
+          className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle"
+        >
+          {topic.content}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+TopicList.propTypes = {
+  minuteId: PropTypes.number,
+  topics: PropTypes.array,
+}

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,3 +1,5 @@
 class Topic < ApplicationRecord
   belongs_to :minute
+
+  validates :content, presence: true
 end

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,15 +1,15 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">ふりかえり・計画ミーティング<%= @minute.meeting_date.strftime('%Y年%m月%d日') %></h1>
 
-  <h3 class="font-bold text-xl">今週のリリースの確認</h3>
-  <p>木曜日の15時頃リリースします。</p>
-  <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch}.to_json do %><% end %>
-  <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note}.to_json do %><% end %>
-
   <h3 class="font-bold text-xl">デモ</h3>
   <p>
     今回のイテレーションで実装した機能をプロダクトオーナーに向けてデモします。（画面共有使用） 「お客様」相手にデモをするという設定なので、MTG前に事前に準備をしておくといいかもしれません。 テストデータなどは事前に準備しておいてください。
   </p>
+
+  <h3 class="font-bold text-xl">今週のリリースの確認</h3>
+  <p>木曜日の15時頃リリースします。</p>
+  <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch}.to_json do %><% end %>
+  <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">その他</h3>
   <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other}.to_json do %><% end %>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -13,7 +13,7 @@
 
   <h3 class="font-bold text-xl">話題にしたいこと・心配事</h3>
   <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>
-  <%= content_tag :div, id: 'topics', data: {topics: @minute.topics}.to_json do %><% end %>
+  <%= content_tag :div, id: 'topics', data: {minuteId: @minute.id, topics: @minute.topics}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">その他</h3>
   <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other}.to_json do %><% end %>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -11,6 +11,10 @@
   <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch}.to_json do %><% end %>
   <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note}.to_json do %><% end %>
 
+  <h3 class="font-bold text-xl">話題にしたいこと・心配事</h3>
+  <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>
+  <%= content_tag :div, id: 'topics', data: {topics: @minute.topics}.to_json do %><% end %>
+
   <h3 class="font-bold text-xl">その他</h3>
   <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other}.to_json do %><% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,9 @@ Rails.application.routes.draw do
   resources :minutes
 
   namespace :api do
-    resources :minutes, only: [ :update ]
+    resources :minutes, only: [ :update ] do
+      resources :topics, only: [ :create ], module: :minutes
+    end
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :minutes, only: [ :update ] do
-      resources :topics, only: [ :create, :update ], module: :minutes
+      resources :topics, only: [ :create, :update, :destroy ], module: :minutes
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :minutes, only: [ :update ] do
-      resources :topics, only: [ :create ], module: :minutes
+      resources :topics, only: [ :create, :update ], module: :minutes
     end
   end
 


### PR DESCRIPTION
## Issue
- #54 

## 概要
議事録編集ページに以下の機能を追加した。
- 「話題にしたいこと・心配事」を一覧で表示するようにした
- 作成された「話題にしたいこと・心配事」を編集・更新・削除できるようにした

## Screenshot
作成
[![Image from Gyazo](https://i.gyazo.com/70f5b80b4c6e82164561686967665ec0.gif)](https://gyazo.com/70f5b80b4c6e82164561686967665ec0)

編集→更新
[![Image from Gyazo](https://i.gyazo.com/e866e1237dfbbb4ba8c8bdcdfc2bb31f.gif)](https://gyazo.com/e866e1237dfbbb4ba8c8bdcdfc2bb31f)

削除
[![Image from Gyazo](https://i.gyazo.com/1aeabc7711d9626cb703e2fab9ed0cbb.gif)](https://gyazo.com/1aeabc7711d9626cb703e2fab9ed0cbb)
