### PR TITLE
議事録の編集をリアルタイムで反映するようにした

### DIFF
--- a/app/channels/minute_channel.rb
+++ b/app/channels/minute_channel.rb
@@ -1,0 +1,6 @@
+class MinuteChannel < ApplicationCable::Channel
+  def subscribed
+    minute = Minute.find(params[:id])
+    stream_for minute
+  end
+end

--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -3,6 +3,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     topic = @minute.topics.new(topic_params)
     if topic.save
       render json: @minute, status: :created
+      broadcast_to_channel
     else
       render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
     end
@@ -12,6 +13,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     topic = @minute.topics.find(params[:id])
     if topic.update(topic_params)
       render json: topic, status: :ok
+      broadcast_to_channel
     else
       render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
     end
@@ -22,11 +24,16 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     topic.destroy!
 
     head :no_content
+    broadcast_to_channel
   end
 
   private
 
   def topic_params
     params.require(:topic).permit(:content)
+  end
+
+  def broadcast_to_channel
+    MinuteChannel.broadcast_to(@minute, body: { topics: @minute.topics.order(:created_at).as_json(only: [ :id, :content ]) })
   end
 end

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -4,6 +4,7 @@ class API::MinutesController < API::BaseController
 
     if minute.update(minute_params)
       render json: minute, status: :ok
+      MinuteChannel.broadcast_to(minute, body: { minute: minute.as_json(only: [ :release_branch, :release_note ]) })
     else
       render json: { errors: minute.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -4,7 +4,7 @@ class API::MinutesController < API::BaseController
 
     if minute.update(minute_params)
       render json: minute, status: :ok
-      MinuteChannel.broadcast_to(minute, body: { minute: minute.as_json(only: [ :release_branch, :release_note, :other ]) })
+      MinuteChannel.broadcast_to(minute, body: { minute: minute.as_json(only: [ :release_branch, :release_note, :other, :next_meeting_date ]) })
     else
       render json: { errors: minute.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -4,7 +4,7 @@ class API::MinutesController < API::BaseController
 
     if minute.update(minute_params)
       render json: minute, status: :ok
-      MinuteChannel.broadcast_to(minute, body: { minute: minute.as_json(only: [ :release_branch, :release_note ]) })
+      MinuteChannel.broadcast_to(minute, body: { minute: minute.as_json(only: [ :release_branch, :release_note, :other ]) })
     else
       render json: { errors: minute.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from '@rails/actioncable'
+
+export default createConsumer()

--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
 import weekday from 'dayjs/plugin/weekday'
 import holidayJP from '@holiday-jp/holiday_jp'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
-import consumer from '../channels/consumer.js'
+import useChannel from '../hooks/useChannel.js'
 
 dayjs.locale(ja)
 dayjs.extend(weekday)
@@ -14,22 +14,12 @@ export default function NextMeetingDateForm({ minuteId, nextMeetingDate }) {
   const [date, setDate] = useState(nextMeetingDate)
   const [isEditing, setIsEditing] = useState(false)
 
-  useEffect(() => {
-    consumer.subscriptions.create(
-      { channel: 'MinuteChannel', id: minuteId },
-      {
-        received(data) {
-          if ('minute' in data.body) {
-            setDate(data.body.minute.next_meeting_date)
-          }
-        },
-      }
-    )
-
-    return () => {
-      consumer.disconnect()
+  const onReceivedData = function (data) {
+    if ('minute' in data.body) {
+      setDate(data.body.minute.next_meeting_date)
     }
-  }, [minuteId])
+  }
+  useChannel(minuteId, onReceivedData)
 
   return (
     <>

--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import dayjs from 'dayjs'
 import ja from 'dayjs/locale/ja'
 import weekday from 'dayjs/plugin/weekday'
@@ -14,11 +14,11 @@ export default function NextMeetingDateForm({ minuteId, nextMeetingDate }) {
   const [date, setDate] = useState(nextMeetingDate)
   const [isEditing, setIsEditing] = useState(false)
 
-  const onReceivedData = function (data) {
+  const onReceivedData = useCallback(function (data) {
     if ('minute' in data.body) {
       setDate(data.body.minute.next_meeting_date)
     }
-  }
+  }, [])
   useChannel(minuteId, onReceivedData)
 
   return (

--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -19,7 +19,9 @@ export default function NextMeetingDateForm({ minuteId, nextMeetingDate }) {
       { channel: 'MinuteChannel', id: minuteId },
       {
         received(data) {
-          setDate(data.body.minute.next_meeting_date)
+          if ('minute' in data.body) {
+            setDate(data.body.minute.next_meeting_date)
+          }
         },
       }
     )

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
@@ -6,11 +6,11 @@ import useChannel from '../hooks/useChannel.js'
 export default function OtherForm({ minuteId, content }) {
   const [inputValue, setInputValue] = useState(content)
 
-  const onReceivedData = function (data) {
+  const onReceivedData = useCallback(function (data) {
     if ('minute' in data.body) {
       setInputValue(data.body.minute.other)
     }
-  }
+  }, [])
   useChannel(minuteId, onReceivedData)
 
   const handleChange = function (e) {

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -1,9 +1,25 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
+import consumer from '../channels/consumer.js'
 
 export default function OtherForm({ minuteId, content }) {
   const [inputValue, setInputValue] = useState(content)
+
+  useEffect(() => {
+    consumer.subscriptions.create(
+      { channel: 'MinuteChannel', id: minuteId },
+      {
+        received(data) {
+          setInputValue(data.body.minute.other)
+        },
+      }
+    )
+
+    return () => {
+      consumer.disconnect()
+    }
+  }, [minuteId])
 
   const handleChange = function (e) {
     setInputValue(e.target.value)

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -1,27 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
-import consumer from '../channels/consumer.js'
+import useChannel from '../hooks/useChannel.js'
 
 export default function OtherForm({ minuteId, content }) {
   const [inputValue, setInputValue] = useState(content)
 
-  useEffect(() => {
-    consumer.subscriptions.create(
-      { channel: 'MinuteChannel', id: minuteId },
-      {
-        received(data) {
-          if ('minute' in data.body) {
-            setInputValue(data.body.minute.other)
-          }
-        },
-      }
-    )
-
-    return () => {
-      consumer.disconnect()
+  const onReceivedData = function (data) {
+    if ('minute' in data.body) {
+      setInputValue(data.body.minute.other)
     }
-  }, [minuteId])
+  }
+  useChannel(minuteId, onReceivedData)
 
   const handleChange = function (e) {
     setInputValue(e.target.value)

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -11,7 +11,9 @@ export default function OtherForm({ minuteId, content }) {
       { channel: 'MinuteChannel', id: minuteId },
       {
         received(data) {
-          setInputValue(data.body.minute.other)
+          if ('minute' in data.body) {
+            setInputValue(data.body.minute.other)
+          }
         },
       }
     )

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -16,8 +16,10 @@ export default function ReleaseInformationForm({
       { channel: 'MinuteChannel', id: minuteId },
       {
         received(data) {
-          const key = `release_${description}`
-          setInformationContent(data.body.minute[key])
+          if ('minute' in data.body) {
+            const key = `release_${description}`
+            setInformationContent(data.body.minute[key])
+          }
         },
       }
     )

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
@@ -11,12 +11,15 @@ export default function ReleaseInformationForm({
   const [informationContent, setInformationContent] = useState(content)
   const [isEditing, setIsEditing] = useState(false)
 
-  const onReceivedData = function (data) {
-    if ('minute' in data.body) {
-      const key = `release_${description}`
-      setInformationContent(data.body.minute[key])
-    }
-  }
+  const onReceivedData = useCallback(
+    function (data) {
+      if ('minute' in data.body) {
+        const key = `release_${description}`
+        setInformationContent(data.body.minute[key])
+      }
+    },
+    [description]
+  )
   useChannel(minuteId, onReceivedData)
 
   const label = description === 'branch' ? 'リリースブランチ' : 'リリースノート'

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
-import consumer from '../channels/consumer.js'
+import useChannel from '../hooks/useChannel.js'
 
 export default function ReleaseInformationForm({
   minuteId,
@@ -11,24 +11,13 @@ export default function ReleaseInformationForm({
   const [informationContent, setInformationContent] = useState(content)
   const [isEditing, setIsEditing] = useState(false)
 
-  useEffect(() => {
-    consumer.subscriptions.create(
-      { channel: 'MinuteChannel', id: minuteId },
-      {
-        received(data) {
-          if ('minute' in data.body) {
-            const key = `release_${description}`
-            setInformationContent(data.body.minute[key])
-          }
-        },
-      }
-    )
-
-    return () => {
-      // WebSocket接続を切断する : https://github.com/rails/rails/blob/f903206386a9e7d125c13dcdaa22be65680f428c/actioncable/app/javascript/action_cable/consumer.js#L19
-      consumer.disconnect()
+  const onReceivedData = function (data) {
+    if ('minute' in data.body) {
+      const key = `release_${description}`
+      setInformationContent(data.body.minute[key])
     }
-  }, [description, minuteId])
+  }
+  useChannel(minuteId, onReceivedData)
 
   const label = description === 'branch' ? 'リリースブランチ' : 'リリースノート'
 

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
@@ -6,11 +6,11 @@ import useChannel from '../hooks/useChannel.js'
 export default function TopicList({ minuteId, topics }) {
   const [allTopics, setAllTopics] = useState(topics)
 
-  const onReceivedData = function (data) {
+  const onReceivedData = useCallback(function (data) {
     if ('topics' in data.body) {
       setAllTopics(data.body.topics)
     }
-  }
+  }, [])
   useChannel(minuteId, onReceivedData)
 
   return (

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -1,12 +1,32 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
+import consumer from '../channels/consumer.js'
 
 export default function TopicList({ minuteId, topics }) {
+  const [allTopics, setAllTopics] = useState(topics)
+
+  useEffect(() => {
+    consumer.subscriptions.create(
+      { channel: 'MinuteChannel', id: minuteId },
+      {
+        received(data) {
+          if ('topics' in data.body) {
+            setAllTopics(data.body.topics)
+          }
+        },
+      }
+    )
+
+    return () => {
+      consumer.disconnect()
+    }
+  }, [minuteId])
+
   return (
     <>
       <ul>
-        {topics.map((topic) => (
+        {allTopics.map((topic) => (
           <Topic key={topic.id} minuteId={minuteId} topic={topic} />
         ))}
       </ul>

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -1,27 +1,17 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
-import consumer from '../channels/consumer.js'
+import useChannel from '../hooks/useChannel.js'
 
 export default function TopicList({ minuteId, topics }) {
   const [allTopics, setAllTopics] = useState(topics)
 
-  useEffect(() => {
-    consumer.subscriptions.create(
-      { channel: 'MinuteChannel', id: minuteId },
-      {
-        received(data) {
-          if ('topics' in data.body) {
-            setAllTopics(data.body.topics)
-          }
-        },
-      }
-    )
-
-    return () => {
-      consumer.disconnect()
+  const onReceivedData = function (data) {
+    if ('topics' in data.body) {
+      setAllTopics(data.body.topics)
     }
-  }, [minuteId])
+  }
+  useChannel(minuteId, onReceivedData)
 
   return (
     <>

--- a/app/javascript/hooks/useChannel.js
+++ b/app/javascript/hooks/useChannel.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+import consumer from '../channels/consumer.js'
+
+export default function useChannel(minuteId, callback) {
+  useEffect(() => {
+    consumer.subscriptions.create(
+      { channel: 'MinuteChannel', id: minuteId },
+      {
+        received(data) {
+          callback(data)
+        },
+      }
+    )
+
+    return () => {
+      // WebSocket接続を切断する : https://github.com/rails/rails/blob/f903206386a9e7d125c13dcdaa22be65680f428c/actioncable/app/javascript/action_cable/consumer.js#L19
+      consumer.disconnect()
+    }
+  }, [minuteId, callback])
+}


### PR DESCRIPTION
## Issue
- #54 

## 概要
議事録の各項目を更新すると、更新内容が他のブラウザでもリアルタイムで反映されるようにした。

## Screenshot
例として、リリースブランチを変更した時のスクリーンショット。
(左画面がChrome, 右画面がSafariで収録)
[![Image from Gyazo](https://i.gyazo.com/6301f8d92e7294b819c72745312b92a2.gif)](https://gyazo.com/6301f8d92e7294b819c72745312b92a2)
