### PR TITLE
出席を編集できるようにした

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,0 +1,31 @@
+class AttendancesController < ApplicationController
+  def edit
+    @attendance = Attendance.find(params[:id])
+  end
+
+  def update
+    @attendance = Attendance.find(params[:id])
+    remove_unnecessary_values
+
+    if @attendance.update(attendance_params)
+      redirect_to edit_minute_path(@attendance.minute_id), notice: "Attendance was successfully updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def attendance_params
+    params.require(:attendance).permit(:status, :time, :absence_reason, :progress_report)
+  end
+
+  def remove_unnecessary_values
+    if attendance_params["status"] == "present"
+      @attendance.absence_reason = nil
+      @attendance.progress_report = nil
+    elsif attendance_params["status"] == "absent"
+      @attendance.time = nil
+    end
+  end
+end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,10 +1,10 @@
 class AttendancesController < ApplicationController
   def edit
-    @attendance = Attendance.find(params[:id])
+    @attendance = current_member.attendances.find(params[:id])
   end
 
   def update
-    @attendance = Attendance.find(params[:id])
+    @attendance = current_member.attendances.find(params[:id])
     remove_unnecessary_values
 
     if @attendance.update(attendance_params)

--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -2,7 +2,7 @@ import useSWR from 'swr'
 import fetcher from '../fetcher.js'
 import PropTypes from 'prop-types'
 
-export default function AbsenteesList({ minuteId }) {
+export default function AbsenteesList({ minuteId, currentMemberId, isAdmin }) {
   const { data, error, isLoading } = useSWR(
     `/api/minutes/${minuteId}/attendances`,
     fetcher
@@ -16,30 +16,38 @@ export default function AbsenteesList({ minuteId }) {
       {data.absentees.map((absentee) => (
         <Absentee
           key={absentee.attendance_id}
-          name={absentee.name}
-          absence_reason={absentee.absence_reason}
-          progress_report={absentee.progress_report}
+          absentee={absentee}
+          currentMemberId={currentMemberId}
+          isAdmin={isAdmin}
         />
       ))}
     </ul>
   )
 }
 
-function Absentee({ name, absence_reason, progress_report }) {
+function Absentee({ absentee, currentMemberId, isAdmin }) {
   return (
     <li>
       <a
-        href={`https://github.com/${name}`}
+        href={`https://github.com/${absentee.name}`}
         className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle text-sky-600 underline"
       >
-        {`@${name}`}
+        {`@${absentee.name}`}
       </a>
+      {!isAdmin && currentMemberId === absentee.member_id && (
+        <a
+          href={`/attendances/${absentee.attendance_id}/edit`}
+          className="inline-block ml-2 py-1 px-2 border border-black"
+        >
+          出席編集
+        </a>
+      )}
       <ul>
         <li className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-          欠席理由: {absence_reason}
+          欠席理由: {absentee.absence_reason}
         </li>
         <li className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-          今週の進捗: {progress_report}
+          今週の進捗: {absentee.progress_report}
         </li>
       </ul>
     </li>
@@ -48,10 +56,12 @@ function Absentee({ name, absence_reason, progress_report }) {
 
 AbsenteesList.propTypes = {
   minuteId: PropTypes.number,
+  currentMemberId: PropTypes.number,
+  isAdmin: PropTypes.bool,
 }
 
 Absentee.propTypes = {
-  name: PropTypes.string,
-  absence_reason: PropTypes.string,
-  progress_report: PropTypes.string,
+  absentee: PropTypes.object,
+  currentMemberId: PropTypes.number,
+  isAdmin: PropTypes.bool,
 }

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -2,7 +2,7 @@ import useSWR from 'swr'
 import fetcher from '../fetcher.js'
 import PropTypes from 'prop-types'
 
-export default function AttendeesList({ minuteId }) {
+export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
   const { data, error, isLoading } = useSWR(
     `/api/minutes/${minuteId}/attendances`,
     fetcher
@@ -18,11 +18,19 @@ export default function AttendeesList({ minuteId }) {
         <ul>
           <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
             昼
-            <Attendees attendees={data.day_attendees} />
+            <Attendees
+              attendees={data.day_attendees}
+              currentMemberId={currentMemberId}
+              isAdmin={isAdmin}
+            />
           </li>
           <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
             夜
-            <Attendees attendees={data.night_attendees} />
+            <Attendees
+              attendees={data.night_attendees}
+              currentMemberId={currentMemberId}
+              isAdmin={isAdmin}
+            />
           </li>
         </ul>
       </li>
@@ -56,7 +64,7 @@ export default function AttendeesList({ minuteId }) {
   )
 }
 
-function Attendees({ attendees }) {
+function Attendees({ attendees, currentMemberId, isAdmin }) {
   return (
     <ul>
       {attendees.map((attendee) => (
@@ -68,6 +76,14 @@ function Attendees({ attendees }) {
             href={`https://github.com/${attendee.name}`}
             className="text-sky-600 underline"
           >{`@${attendee.name}`}</a>
+          {!isAdmin && currentMemberId === attendee.member_id && (
+            <a
+              href={`/attendances/${attendee.attendance_id}/edit`}
+              className="inline-block ml-2 py-1 px-2 border border-black"
+            >
+              出席編集
+            </a>
+          )}
         </li>
       ))}
     </ul>
@@ -76,8 +92,12 @@ function Attendees({ attendees }) {
 
 AttendeesList.propTypes = {
   minuteId: PropTypes.number,
+  currentMemberId: PropTypes.number,
+  isAdmin: PropTypes.bool,
 }
 
 Attendees.propTypes = {
   attendees: PropTypes.array,
+  currentMemberId: PropTypes.number,
+  isAdmin: PropTypes.bool,
 }

--- a/app/javascript/components/UnexcusedAbsenteesList.jsx
+++ b/app/javascript/components/UnexcusedAbsenteesList.jsx
@@ -2,7 +2,11 @@ import useSWR from 'swr'
 import fetcher from '../fetcher.js'
 import PropTypes from 'prop-types'
 
-export default function UnexcusedAbsenteesList({ minuteId }) {
+export default function UnexcusedAbsenteesList({
+  minuteId,
+  currentMemberId,
+  isAdmin,
+}) {
   const { data, error, isLoading } = useSWR(
     `/api/minutes/${minuteId}/attendances`,
     fetcher
@@ -16,11 +20,20 @@ export default function UnexcusedAbsenteesList({ minuteId }) {
       {data.unexcused_absentees.map((absentee) => (
         <li
           key={absentee.member_id}
-          className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle text-sky-600 underline"
+          className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle"
         >
           <a
             href={`https://github.com/${absentee.name}`}
+            className="text-sky-600 underline"
           >{`@${absentee.name}`}</a>
+          {!isAdmin && currentMemberId === absentee.member_id && (
+            <a
+              href={`/minutes/${minuteId}/attendances/new`}
+              className="inline-block ml-2 py-1 px-2 border border-black"
+            >
+              出席登録
+            </a>
+          )}
         </li>
       ))}
     </ul>
@@ -29,4 +42,6 @@ export default function UnexcusedAbsenteesList({ minuteId }) {
 
 UnexcusedAbsenteesList.propTypes = {
   minuteId: PropTypes.number,
+  currentMemberId: PropTypes.number,
+  isAdmin: PropTypes.bool,
 }

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -12,4 +12,8 @@ class Admin < ApplicationRecord
       member.password = Devise.friendly_token[0, 20]
     end
   end
+
+  def admin?
+    true
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -16,4 +16,8 @@ class Member < ApplicationRecord
       member.course_id = params["course_id"].to_i
     end
   end
+
+  def admin?
+    false
+  end
 end

--- a/app/views/api/minutes/attendances/index.json.jbuilder
+++ b/app/views/api/minutes/attendances/index.json.jbuilder
@@ -1,6 +1,7 @@
 json.day_attendees do
   json.array! @attendances.where(time: :day) do |attendance|
     json.attendance_id attendance.id
+    json.member_id attendance.member_id
     json.name attendance.member.name
   end
 end
@@ -8,6 +9,7 @@ end
 json.night_attendees do
   json.array! @attendances.where(time: :night) do |attendance|
     json.attendance_id attendance.id
+    json.member_id attendance.member_id
     json.name attendance.member.name
   end
 end
@@ -15,6 +17,7 @@ end
 json.absentees do
   json.array! @attendances.where(status: :absent) do |attendance|
     json.attendance_id attendance.id
+    json.member_id attendance.member_id
     json.name attendance.member.name
     json.absence_reason attendance.absence_reason
     json.progress_report attendance.progress_report

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,0 +1,49 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">出席編集</h1>
+
+  <div>
+    <%= form_with(model: @attendance, id: "attendance_form", class: "contents") do |form| %>
+      <% if @attendance.errors.any? %>
+        <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+          <h2><%= pluralize(@attendance.errors.count, "error") %> prohibited this attendance from being saved:</h2>
+
+          <ul>
+            <% @attendance.errors.each do |error| %>
+              <li><%= error.full_message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="my-5">
+        <p>出欠</p>
+        <%= form.radio_button :status, "present" %>
+        <%= form.label :status_present, "出席" %>
+        <%= form.radio_button :status, "absent" %>
+        <%= form.label :status_absent, "欠席" %>
+      </div>
+
+      <div class="my-5 present_entry_field">
+        <p>出席時間帯</p>
+        <%= form.radio_button :time, "day" %>
+        <%= form.label :time_day, "昼の部" %>
+        <%= form.radio_button :time, "night" %>
+        <%= form.label :time_night, "夜の部" %>
+      </div>
+
+      <div class="my-5 absent_entry_field">
+        <%= form.label :absence_reason %>
+        <%= form.text_field :absence_reason %>
+      </div>
+
+      <div class="my-5 absent_entry_field">
+        <%= form.label :progress_report %>
+        <%= form.text_field :progress_report %>
+      </div>
+
+      <div class="inline">
+        <%= form.submit '出席を更新', class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -43,7 +43,7 @@
   <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">連絡なし</h3>
-  <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id}.to_json do %><% end %>
+  <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <div class="mt-16">
     <%= link_to "Back to minutes", minutes_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -12,7 +12,7 @@
   <h2 class="font-bold text-2xl">ふりかえり</h2>
 
   <h3 class="font-bold text-xl">メンバー</h3>
-  <%= content_tag :div, id: 'attendees_list', data: {minuteId: @minute.id}.to_json do %><% end %>
+  <%= content_tag :div, id: 'attendees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">デモ</h3>
   <p>
@@ -40,7 +40,7 @@
   </ul>
 
   <h2 class="font-bold text-2xl">欠席者</h2>
-  <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id}.to_json do %><% end %>
+  <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">連絡なし</h3>
   <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id}.to_json do %><% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :minutes do
     resources :attendances, only: [ :new, :create ], module: :minutes
   end
+  resources :attendances, only: [ :edit, :update ]
 
   namespace :api do
     resources :minutes, only: [ :update ] do


### PR DESCRIPTION
## Issue
- #54 

## 概要
議事録編集ページで自分の出欠に`出席編集`というボタンを表示し、出席編集を行えるようにした。

## Screenshot
出席している場合、欠席している場合、無断欠席している場合それぞれで編集ボタンが表示される。

- 出席している場合

[![Image from Gyazo](https://i.gyazo.com/1a9f0c5825a9492edd1fc1956d7fc95a.gif)](https://gyazo.com/1a9f0c5825a9492edd1fc1956d7fc95a)

- 欠席している場合

[![Image from Gyazo](https://i.gyazo.com/f8cf2a22877ac0275b1143691dcafe1d.gif)](https://gyazo.com/f8cf2a22877ac0275b1143691dcafe1d)

- 無断欠席している場合
  - 無断欠席の場合は出席登録ページに遷移するボタンが表示される

[![Image from Gyazo](https://i.gyazo.com/bb1501c9db3479e57f4e0b2ac0a197c9.gif)](https://gyazo.com/bb1501c9db3479e57f4e0b2ac0a197c9)


