### PR TITLE
XSS対策として、Content-Security-Policyヘッダーの設定を追加

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,22 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = [ "script-src", "style-src" ]
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end


### PR DESCRIPTION
## Issue
- #23 

## 概要
XSSを防ぐ手段として、レスポンスヘッダー内で[Content\-Security\-Policy](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Security-Policy)を定義するように設定を追加した。

※ 設定はデフォルトのものを利用

## Screenshot
設定追加後のレスポンスヘッダーの`Content-Security-Policy`の中身。

![C3E9C326-F76B-4C8B-9A72-A3EF7C6F48A9](https://github.com/user-attachments/assets/ccbc00c5-3652-4ca5-b429-7206619d464d)


## 備考
XSSとその対策について調査した内容はIssueを参照。
ここではContent-Security-Policyヘッダーの見方について記録しておく。

### CSPヘッダー
ヘッダーの中身は次のようになっている。(読みやすさのために改行を追加)
```
default-src 'self' https:; 
font-src 'self' https: data:; 
img-src 'self' https: data:; 
object-src 'none'; 
script-src 'self' https: 'nonce-8f6f0add9bd0f5ae5bf27bad2f88d321'; 
style-src 'self' https: 'nonce-8f6f0add9bd0f5ae5bf27bad2f88d321'
```

各行は`policy-directive`と呼ばれ、`policy-directive`は`directive`と`value`から構成されている。
`default-src 'self' https:; `であれば、次のようになる。
- `policy-directive` : `default-src 'self' https:; `
- `directive` : `default-src`
- `value` : `'self'`, `https:`

各`directive`の詳細は以下参照。
https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Security-Policy#%E3%83%95%E3%82%A7%E3%83%83%E3%83%81%E3%83%87%E3%82%A3%E3%83%AC%E3%82%AF%E3%83%86%E3%82%A3%E3%83%96

各`value`の詳細は以下参照
https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#%E3%82%BD%E3%83%BC%E3%82%B9
