### PR TITLE
「話題にしたいこと・心配事」の作成者の名前を表示するようにした

### DIFF
--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -1,6 +1,7 @@
 class API::Minutes::TopicsController < API::Minutes::ApplicationController
   def create
-    topic = @minute.topics.new(topic_params)
+    topic = current_development_member.topics.new(topic_params)
+    topic.minute_id = @minute.id
     if topic.save
       render json: @minute, status: :created
       broadcast_to_channel
@@ -10,7 +11,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
   end
 
   def update
-    topic = @minute.topics.find(params[:id])
+    topic = current_development_member.topics.find(params[:id])
     if topic.update(topic_params)
       render json: topic, status: :ok
       broadcast_to_channel
@@ -20,7 +21,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
   end
 
   def destroy
-    topic = @minute.topics.find(params[:id])
+    topic = current_development_member.topics.find(params[:id])
     topic.destroy!
 
     head :no_content
@@ -34,6 +35,6 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
   end
 
   def broadcast_to_channel
-    MinuteChannel.broadcast_to(@minute, body: { topics: @minute.topics.order(:created_at).as_json(only: [ :id, :content ]) })
+    MinuteChannel.broadcast_to(@minute, body: { topics: @minute.topics.order(:created_at).as_json(only: [ :id, :content, :topicable_id, :topicable_type ], include: { topicable: { only: [ :name ] } }) })
   end
 end

--- a/app/controllers/minutes_controller.rb
+++ b/app/controllers/minutes_controller.rb
@@ -18,6 +18,7 @@ class MinutesController < ApplicationController
 
   # GET /minutes/1/edit
   def edit
+    @topics = @minute.topics.order(:created_at)
   end
 
   # POST /minutes or /minutes.json

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -3,7 +3,12 @@ import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
 
-export default function TopicList({ minuteId, topics }) {
+export default function TopicList({
+  minuteId,
+  topics,
+  currentDevelopmentMemberId,
+  currentDevelopmentMemberType,
+}) {
   const [allTopics, setAllTopics] = useState(topics)
 
   const onReceivedData = useCallback(function (data) {
@@ -17,7 +22,13 @@ export default function TopicList({ minuteId, topics }) {
     <>
       <ul>
         {allTopics.map((topic) => (
-          <Topic key={topic.id} minuteId={minuteId} topic={topic} />
+          <Topic
+            key={topic.id}
+            minuteId={minuteId}
+            topic={topic}
+            currentDevelopmentMemberId={currentDevelopmentMemberId}
+            currentDevelopmentMemberType={currentDevelopmentMemberType}
+          />
         ))}
       </ul>
       <CreateForm minuteId={minuteId} />
@@ -25,7 +36,12 @@ export default function TopicList({ minuteId, topics }) {
   )
 }
 
-function Topic({ minuteId, topic }) {
+function Topic({
+  minuteId,
+  topic,
+  currentDevelopmentMemberId,
+  currentDevelopmentMemberType,
+}) {
   const [isEditing, setIsEditing] = useState(false)
 
   const handleDelete = async function (e) {
@@ -55,24 +71,37 @@ function Topic({ minuteId, topic }) {
       ) : (
         <li className="pl-8 mb-2 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
           <span>{topic.content}</span>
-          <button
-            type="button"
-            onClick={() => setIsEditing(true)}
-            className="ml-2 py-1 px-2 border border-black"
-          >
-            編集
-          </button>
-          <button
-            type="button"
-            onClick={handleDelete}
-            className="ml-2 py-1 px-2 border border-black"
-          >
-            削除
-          </button>
+          {isMine(
+            topic.topicable_id,
+            topic.topicable_type,
+            currentDevelopmentMemberId,
+            currentDevelopmentMemberType
+          ) && (
+            <>
+              <button
+                type="button"
+                onClick={() => setIsEditing(true)}
+                className="ml-2 py-1 px-2 border border-black"
+              >
+                編集
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="ml-2 py-1 px-2 border border-black"
+              >
+                削除
+              </button>
+            </>
+          )}
         </li>
       )}
     </>
   )
+}
+
+function isMine(topicableId, topicableType, memberId, memberType) {
+  return topicableId === memberId && topicableType === memberType
 }
 
 function EditForm({ minuteId, topicId, content, setIsEditing }) {
@@ -178,11 +207,15 @@ function CreateForm({ minuteId }) {
 TopicList.propTypes = {
   minuteId: PropTypes.number,
   topics: PropTypes.array,
+  currentDevelopmentMemberId: PropTypes.number,
+  currentDevelopmentMemberType: PropTypes.string,
 }
 
 Topic.propTypes = {
   minuteId: PropTypes.number,
   topic: PropTypes.object,
+  currentDevelopmentMemberId: PropTypes.number,
+  currentDevelopmentMemberType: PropTypes.string,
 }
 
 EditForm.propTypes = {

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -70,7 +70,9 @@ function Topic({
         />
       ) : (
         <li className="pl-8 mb-2 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
-          <span>{topic.content}</span>
+          <span>
+            {topic.content}({topic.topicable.name})
+          </span>
           {isMine(
             topic.topicable_id,
             topic.topicable_type,

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -4,6 +4,8 @@ class Admin < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 
+  has_many :topics, as: :topicable
+
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|
       member.email = auth.info.email

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -6,6 +6,7 @@ class Member < ApplicationRecord
 
   belongs_to :course
   has_many :attendances
+  has_many :topics, as: :topicable
 
   def self.from_omniauth(auth, params)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,5 +1,6 @@
 class Topic < ApplicationRecord
   belongs_to :minute
+  belongs_to :topicable, polymorphic: true
 
   validates :content, presence: true
 end

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -26,7 +26,10 @@
 
   <h3 class="font-bold text-xl">話題にしたいこと・心配事</h3>
   <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>
-  <%= content_tag :div, id: 'topics', data: {minuteId: @minute.id, topics: @minute.topics.order(:created_at)}.to_json do %><% end %>
+  <%= content_tag :div, id: 'topics', data: { minuteId: @minute.id,
+                                              topics: @topics.as_json(only: [:id, :content, :topicable_id, :topicable_type], include: { topicable: { only: [:name] } }),
+                                              currentDevelopmentMemberId: current_development_member.id,
+                                              currentDevelopmentMemberType: current_development_member.class.name}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">その他</h3>
   <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other}.to_json do %><% end %>

--- a/db/migrate/20241015072227_add_polymorphic_association_to_topics.rb
+++ b/db/migrate/20241015072227_add_polymorphic_association_to_topics.rb
@@ -1,0 +1,8 @@
+class AddPolymorphicAssociationToTopics < ActiveRecord::Migration[7.2]
+  def change
+    add_column :topics, :topicable_id, :bigint
+    add_column :topics, :topicable_type, :string
+
+    add_index :topics, [ :topicable_id, :topicable_type ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_13_005451) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_15_072227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,7 +81,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_13_005451) do
     t.bigint "minute_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "topicable_id"
+    t.string "topicable_type"
     t.index ["minute_id"], name: "index_topics_on_minute_id"
+    t.index ["topicable_id", "topicable_type"], name: "index_topics_on_topicable_id_and_topicable_type"
   end
 
   add_foreign_key "attendances", "members"


### PR DESCRIPTION
## Issue
- #54 

## 概要
「話題にしたいこと・心配事」に作者情報を保存するようにし、以下を行うようにした。
- 作者の名前を表示する
- 自分が作成した「話題にしたいこと・心配事」のみ編集・削除ボタンが表示される
- 自分が作成した「話題にしたいこと・心配事」のみ編集・削除できる

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/40b7eb9bad20588af1d2af928de34c9b.gif)](https://gyazo.com/40b7eb9bad20588af1d2af928de34c9b)

## 備考
「話題にしたいこと・心配事」はAdminモデルとMemberモデルが作成することができるため、作者情報にはポリモーフィック関連付けを利用している。
https://railsguides.jp/association_basics.html#%E3%83%9D%E3%83%AA%E3%83%A2%E3%83%BC%E3%83%95%E3%82%A3%E3%83%83%E3%82%AF%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91

AdminモデルとMemberモデルは同じIDの値を取る可能性があるため、「話題にしたいこと・心配事」の作成者を特定するには**作成者のID**と**作成者のモデル名**(`Admin`, `Member`)の二つが必要となる。

ポリモーフィック関連付けで関わる関連先のデータを取得する際、`as_json`メソッドの`:include`オプションを利用している。
https://api.rubyonrails.org/classes/ActiveModel/Serializers/JSON.html#method-i-as_json
