### PR TITLE
議事録編集ページで、出席表示の並び順を指定

### DIFF
--- a/app/controllers/api/minutes/attendances_controller.rb
+++ b/app/controllers/api/minutes/attendances_controller.rb
@@ -1,7 +1,7 @@
 class API::Minutes::AttendancesController < API::Minutes::ApplicationController
   def index
-    @attendances = @minute.attendances.includes(:member)
+    @attendances = @minute.attendances.includes(:member).order(:member_id)
     # 休止機能を実装した際、無断欠席者から休止者は除外するようにする
-    @unexcused_absentees = Member.where(course_id: @minute.course_id).where.not(id: @attendances.pluck(:member_id))
+    @unexcused_absentees = Member.where(course_id: @minute.course_id).where.not(id: @attendances.pluck(:member_id)).order(:id)
   end
 end


### PR DESCRIPTION
## Issue
- #88 

## 概要
議事録編集ページで出席表示を行う際、メンバーのIDで表示されるようにした。

