### PR TITLE
ログイン機能と認可機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  devise_group :development_member, contains: [ :member, :admin ]
 
   def after_sign_in_path_for(resource)
     root_path
+  end
+
+  private
+
+  def admin_login?
+    development_member_signed_in? && current_development_member.is_a?(Admin)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
   devise_group :development_member, contains: [ :member, :admin ]
+  before_action :authenticate_development_member!
 
   def after_sign_in_path_for(resource)
     root_path

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_before_action :authenticate_development_member!, only: [ :index ]
+
   def index
     if current_development_member
       template = admin_login? ? "admin_dashboard" : "member_dashboard"

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,8 @@
 class HomeController < ApplicationController
   def index
-    if current_member
-      render "member_dashboard"
+    if current_development_member
+      template = admin_login? ? "admin_dashboard" : "member_dashboard"
+      render template
     else
       render "index"
     end

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -1,4 +1,5 @@
 class MinutesController < ApplicationController
+  skip_before_action :authenticate_development_member!, only: [ :index ]
   before_action :set_minute, only: %i[ show edit update destroy ]
 
   # GET /minutes or /minutes.json

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,0 +1,6 @@
+class Admin < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable, :trackable, :recoverable, and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :rememberable, :validatable
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,4 +3,13 @@ class Admin < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable, :recoverable, and :omniauthable
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
+
+  def self.from_omniauth(auth)
+    find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|
+      member.email = auth.info.email
+      member.name = auth.info.nickname
+      member.avatar_url = auth.info.image
+      member.password = Devise.friendly_token[0, 20]
+    end
+  end
 end

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,0 +1,16 @@
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <h1 class="font-bold text-4xl">
+    <%= "管理者用のダッシュボード" %>
+  </h1>
+
+  <div>
+    <p>管理者名 : <%= current_admin.name %></p>
+    <% if current_admin.avatar_url %>
+      <%= image_tag(current_admin.avatar_url, size: '100x100', alt: '管理者のGitHubアカウントの画像') %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -278,10 +278,12 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    # authenticate_XXXメソッドで認証されていないユーザーのリダイレクト先を設定(lib/custom_failure_app.rb)
+    manager.failure_app = CustomFailureApp
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   end
 
   devise_for :members
+  devise_for :admins
   devise_scope :member do
     get "/auth/:provider/callback" => "authentications#create"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
     end
   end
 
-  devise_for :members
-  devise_for :admins
+  devise_for :members, skip: :all
+  devise_for :admins, skip: :all
   devise_scope :member do
     get "/auth/:provider/callback" => "authentications#create"
   end

--- a/db/migrate/20241011055502_devise_create_admins.rb
+++ b/db/migrate/20241011055502_devise_create_admins.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class DeviseCreateAdmins < ActiveRecord::Migration[7.2]
+  def change
+    create_table :admins do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Recoverable
+      # t.string   :reset_password_token
+      # t.datetime :reset_password_sent_at
+
+      ## Trackable
+      # t.integer  :sign_in_count, default: 0, null: false
+      # t.datetime :current_sign_in_at
+      # t.datetime :last_sign_in_at
+      # t.string   :current_sign_in_ip
+      # t.string   :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :admins, :email,                unique: true
+    # add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20241011060654_add_omniauth_to_admins.rb
+++ b/db/migrate/20241011060654_add_omniauth_to_admins.rb
@@ -1,0 +1,8 @@
+class AddOmniauthToAdmins < ActiveRecord::Migration[7.2]
+  def change
+    add_column :admins, :provider, :string, null: false
+    add_column :admins, :uid, :string, null: false
+    add_column :admins, :name, :string
+    add_column :admins, :avatar_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_10_215545) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_11_055502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admins", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+  end
 
   create_table "courses", force: :cascade do |t|
     t.string "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_11_055502) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_11_060654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_11_055502) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider", null: false
+    t.string "uid", null: false
+    t.string "name"
+    t.string "avatar_url"
     t.index ["email"], name: "index_admins_on_email", unique: true
   end
 

--- a/lib/custom_failure_app.rb
+++ b/lib/custom_failure_app.rb
@@ -1,0 +1,5 @@
+class CustomFailureApp < Devise::FailureApp
+  def route(scope)
+    :root_url
+  end
+end


### PR DESCRIPTION
## Issue
- #55 

## 概要
以下のユーザーは管理者としてログインできるようにした。
- komagataさん
- machidaさん
- Kassy0220(本番環境で運用する際に自分も管理者としていいかは要確認)

また、ログインしていないユーザーはページを閲覧できないようにした。
ただし、以下のページは未ログインでも閲覧可能にしている。
- トップページ
- 議事録一覧ページ

## Screenshot
### 管理者でログイン
管理者でログインする場合は、どちらのボタンを押してもログインが可能。
[![Image from Gyazo](https://i.gyazo.com/84a59c51db294b638e4f7e13b74abfa9.gif)](https://gyazo.com/84a59c51db294b638e4f7e13b74abfa9)

### 非ログイン時のリダイレクト
[![Image from Gyazo](https://i.gyazo.com/ade1a56e5862ae4f3cb2d2d508b1aa5c.gif)](https://gyazo.com/ade1a56e5862ae4f3cb2d2d508b1aa5c)

## 備考
### 認証失敗時のリダイレクト先の設定
アクセスしたユーザーが認証しているかを`authenticate_xxx`メソッドでチェックしている。
認証していないユーザーはデフォルトでログインパス(`new_member_session_url`)にリダイレクトされるが、今回はルートパスにリダイレクトしたい。
ということで以下のページを参考にリダイレクト先を変更している。

https://github.com/heartcombo/devise/wiki/Redirect-to-new-registration-(sign-up)-path-if-unauthenticated

### 不要なパスの削除
`devise_for`によって生成されるパスは、`:skip`オプションを指定することで省略が可能。

https://github.com/heartcombo/devise/blob/72884642f5700439cc96ac560ee19a44af5a2d45/lib/devise/rails/routes.rb#L151