### PR TITLE
管理者とチームメンバーで編集フォームの表示を変更する

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,13 +6,10 @@
 
 @layer base {
     ul {
-        @apply list-disc list-inside [&_ul]:list-[revert];
+        @apply list-disc list-inside pl-8 [&_ul]:list-[revert];
     }
     ol {
-        @apply list-decimal list-inside;
-    }
-    li {
-        @apply pl-8;
+        @apply list-decimal list-inside pl-8;
     }
 }
 

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,3 +1,5 @@
+@import "github-markdown-css/github-markdown-light.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -1,4 +1,6 @@
 class API::MinutesController < API::BaseController
+  before_action :authenticate_admin!
+
   def update
     minute = Minute.find(params[:id])
 

--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -10,7 +10,11 @@ import useChannel from '../hooks/useChannel.js'
 dayjs.locale(ja)
 dayjs.extend(weekday)
 
-export default function NextMeetingDateForm({ minuteId, nextMeetingDate }) {
+export default function NextMeetingDateForm({
+  minuteId,
+  nextMeetingDate,
+  isAdmin,
+}) {
   const [date, setDate] = useState(nextMeetingDate)
   const [isEditing, setIsEditing] = useState(false)
 
@@ -31,7 +35,11 @@ export default function NextMeetingDateForm({ minuteId, nextMeetingDate }) {
             setIsEditing={setIsEditing}
           />
         ) : (
-          <NextMeetingDate date={date} setIsEditing={setIsEditing} />
+          <NextMeetingDate
+            date={date}
+            setIsEditing={setIsEditing}
+            isAdmin={isAdmin}
+          />
         )}
         <ul>
           <li>
@@ -85,7 +93,7 @@ function EditForm({ minuteId, date, setIsEditing }) {
   )
 }
 
-function NextMeetingDate({ date, setIsEditing }) {
+function NextMeetingDate({ date, setIsEditing, isAdmin }) {
   const formattedDate = dayjs(date).format('YYYY年MM月DD日')
   const weekday = dayjs(date).format('dd')
   const isHoliday = holidayJP.isHoliday(new Date(date))
@@ -98,13 +106,15 @@ function NextMeetingDate({ date, setIsEditing }) {
           ※{holidayJP.holidays[date].name}
         </span>
       )}
-      <button
-        type="button"
-        onClick={() => setIsEditing(true)}
-        className="ml-2 py-1 px-2 border border-black"
-      >
-        編集
-      </button>
+      {isAdmin && (
+        <button
+          type="button"
+          onClick={() => setIsEditing(true)}
+          className="ml-2 py-1 px-2 border border-black"
+        >
+          編集
+        </button>
+      )}
     </>
   )
 }
@@ -112,6 +122,7 @@ function NextMeetingDate({ date, setIsEditing }) {
 NextMeetingDateForm.propTypes = {
   minuteId: PropTypes.number,
   nextMeetingDate: PropTypes.string,
+  isAdmin: PropTypes.bool,
 }
 
 EditForm.propTypes = {
@@ -123,4 +134,5 @@ EditForm.propTypes = {
 NextMeetingDate.propTypes = {
   date: PropTypes.string,
   setIsEditing: PropTypes.func,
+  isAdmin: PropTypes.bool,
 }

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -4,14 +4,28 @@ import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
 
 export default function OtherForm({ minuteId, content, isAdmin }) {
-  const [inputValue, setInputValue] = useState(content)
+  const [otherContent, setOtherContent] = useState(content)
 
   const onReceivedData = useCallback(function (data) {
     if ('minute' in data.body) {
-      setInputValue(data.body.minute.other)
+      setOtherContent(data.body.minute.other)
     }
   }, [])
   useChannel(minuteId, onReceivedData)
+
+  return (
+    <>
+      {isAdmin ? (
+        <EditForm minuteId={minuteId} content={otherContent} />
+      ) : (
+        <p>{otherContent}</p>
+      )}
+    </>
+  )
+}
+
+function EditForm({ minuteId, content }) {
+  const [inputValue, setInputValue] = useState(content)
 
   const handleChange = function (e) {
     setInputValue(e.target.value)
@@ -35,24 +49,18 @@ export default function OtherForm({ minuteId, content, isAdmin }) {
 
   return (
     <>
-      {isAdmin ? (
-        <>
-          <textarea
-            value={inputValue}
-            onChange={handleChange}
-            className="w-[400px] resize-y align-middle field-sizing-content"
-          />
-          <button
-            type="button"
-            onClick={handleClick}
-            className="ml-2 py-1 px-2 border border-black"
-          >
-            更新
-          </button>
-        </>
-      ) : (
-        <p>{inputValue}</p>
-      )}
+      <textarea
+        value={inputValue}
+        onChange={handleChange}
+        className="w-[400px] resize-y align-middle field-sizing-content"
+      />
+      <button
+        type="button"
+        onClick={handleClick}
+        className="ml-2 py-1 px-2 border border-black"
+      >
+        更新
+      </button>
     </>
   )
 }
@@ -61,4 +69,9 @@ OtherForm.propTypes = {
   minuteId: PropTypes.number,
   content: PropTypes.string,
   isAdmin: PropTypes.bool,
+}
+
+EditForm.propTypes = {
+  minuteId: PropTypes.number,
+  content: PropTypes.string,
 }

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -2,6 +2,8 @@ import { useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
+import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 export default function OtherForm({ minuteId, content, isAdmin }) {
   const [otherContent, setOtherContent] = useState(content)
@@ -18,7 +20,7 @@ export default function OtherForm({ minuteId, content, isAdmin }) {
       {isAdmin ? (
         <EditForm minuteId={minuteId} content={otherContent} />
       ) : (
-        <p>{otherContent}</p>
+        <Other content={otherContent} />
       )}
     </>
   )
@@ -65,6 +67,14 @@ function EditForm({ minuteId, content }) {
   )
 }
 
+function Other({ content }) {
+  const sanitizedHTML = { __html: DOMPurify.sanitize(marked.parse(content)) }
+
+  return (
+    <div className="markdown-body" dangerouslySetInnerHTML={sanitizedHTML} />
+  )
+}
+
 OtherForm.propTypes = {
   minuteId: PropTypes.number,
   content: PropTypes.string,
@@ -73,5 +83,9 @@ OtherForm.propTypes = {
 
 EditForm.propTypes = {
   minuteId: PropTypes.number,
+  content: PropTypes.string,
+}
+
+Other.propTypes = {
   content: PropTypes.string,
 }

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
 
-export default function OtherForm({ minuteId, content }) {
+export default function OtherForm({ minuteId, content, isAdmin }) {
   const [inputValue, setInputValue] = useState(content)
 
   const onReceivedData = useCallback(function (data) {
@@ -35,18 +35,24 @@ export default function OtherForm({ minuteId, content }) {
 
   return (
     <>
-      <textarea
-        value={inputValue}
-        onChange={handleChange}
-        className="w-[400px] resize-y align-middle field-sizing-content"
-      />
-      <button
-        type="button"
-        onClick={handleClick}
-        className="ml-2 py-1 px-2 border border-black"
-      >
-        更新
-      </button>
+      {isAdmin ? (
+        <>
+          <textarea
+            value={inputValue}
+            onChange={handleChange}
+            className="w-[400px] resize-y align-middle field-sizing-content"
+          />
+          <button
+            type="button"
+            onClick={handleClick}
+            className="ml-2 py-1 px-2 border border-black"
+          >
+            更新
+          </button>
+        </>
+      ) : (
+        <p>{inputValue}</p>
+      )}
     </>
   )
 }
@@ -54,4 +60,5 @@ export default function OtherForm({ minuteId, content }) {
 OtherForm.propTypes = {
   minuteId: PropTypes.number,
   content: PropTypes.string,
+  isAdmin: PropTypes.bool,
 }

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -7,6 +7,7 @@ export default function ReleaseInformationForm({
   minuteId,
   description,
   content,
+  isAdmin,
 }) {
   const [informationContent, setInformationContent] = useState(content)
   const [isEditing, setIsEditing] = useState(false)
@@ -40,6 +41,7 @@ export default function ReleaseInformationForm({
             <ReleaseInformation
               content={informationContent}
               setIsEditing={setIsEditing}
+              isAdmin={isAdmin}
             />
           )}
         </ul>
@@ -94,17 +96,19 @@ function EditForm({ minuteId, description, content, setIsEditing }) {
   )
 }
 
-function ReleaseInformation({ content, setIsEditing }) {
+function ReleaseInformation({ content, setIsEditing, isAdmin }) {
   return (
     <li>
       <span>{content}</span>
-      <button
-        type="button"
-        onClick={() => setIsEditing(true)}
-        className="ml-2 py-1 px-2 border border-black"
-      >
-        編集
-      </button>
+      {isAdmin && (
+        <button
+          type="button"
+          onClick={() => setIsEditing(true)}
+          className="ml-2 py-1 px-2 border border-black"
+        >
+          編集
+        </button>
+      )}
     </li>
   )
 }
@@ -113,6 +117,7 @@ ReleaseInformationForm.propTypes = {
   minuteId: PropTypes.number,
   description: PropTypes.string,
   content: PropTypes.string,
+  isAdmin: PropTypes.bool,
 }
 
 EditForm.propTypes = {
@@ -125,4 +130,5 @@ EditForm.propTypes = {
 ReleaseInformation.propTypes = {
   content: PropTypes.string,
   setIsEditing: PropTypes.func,
+  isAdmin: PropTypes.bool,
 }

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -21,8 +21,8 @@
 
   <h3 class="font-bold text-xl">今週のリリースの確認</h3>
   <p>木曜日の15時頃リリースします。</p>
-  <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch}.to_json do %><% end %>
-  <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note}.to_json do %><% end %>
+  <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+  <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">話題にしたいこと・心配事</h3>
   <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>
@@ -32,10 +32,10 @@
                                               currentDevelopmentMemberType: current_development_member.class.name}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">その他</h3>
-  <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other}.to_json do %><% end %>
+  <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <h3 class="font-bold text-xl">次回のMTG</h3>
-  <%= content_tag :div, id: 'next_meeting_date_form', data: {minuteId: @minute.id, nextMeetingDate: @minute.next_meeting_date}.to_json do %><% end %>
+  <%= content_tag :div, id: 'next_meeting_date_form', data: {minuteId: @minute.id, nextMeetingDate: @minute.next_meeting_date, isAdmin: current_development_member.admin?}.to_json do %><% end %>
 
   <h2 class="font-bold text-2xl">計画ミーティング</h2>
   <ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
         "@hotwired/stimulus": "^3.2.2",
         "@hotwired/turbo-rails": "^8.0.10",
         "dayjs": "^1.11.13",
+        "dompurify": "^3.1.7",
+        "marked": "^14.1.3",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -789,6 +791,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -2280,6 +2288,18 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.3.tgz",
+      "integrity": "sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/minimatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@hotwired/turbo-rails": "^8.0.10",
         "dayjs": "^1.11.13",
         "dompurify": "^3.1.7",
+        "github-markdown-css": "^5.7.0",
         "marked": "^14.1.3",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
@@ -1499,6 +1500,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/github-markdown-css": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.7.0.tgz",
+      "integrity": "sha512-GoYhaqELL4YUjz4tZ00PQ4JzFQkMfrBVuEeRB8W74HoikHWNiaGqSgynpwJEc+xom5uf04qoD/tUSS6ziZltaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.10",
     "dayjs": "^1.11.13",
+    "dompurify": "^3.1.7",
+    "marked": "^14.1.3",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@hotwired/turbo-rails": "^8.0.10",
     "dayjs": "^1.11.13",
     "dompurify": "^3.1.7",
+    "github-markdown-css": "^5.7.0",
     "marked": "^14.1.3",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -858,6 +858,11 @@ get-symbol-description@^1.0.2:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
 
+github-markdown-css@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.7.0.tgz"
+  integrity sha512-GoYhaqELL4YUjz4tZ00PQ4JzFQkMfrBVuEeRB8W74HoikHWNiaGqSgynpwJEc+xom5uf04qoD/tUSS6ziZltaQ==
+
 glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dompurify@^3.1.7:
+  version "3.1.7"
+  resolved "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz"
+  integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
+
 emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
@@ -1261,6 +1266,11 @@ loose-envify@^1.1.0, loose-envify@^1.4.0:
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+marked@^14.1.3:
+  version "14.1.3"
+  resolved "https://registry.npmjs.org/marked/-/marked-14.1.3.tgz"
+  integrity sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==
 
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"


### PR DESCRIPTION
## Issue
- #54 

## 概要
議事録編集ページで、議事録の編集フォームの表示を管理者とチームメンバーで切り替えるようにした。

管理者は以下の編集フォームにアクセス可能。
- リリースブランチ
- リリースノート
- 話題にしたいこと・心配事
- その他
- 次回のミーティング開催日

チームメンバーは以下の編集フォームにアクセス可能。
- 話題にしたいこと・心配事

## Screenshot
- 管理者で編集ページを表示した時

![F7D52ED2-F290-4FD2-99E4-962A51257B82](https://github.com/user-attachments/assets/47e296d5-291c-4c15-a531-c352041f3471)

- チームメンバーで編集ページを表示した時

![EF11A32B-69F3-4BF3-A439-9CB357879DCB](https://github.com/user-attachments/assets/4c4bd3fe-de31-4f99-bb57-69e4a1458cf4)

## 備考
その他でMarkdownをパースして表示を行っているが、実装については #81 を参照。
