### PR TITLE
ブラウザからスタイルシートを取得てきていない問題を修正

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,6 +5,7 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets


### PR DESCRIPTION
## Issue
- #93 

## 概要
`github-markdown-css/github-markdown-light.css`を取得できずに404(Not Found)となっている問題を修正した。

該当のスタイルシートのパスは`node_modules/github-markdown-css/github-markdown-light.css`となっており、`node_modules`内にファイルが存在している。

アセットの探索パスはデフォルトで次のようになっている模様。
```
["/Users/user_name/Working/HomeGrownService/FjordMinutes/app/assets/builds",
 "/Users/user_name/Working/HomeGrownService/FjordMinutes/app/assets/config",
 "/Users/user_name/Working/HomeGrownService/FjordMinutes/app/assets/images",
 "/Users/user_name/Working/HomeGrownService/FjordMinutes/app/assets/stylesheets",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/tailwindcss-rails-2.7.6-arm64-darwin/app/assets/fonts",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/tailwindcss-rails-2.7.6-arm64-darwin/app/assets/stylesheets",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/stimulus-rails-1.3.4/app/assets/javascripts",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/turbo-rails-2.0.10/app/assets/javascripts",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/actioncable-7.2.1/app/assets/javascripts",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activestorage-7.2.1/app/assets/javascripts",
 "/Users/user_name/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/actionview-7.2.1/app/assets/javascripts"]
```

https://railsguides.jp/configuring.html#config-assets-paths を参考に、`node_modules`も探索パスに加えることにした。


