### PR TITLE
出席登録・編集フォームと出席登録・編集ボタンの見た目を整えた

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -16,6 +16,9 @@
         /*field-sizingはまだ実験的機能でTailwindに実装されていないため、カスタムCSSという形で追加する*/
         field-sizing: content;
     }
+    .field_with_errors {
+        display: inline;
+    }
     .button {
         @apply text-white bg-blue-600 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800;
     }

--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -27,7 +27,7 @@ export default function AbsenteesList({ minuteId, currentMemberId, isAdmin }) {
 
 function Absentee({ absentee, currentMemberId, isAdmin }) {
   return (
-    <li>
+    <li className="mb-4">
       <a
         href={`https://github.com/${absentee.name}`}
         className="text-sky-600 underline"
@@ -37,12 +37,12 @@ function Absentee({ absentee, currentMemberId, isAdmin }) {
       {!isAdmin && currentMemberId === absentee.member_id && (
         <a
           href={`/attendances/${absentee.attendance_id}/edit`}
-          className="inline-block ml-2 py-1 px-2 border border-black"
+          className="ps-4 no-underline hover:!no-underline"
         >
-          出席編集
+          <span className="button">出席編集</span>
         </a>
       )}
-      <ul>
+      <ul className="!mt-2">
         <li>欠席理由: {absentee.absence_reason}</li>
         <li>今週の進捗: {absentee.progress_report}</li>
       </ul>

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -84,9 +84,9 @@ function Attendee({ attendee, currentMemberId, isAdmin }) {
       {!isAdmin && currentMemberId === attendee.member_id && (
         <a
           href={`/attendances/${attendee.attendance_id}/edit`}
-          className="inline-block ml-2 py-1 px-2 border border-black"
+          className="ps-4 no-underline hover:!no-underline"
         >
-          出席編集
+          <span className="button">出席編集</span>
         </a>
       )}
     </li>

--- a/app/javascript/components/UnexcusedAbsenteesList.jsx
+++ b/app/javascript/components/UnexcusedAbsenteesList.jsx
@@ -18,7 +18,7 @@ export default function UnexcusedAbsenteesList({
   return (
     <ul>
       {data.unexcused_absentees.map((absentee) => (
-        <li key={absentee.member_id}>
+        <li key={absentee.member_id} className="mb-4">
           <a
             href={`https://github.com/${absentee.name}`}
             className="text-sky-600 underline"
@@ -26,9 +26,9 @@ export default function UnexcusedAbsenteesList({
           {!isAdmin && currentMemberId === absentee.member_id && (
             <a
               href={`/minutes/${minuteId}/attendances/new`}
-              className="inline-block ml-2 py-1 px-2 border border-black"
+              className="ps-4 no-underline hover:!no-underline"
             >
-              出席登録
+              <span className="button">出席登録</span>
             </a>
           )}
         </li>

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,5 +1,5 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">出席編集</h1>
+<div class="mx-auto w-full">
+  <h1 class="font-bold text-4xl text-center">出席編集</h1>
 
   <div>
     <%= form_with(model: @attendance, id: "attendance_form", class: "contents") do |form| %>
@@ -15,33 +15,33 @@
         </div>
       <% end %>
 
-      <div class="my-5">
+      <div class="my-5 text-center">
         <p>出欠</p>
         <%= form.radio_button :status, "present" %>
-        <%= form.label :status_present, "出席" %>
+        <%= form.label :status_present, "出席", class: "mr-10" %>
         <%= form.radio_button :status, "absent" %>
         <%= form.label :status_absent, "欠席" %>
       </div>
 
-      <div class="my-5 present_entry_field">
+      <div class="my-5 text-center present_entry_field">
         <p>出席時間帯</p>
         <%= form.radio_button :time, "day" %>
-        <%= form.label :time_day, "昼の部" %>
+        <%= form.label :time_day, "昼の部", class: "mr-10" %>
         <%= form.radio_button :time, "night" %>
         <%= form.label :time_night, "夜の部" %>
       </div>
 
-      <div class="my-5 absent_entry_field">
+      <div class="my-5 text-center absent_entry_field">
         <%= form.label :absence_reason %>
         <%= form.text_field :absence_reason %>
       </div>
 
-      <div class="my-5 absent_entry_field">
+      <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report %>
         <%= form.text_field :progress_report %>
       </div>
 
-      <div class="inline">
+      <div class="text-center">
         <%= form.submit '出席を更新', class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
       </div>
     <% end %>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,5 +1,5 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">出席登録</h1>
+<div class="mx-auto w-full">
+  <h1 class="font-bold text-4xl text-center">出席登録</h1>
 
   <div>
     <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
@@ -15,34 +15,34 @@
         </div>
       <% end %>
 
-      <div class="my-5">
+      <div class="my-5 text-center">
         <p>出欠</p>
         <%= form.radio_button :status, "present" %>
-        <%= form.label :status_present, "出席" %>
+        <%= form.label :status_present, "出席", class: "mr-10" %>
         <%= form.radio_button :status, "absent" %>
         <%= form.label :status_absent, "欠席" %>
       </div>
 
-      <div class="my-5 present_entry_field">
+      <div class="my-5 text-center present_entry_field">
         <p>出席時間帯</p>
         <%= form.radio_button :time, "day" %>
-        <%= form.label :time_day, "昼の部" %>
+        <%= form.label :time_day, "昼の部", class: "mr-10" %>
         <%= form.radio_button :time, "night" %>
         <%= form.label :time_night, "夜の部" %>
       </div>
 
-      <div class="my-5 absent_entry_field">
-        <%= form.label :absence_reason %>
-        <%= form.text_field :absence_reason %>
+      <div class="my-5 text-center absent_entry_field">
+        <%= form.label :absence_reason, "欠席理由" %>
+        <%= form.text_field :absence_reason, class: 'input_type_text' %>
       </div>
 
-      <div class="my-5 absent_entry_field">
-        <%= form.label :progress_report %>
-        <%= form.text_field :progress_report %>
+      <div class="my-5 text-center absent_entry_field">
+        <%= form.label :progress_report, "進捗報告" %>
+        <%= form.text_field :progress_report, class: 'input_type_text' %>
       </div>
 
-      <div class="inline">
-        <%= form.submit '出席を登録', class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      <div class="text-center">
+        <%= form.submit '出席を登録', class: "button" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Issue
- #98 

## 概要
以下のページ・リンクの見た目を整えた。
- 出席作成ページ
- 出席編集ページ
- 議事録編集ページに表示される出席登録リンク
- 議事録編集ページに表示される出席編集リンク

## Screenshot
- 出席作成・編集ページの出席時間帯選択フォーム

![1DF0686A-169D-455F-917B-E1A8D5B35255](https://github.com/user-attachments/assets/508374b9-dd2b-4d0e-94e4-ccf86ef7953b)

- 出席作成・編集ページの欠席理由・進捗報告入力フォーム

![8E81F888-87D1-4E3C-9665-7315B14F1294](https://github.com/user-attachments/assets/3faa03a7-a5d4-4435-8838-0cf38768f1d3)

- 出席登録リンク

![1904085B-F01F-4CF8-A30F-E0CE4ADC20CD_4_5005_c](https://github.com/user-attachments/assets/d9d97525-7ff9-4d87-861d-04c748100a6e)

- 出席編集リンク

![1B883164-CC28-4944-87F6-3EE4F6275BB5](https://github.com/user-attachments/assets/4ec5c9c8-3f7d-4caf-943a-36a2549c654a)

