### PR TITLE
本番環境でRedisがTLS接続を行うための設定を追加

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+$redis = Redis.new(url: ENV["REDIS_URL"], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE })


### PR DESCRIPTION
## Issue
- #54 

関連PR
- #68 

## 概要
Heroku Data for Redisの本番環境プランではTLS接続が必須になるため、RedisのTLS接続の設定を追加した。

## 備考
Heroku Data for RedisのMiniプランでは、TLS接続と非暗号化接続の両方をサポートしていたが、2024/12/02以降はTLSが必要となる。

現時点(2024/10/10)で次の環境変数が使われている。
- `REDIS_TLS_URL`
  - TLS接続用URL
  - redissスキームを利用し、TLSポートを指定する

- `REDIS_URL`
  - 非TLS接続URL
  -  redisスキームを利用し、非TLSポートを指定する

https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance

2024/09/30以降、**`REDIS_URL`が安全なTLS接続URLとなるように変更された**。
https://devcenter.heroku.com/changelog-items/2992

そのため、`REDIS_URL`にTLS接続用URLを設定する必要がある。

Railsアプリケーション側の設定は次のページを参照した。
https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby