### PR TITLE
開発環境にGitHub認証なしのログイン機能を追加

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -15,4 +15,15 @@
       <% end %>
     <% end %>
   </div>
+
+  <% if Rails.env.development? %>
+    <div>
+      <p>Developerでログイン</p>
+      <% Course.all.each do |course| %>
+        <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
+          <button type='submit' class="ml-2 mt-2 py-1 px-2 border border-black hover:text-white hover:bg-black"><%= course.name %></button>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :developer, fields: [ :email, :nickname, :image ], uid_field: :email if Rails.env.development?
   provider :github, ENV["AUTH_APP_ID"], ENV["AUTH_APP_SECRET"]
   on_failure { |env| AuthenticationsController.action(:failure).call(env) }
 end


### PR DESCRIPTION
## Issue
- #55 

## 概要
開発環境でGitHub認証を行わず、フォームを入力することでサインアップできるようにした。

## Screenshot
開発環境ではトップページに`Developerでログイン`のログインボタンが追加される。
![53AAA154-BD85-4F8E-B02F-A664B816341D](https://github.com/user-attachments/assets/d51608a9-edb6-4656-b9f9-062af49e7278)

ボタンをクリックすると、ユーザー情報の入力フォームが表示される。
`Sign up`を押すと、入力した内容でユーザー登録される。
![A89E0EE8-446C-47BF-96EC-8E3FE0DFD480](https://github.com/user-attachments/assets/8f10dc37-b8db-4b57-93c3-daf2f4f05987)


## 備考
開発環境用のログインは、omniauth gemのdevelopment strategyを利用した。

https://github.com/omniauth/omniauth?tab=readme-ov-file#rails-without-devise

https://www.rubydoc.info/github/intridea/omniauth/OmniAuth/Strategies/Developer
