### PR TITLE
出席機能を追加

### DIFF
--- a/app/controllers/minutes/application_controller.rb
+++ b/app/controllers/minutes/application_controller.rb
@@ -1,0 +1,9 @@
+class Minutes::ApplicationController < ApplicationController
+  before_action :set_minute
+
+  private
+
+  def set_minute
+    @minute = Minute.find(params[:minute_id])
+  end
+end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -1,0 +1,22 @@
+class Minutes::AttendancesController < Minutes::ApplicationController
+  def new
+    @attendance = Attendance.new
+  end
+
+  def create
+    attendance = @minute.attendances.new(attendance_params)
+    attendance.member_id = current_member.id
+
+    if attendance.save
+      redirect_to edit_minute_url(@minute), notice: "Attendance was successfully created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def attendance_params
+    params.require(:attendance).permit(:status, :time, :absence_reason, :progress_report)
+  end
+end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -1,5 +1,7 @@
 class Minutes::AttendancesController < Minutes::ApplicationController
   def new
+    redirect_to edit_minute_url(@minute), alert: "You already registered attendance!" if already_registered_attendance
+
     @attendance = Attendance.new
   end
 
@@ -18,5 +20,9 @@ class Minutes::AttendancesController < Minutes::ApplicationController
 
   def attendance_params
     params.require(:attendance).permit(:status, :time, :absence_reason, :progress_report)
+  end
+
+  def already_registered_attendance
+    @minute.attendances.where(member_id: current_member.id).any?
   end
 end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -6,10 +6,10 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   end
 
   def create
-    attendance = @minute.attendances.new(attendance_params)
-    attendance.member_id = current_member.id
+    @attendance = @minute.attendances.new(attendance_params)
+    @attendance.member_id = current_member.id
 
-    if attendance.save
+    if @attendance.save
       redirect_to edit_minute_url(@minute), notice: "Attendance was successfully created."
     else
       render :new, status: :unprocessable_entity

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -3,6 +3,7 @@ import ReleaseInformationForm from './components/ReleaseInformationForm.jsx'
 import TopicList from './components/TopicList.jsx'
 import OtherForm from './components/OtherForm.jsx'
 import NextMeetingDateForm from './components/NextMeetingDateForm.jsx'
+import './toggleAttendanceForm'
 
 mountComponent('release_branch_form', ReleaseInformationForm)
 mountComponent('release_note_form', ReleaseInformationForm)

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const attendanceForm = document.querySelector('#attendance_form')
+  if (!attendanceForm) {
+    return null
+  }
+
+  const statusRadioButtons = document.querySelectorAll(
+    '[name="attendance[status]"]'
+  )
+  const presentFields = document.querySelectorAll('.present_entry_field')
+  const absentFields = document.querySelectorAll('.absent_entry_field')
+
+  const handleChange = function () {
+    toggleForm()
+  }
+
+  const toggleForm = function () {
+    const checkedStatus = attendanceForm.elements['attendance[status]'].value
+    if (checkedStatus === 'present') {
+      showPresentField()
+      hideAbsentField()
+    } else if (checkedStatus === 'absent') {
+      hidePresentField()
+      showAbsentField()
+    }
+  }
+
+  const showPresentField = function () {
+    presentFields.forEach((field) => {
+      field.style.display = 'block'
+    })
+  }
+
+  const hidePresentField = function () {
+    presentFields.forEach((field) => {
+      field.style.display = 'none'
+    })
+  }
+
+  const showAbsentField = function () {
+    absentFields.forEach((field) => {
+      field.style.display = 'block'
+    })
+  }
+
+  const hideAbsentField = function () {
+    absentFields.forEach((field) => {
+      field.style.display = 'none'
+    })
+  }
+
+  statusRadioButtons.forEach((button) => {
+    button.addEventListener('change', handleChange)
+  })
+
+  toggleForm()
+})

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -54,7 +54,15 @@ document.addEventListener('DOMContentLoaded', () => {
     button.addEventListener('change', handleChange)
   })
 
-  toggleForm()
+  const isStatusChecked =
+    attendanceForm.elements['attendance[status]'].value !== ''
+  if (isStatusChecked) {
+    toggleForm()
+  } else {
+    // 出欠が未選択の場合、まず出欠を入力してもらうために他の入力欄を隠しておく
+    hidePresentField()
+    hideAbsentField()
+  }
 
   // 出席時間帯のラジオボタンを2度クリックするとチェックを消せるようにする処理
   const timeRadioButtons = document.querySelectorAll(

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return null
   }
 
+  // 出欠のラジオボタンでフォームの表示を切り替える処理
   const statusRadioButtons = document.querySelectorAll(
     '[name="attendance[status]"]'
   )
@@ -54,4 +55,21 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   toggleForm()
+
+  // 出席時間帯のラジオボタンを2度クリックするとチェックを消せるようにする処理
+  const timeRadioButtons = document.querySelectorAll(
+    '[name="attendance[time]"]'
+  )
+  let lastCheckedTimeRadioButton = null
+
+  timeRadioButtons.forEach((button) => {
+    button.addEventListener('click', function () {
+      if (lastCheckedTimeRadioButton === this) {
+        this.checked = false
+        lastCheckedTimeRadioButton = null
+      } else {
+        lastCheckedTimeRadioButton = this
+      }
+    })
+  })
 })

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -4,4 +4,9 @@ class Attendance < ApplicationRecord
 
   belongs_to :minute
   belongs_to :member
+
+  validates :status, presence: true
+  validates :time, presence: true, if: Proc.new { |attendance| attendance.present? }
+  validates :absence_reason, presence: true, if: Proc.new { |attendance| attendance.absent? }
+  validates :progress_report, presence: true, if: Proc.new { |attendance| attendance.absent? }
 end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,0 +1,7 @@
+class Attendance < ApplicationRecord
+  enum :status, [ :present, :absent ]
+  enum :time, [ :day, :night ], suffix: true
+
+  belongs_to :minute
+  belongs_to :member
+end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -7,6 +7,9 @@ class Attendance < ApplicationRecord
 
   validates :status, presence: true
   validates :time, presence: true, if: Proc.new { |attendance| attendance.present? }
+  validates :time, absence: true, if: Proc.new { |attendance| attendance.absent? }
   validates :absence_reason, presence: true, if: Proc.new { |attendance| attendance.absent? }
   validates :progress_report, presence: true, if: Proc.new { |attendance| attendance.absent? }
+  validates :absence_reason, absence: true, if: Proc.new { |attendance| attendance.present? }
+  validates :progress_report, absence: true, if: Proc.new { |attendance| attendance.present? }
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -5,6 +5,7 @@ class Member < ApplicationRecord
          :rememberable, :validatable
 
   belongs_to :course
+  has_many :attendances
 
   def self.from_omniauth(auth, params)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -1,4 +1,5 @@
 class Minute < ApplicationRecord
   belongs_to :course
   has_many :topics, dependent: :destroy
+  has_many :attendances
 end

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,0 +1,49 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">出席登録</h1>
+
+  <div id='attendance_form'>
+    <%= form_with(model: [ @minute, @attendance ], class: "contents") do |form| %>
+      <% if @attendance.errors.any? %>
+        <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+          <h2><%= pluralize(@attendance.errors.count, "error") %> prohibited this attendance from being saved:</h2>
+
+          <ul>
+            <% @attendance.errors.each do |error| %>
+              <li><%= error.full_message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="my-5">
+        <p>出欠</p>
+        <%= form.radio_button :status, "present" %>
+        <%= form.label :status_present, "出席" %>
+        <%= form.radio_button :status, "absent" %>
+        <%= form.label :status_absent, "欠席" %>
+      </div>
+
+      <div class="my-5">
+        <p>出席時間帯</p>
+        <%= form.radio_button :time, "day" %>
+        <%= form.label :time_day, "昼の部" %>
+        <%= form.radio_button :time, "night" %>
+        <%= form.label :time_night, "夜の部" %>
+      </div>
+
+      <div class="my-5">
+        <%= form.label :absence_reason %>
+        <%= form.text_field :absence_reason %>
+      </div>
+
+      <div class="my-5">
+        <%= form.label :progress_report %>
+        <%= form.text_field :progress_report %>
+      </div>
+
+      <div class="inline">
+        <%= form.submit '出席を登録', class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,8 +1,8 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">出席登録</h1>
 
-  <div id='attendance_form'>
-    <%= form_with(model: [ @minute, @attendance ], class: "contents") do |form| %>
+  <div>
+    <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
           <h2><%= pluralize(@attendance.errors.count, "error") %> prohibited this attendance from being saved:</h2>
@@ -23,7 +23,7 @@
         <%= form.label :status_absent, "欠席" %>
       </div>
 
-      <div class="my-5">
+      <div class="my-5 present_entry_field">
         <p>出席時間帯</p>
         <%= form.radio_button :time, "day" %>
         <%= form.label :time_day, "昼の部" %>
@@ -31,12 +31,12 @@
         <%= form.label :time_night, "夜の部" %>
       </div>
 
-      <div class="my-5">
+      <div class="my-5 absent_entry_field">
         <%= form.label :absence_reason %>
         <%= form.text_field :absence_reason %>
       </div>
 
-      <div class="my-5">
+      <div class="my-5 absent_entry_field">
         <%= form.label :progress_report %>
         <%= form.text_field :progress_report %>
       </div>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,4 +1,8 @@
 <div class="mx-auto md:w-2/3 w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
   <h1 class="font-bold text-4xl">ふりかえり・計画ミーティング<%= @minute.meeting_date.strftime('%Y年%m月%d日') %></h1>
 
   <h3 class="font-bold text-xl">デモ</h3>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -3,6 +3,10 @@
     <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
   <% end %>
 
+  <% if alert.present? %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
+  <% end %>
+
   <h1 class="font-bold text-4xl">ふりかえり・計画ミーティング<%= @minute.meeting_date.strftime('%Y年%m月%d日') %></h1>
 
   <h3 class="font-bold text-xl">デモ</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root "home#index"
-  resources :minutes
+  resources :minutes do
+    resources :attendances, only: [ :new, :create ], module: :minutes
+  end
 
   namespace :api do
     resources :minutes, only: [ :update ] do

--- a/db/migrate/20241012222046_create_attendances.rb
+++ b/db/migrate/20241012222046_create_attendances.rb
@@ -1,0 +1,14 @@
+class CreateAttendances < ActiveRecord::Migration[7.2]
+  def change
+    create_table :attendances do |t|
+      t.integer :status, null: false
+      t.integer :time
+      t.string :absence_reason
+      t.string :progress_report
+      t.references :minute, null: false, foreign_key: true
+      t.references :member, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241013005451_add_unique_index_to_attendances.rb
+++ b/db/migrate/20241013005451_add_unique_index_to_attendances.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToAttendances < ActiveRecord::Migration[7.2]
+  def change
+    add_index(:attendances, [ :minute_id, :member_id ], unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_11_060654) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_12_222046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,19 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_11_060654) do
     t.string "name"
     t.string "avatar_url"
     t.index ["email"], name: "index_admins_on_email", unique: true
+  end
+
+  create_table "attendances", force: :cascade do |t|
+    t.integer "status", null: false
+    t.integer "time"
+    t.string "absence_reason"
+    t.string "progress_report"
+    t.bigint "minute_id", null: false
+    t.bigint "member_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["member_id"], name: "index_attendances_on_member_id"
+    t.index ["minute_id"], name: "index_attendances_on_minute_id"
   end
 
   create_table "courses", force: :cascade do |t|
@@ -70,6 +83,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_11_060654) do
     t.index ["minute_id"], name: "index_topics_on_minute_id"
   end
 
+  add_foreign_key "attendances", "members"
+  add_foreign_key "attendances", "minutes"
   add_foreign_key "members", "courses"
   add_foreign_key "minutes", "courses"
   add_foreign_key "topics", "minutes"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_12_222046) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_13_005451) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_12_222046) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["member_id"], name: "index_attendances_on_member_id"
+    t.index ["minute_id", "member_id"], name: "index_attendances_on_minute_id_and_member_id", unique: true
     t.index ["minute_id"], name: "index_attendances_on_minute_id"
   end
 


### PR DESCRIPTION
## Issue
- #56 

## 概要
メンバーが議事録に対して出席登録を行えるようにした。
出席として以下の情報を保存する。

- 出欠(出席/欠席)
- 出席時間帯(昼の部/夜の部) ※出席を選択した場合に必須
- 欠席理由 ※欠席を選択した場合に必須
- 今週の進捗報告 ※欠席を選択した場合に必須

## Screenshot
最初に出席登録ページを開くと出欠選択のみ表示され、出欠を選択するとそれに応じて追加の入力欄が表示される。
[![Image from Gyazo](https://i.gyazo.com/4a8a4998e3cec6ecffd7b7c4668775bc.gif)](https://gyazo.com/4a8a4998e3cec6ecffd7b7c4668775bc)

### 不要な値が入力されている場合
`出席`が選択されている時、`欠席理由`や`進捗報告`の項目が入力されているとバリデーションエラーが発生する。
[![Image from Gyazo](https://i.gyazo.com/c81faf7db57e9fa8d87d90db90d148a7.gif)](https://gyazo.com/c81faf7db57e9fa8d87d90db90d148a7)

`欠席`が選択されている場合、`出席時間帯`が選択されているとバリデーションエラーが発生する。
[![Image from Gyazo](https://i.gyazo.com/bb3853b4d6babec4b147cedde8358cd3.gif)](https://gyazo.com/bb3853b4d6babec4b147cedde8358cd3)
