### PR TITLE
list-styleを表示するようにTailwindの設定を追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+    ul {
+        @apply list-disc list-inside [&_ul]:list-[revert];
+    }
+    ol {
+        @apply list-decimal list-inside;
+    }
+}
+
 @layer utilities {
     .field-sizing-content {
         /*field-sizingはまだ実験的機能でTailwindに実装されていないため、カスタムCSSという形で追加する*/

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -9,6 +9,9 @@
     ol {
         @apply list-decimal list-inside;
     }
+    li {
+        @apply pl-8;
+    }
 }
 
 @layer utilities {

--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -27,10 +27,10 @@ export default function AbsenteesList({ minuteId, currentMemberId, isAdmin }) {
 
 function Absentee({ absentee, currentMemberId, isAdmin }) {
   return (
-    <li>
+    <li className="pl-8">
       <a
         href={`https://github.com/${absentee.name}`}
-        className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle text-sky-600 underline"
+        className="text-sky-600 underline"
       >
         {`@${absentee.name}`}
       </a>
@@ -43,12 +43,8 @@ function Absentee({ absentee, currentMemberId, isAdmin }) {
         </a>
       )}
       <ul>
-        <li className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-          欠席理由: {absentee.absence_reason}
-        </li>
-        <li className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-          今週の進捗: {absentee.progress_report}
-        </li>
+        <li className="pl-8">欠席理由: {absentee.absence_reason}</li>
+        <li className="pl-8">今週の進捗: {absentee.progress_report}</li>
       </ul>
     </li>
   )

--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -27,7 +27,7 @@ export default function AbsenteesList({ minuteId, currentMemberId, isAdmin }) {
 
 function Absentee({ absentee, currentMemberId, isAdmin }) {
   return (
-    <li className="pl-8">
+    <li>
       <a
         href={`https://github.com/${absentee.name}`}
         className="text-sky-600 underline"
@@ -43,8 +43,8 @@ function Absentee({ absentee, currentMemberId, isAdmin }) {
         </a>
       )}
       <ul>
-        <li className="pl-8">欠席理由: {absentee.absence_reason}</li>
-        <li className="pl-8">今週の進捗: {absentee.progress_report}</li>
+        <li>欠席理由: {absentee.absence_reason}</li>
+        <li>今週の進捗: {absentee.progress_report}</li>
       </ul>
     </li>
   )

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -13,10 +13,10 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
 
   return (
     <ul>
-      <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+      <li className="pl-8">
         プログラマー
         <ul>
-          <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
+          <li className="pl-8">
             昼
             <Attendees
               attendees={data.day_attendees}
@@ -24,7 +24,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
               isAdmin={isAdmin}
             />
           </li>
-          <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
+          <li className="pl-8">
             夜
             <Attendees
               attendees={data.night_attendees}
@@ -34,10 +34,10 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
           </li>
         </ul>
       </li>
-      <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+      <li className="pl-8">
         プロダクトオーナー
         <ul>
-          <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
+          <li className="pl-8">
             <a
               href="https://github.com/machida"
               className="text-sky-600 underline"
@@ -47,10 +47,10 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
           </li>
         </ul>
       </li>
-      <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+      <li className="pl-8">
         スクラムマスター
         <ul>
-          <li className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
+          <li className="pl-8">
             <a
               href="https://github.com/komagata"
               className="text-sky-600 underline"
@@ -68,10 +68,7 @@ function Attendees({ attendees, currentMemberId, isAdmin }) {
   return (
     <ul>
       {attendees.map((attendee) => (
-        <li
-          key={attendee.attendance_id}
-          className="relative before:absolute before:left-8 before:top-1/2 before:w-1.5 before:h-1.5 before:bg-black before:rounded-sm before:transform before:-translate-y-1/2 before:mr-2 pl-12"
-        >
+        <li key={attendee.attendance_id} className="pl-8">
           <a
             href={`https://github.com/${attendee.name}`}
             className="text-sky-600 underline"

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -13,10 +13,10 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
 
   return (
     <ul>
-      <li className="pl-8">
+      <li>
         プログラマー
         <ul>
-          <li className="pl-8">
+          <li>
             昼
             <Attendees
               attendees={data.day_attendees}
@@ -24,7 +24,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
               isAdmin={isAdmin}
             />
           </li>
-          <li className="pl-8">
+          <li>
             夜
             <Attendees
               attendees={data.night_attendees}
@@ -34,10 +34,10 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
           </li>
         </ul>
       </li>
-      <li className="pl-8">
+      <li>
         プロダクトオーナー
         <ul>
-          <li className="pl-8">
+          <li>
             <a
               href="https://github.com/machida"
               className="text-sky-600 underline"
@@ -47,10 +47,10 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
           </li>
         </ul>
       </li>
-      <li className="pl-8">
+      <li>
         スクラムマスター
         <ul>
-          <li className="pl-8">
+          <li>
             <a
               href="https://github.com/komagata"
               className="text-sky-600 underline"
@@ -68,7 +68,7 @@ function Attendees({ attendees, currentMemberId, isAdmin }) {
   return (
     <ul>
       {attendees.map((attendee) => (
-        <li key={attendee.attendance_id} className="pl-8">
+        <li key={attendee.attendance_id}>
           <a
             href={`https://github.com/${attendee.name}`}
             className="text-sky-600 underline"

--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -22,19 +22,27 @@ export default function NextMeetingDateForm({ minuteId, nextMeetingDate }) {
   useChannel(minuteId, onReceivedData)
 
   return (
-    <>
-      {isEditing ? (
-        <EditForm minuteId={minuteId} date={date} setIsEditing={setIsEditing} />
-      ) : (
-        <NextMeetingDate date={date} setIsEditing={setIsEditing} />
-      )}
-      <div className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-        <span>昼の部：15:00-16:00</span>
-      </div>
-      <div className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-        <span>夜の部：22:00-23:00</span>
-      </div>
-    </>
+    <ul>
+      <li>
+        {isEditing ? (
+          <EditForm
+            minuteId={minuteId}
+            date={date}
+            setIsEditing={setIsEditing}
+          />
+        ) : (
+          <NextMeetingDate date={date} setIsEditing={setIsEditing} />
+        )}
+        <ul>
+          <li>
+            <span>昼の部：15:00-16:00</span>
+          </li>
+          <li>
+            <span>夜の部：22:00-23:00</span>
+          </li>
+        </ul>
+      </li>
+    </ul>
   )
 }
 
@@ -64,7 +72,7 @@ function EditForm({ minuteId, date, setIsEditing }) {
   }
 
   return (
-    <div className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+    <>
       <input type="date" value={inputValue} onChange={handleInput} />
       <button
         type="button"
@@ -73,7 +81,7 @@ function EditForm({ minuteId, date, setIsEditing }) {
       >
         更新
       </button>
-    </div>
+    </>
   )
 }
 
@@ -83,7 +91,7 @@ function NextMeetingDate({ date, setIsEditing }) {
   const isHoliday = holidayJP.isHoliday(new Date(date))
 
   return (
-    <div className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+    <>
       <span>{`${formattedDate} (${weekday})`}</span>
       {isHoliday && (
         <span className="text-red-600 ml-2">
@@ -97,7 +105,7 @@ function NextMeetingDate({ date, setIsEditing }) {
       >
         編集
       </button>
-    </div>
+    </>
   )
 }
 

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -25,24 +25,26 @@ export default function ReleaseInformationForm({
   const label = description === 'branch' ? 'リリースブランチ' : 'リリースノート'
 
   return (
-    <>
-      <div className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+    <ul>
+      <li>
         <span>{label}</span>
-      </div>
-      {isEditing ? (
-        <EditForm
-          minuteId={minuteId}
-          description={description}
-          content={informationContent}
-          setIsEditing={setIsEditing}
-        />
-      ) : (
-        <ReleaseInformation
-          content={informationContent}
-          setIsEditing={setIsEditing}
-        />
-      )}
-    </>
+        <ul>
+          {isEditing ? (
+            <EditForm
+              minuteId={minuteId}
+              description={description}
+              content={informationContent}
+              setIsEditing={setIsEditing}
+            />
+          ) : (
+            <ReleaseInformation
+              content={informationContent}
+              setIsEditing={setIsEditing}
+            />
+          )}
+        </ul>
+      </li>
+    </ul>
   )
 }
 
@@ -74,7 +76,7 @@ function EditForm({ minuteId, description, content, setIsEditing }) {
   }
 
   return (
-    <div className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
+    <li>
       <input
         type="text"
         value={inputValue}
@@ -88,24 +90,22 @@ function EditForm({ minuteId, description, content, setIsEditing }) {
       >
         更新
       </button>
-    </div>
+    </li>
   )
 }
 
 function ReleaseInformation({ content, setIsEditing }) {
   return (
-    <>
-      <div className="pl-16 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-white before:border before:border-black before:rounded-full before:mr-2 before:align-middle">
-        <span>{content}</span>
-        <button
-          type="button"
-          onClick={() => setIsEditing(true)}
-          className="ml-2 py-1 px-2 border border-black"
-        >
-          編集
-        </button>
-      </div>
-    </>
+    <li>
+      <span>{content}</span>
+      <button
+        type="button"
+        onClick={() => setIsEditing(true)}
+        className="ml-2 py-1 px-2 border border-black"
+      >
+        編集
+      </button>
+    </li>
   )
 }
 

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -69,7 +69,7 @@ function Topic({
           setIsEditing={setIsEditing}
         />
       ) : (
-        <li className="pl-8 mb-2 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle">
+        <li className="pl-8">
           <span>
             {topic.content}({topic.topicable.name})
           </span>

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -69,7 +69,7 @@ function Topic({
           setIsEditing={setIsEditing}
         />
       ) : (
-        <li className="pl-8">
+        <li>
           <span>
             {topic.content}({topic.topicable.name})
           </span>

--- a/app/javascript/components/UnexcusedAbsenteesList.jsx
+++ b/app/javascript/components/UnexcusedAbsenteesList.jsx
@@ -18,7 +18,7 @@ export default function UnexcusedAbsenteesList({
   return (
     <ul>
       {data.unexcused_absentees.map((absentee) => (
-        <li key={absentee.member_id} className="pl-8">
+        <li key={absentee.member_id}>
           <a
             href={`https://github.com/${absentee.name}`}
             className="text-sky-600 underline"

--- a/app/javascript/components/UnexcusedAbsenteesList.jsx
+++ b/app/javascript/components/UnexcusedAbsenteesList.jsx
@@ -18,10 +18,7 @@ export default function UnexcusedAbsenteesList({
   return (
     <ul>
       {data.unexcused_absentees.map((absentee) => (
-        <li
-          key={absentee.member_id}
-          className="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle"
-        >
+        <li key={absentee.member_id} className="pl-8">
           <a
             href={`https://github.com/${absentee.name}`}
             className="text-sky-600 underline"

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -39,7 +39,7 @@
 
   <h2 class="font-bold text-2xl">計画ミーティング</h2>
   <ul>
-    <li class="pl-8">プランニングポーカー</li>
+    <li>プランニングポーカー</li>
   </ul>
 
   <h2 class="font-bold text-2xl">欠席者</h2>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -39,7 +39,7 @@
 
   <h2 class="font-bold text-2xl">計画ミーティング</h2>
   <ul>
-    <li class="pl-8 before:content-[''] before:w-1.5 before:h-1.5 before:inline-block before:bg-black before:rounded-full before:mr-2 before:align-middle text-sky-600 underline">プランニングポーカー</li>
+    <li class="pl-8">プランニングポーカー</li>
   </ul>
 
   <h2 class="font-bold text-2xl">欠席者</h2>


### PR DESCRIPTION
## Issue
- #84 

## 概要
Tailwindのデフォルトでは`list-style`が表示されないようになっているため、`ul`タグと`ol`タグで`list-style`を表示するようにTailwindの設定を追加した。

これに関連して、<div>タグにスタイルを当てて<ul>タグのように見せていた箇所を、<ul>タグを使うように修正した。


