### PR TITLE
本番環境でTLSを利用するようにActionCableの設定を追加

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,3 +8,5 @@ production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: fjord_minutes_production
+  ssl_params:
+    verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>


### PR DESCRIPTION
## Issue
- #54 

関連PR
- #70 

## 概要
#70 で設定を追加したが、本番環境で次のエラーが発生した。(一部抜粋)

```
Redis::CannotConnectError (SSL_connect returned=1 errno=0 peeraddr=[54.146.141.60]))
RedisClient::CannotConnectError (SSL_connect returned=1 errno=0 peeraddr=[54.146.141.60])
penSSL::SSL::SSLError (SSL_connect returned=1 errno=0 peeraddr=[54.146.141.60])
```

エラーメッセージで検索してみると、次の記事がヒットした。
https://qiita.com/sazumy/items/1a7c1aefb3d91205035a

[ActionCableの設定](https://railsguides.jp/action_cable_overview.html#redis%E3%82%A2%E3%83%80%E3%83%97%E3%82%BF)を行う必要があるようなので、設定を追加した。