### PR TITLE
すでに終了したミーティングの議事録に対して、出席登録や出席編集をできないようにした

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,10 +1,13 @@
 class AttendancesController < ApplicationController
   def edit
     @attendance = current_member.attendances.find(params[:id])
+    redirect_to edit_minute_url(@attendance.minute), alert: "You cannot edit attendance of finished meeting!" if @attendance.minute.already_finished?
   end
 
   def update
     @attendance = current_member.attendances.find(params[:id])
+    redirect_to edit_minute_url(@attendance.minute), alert: "You cannot edit attendance of finished meeting!" if @attendance.minute.already_finished?
+
     remove_unnecessary_values
 
     if @attendance.update(attendance_params)

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -1,11 +1,14 @@
 class Minutes::AttendancesController < Minutes::ApplicationController
   def new
     redirect_to edit_minute_url(@minute), alert: "You already registered attendance!" if already_registered_attendance
+    redirect_to edit_minute_url(@minute), alert: "You cannot attend finished meeting!" if @minute.already_finished?
 
     @attendance = Attendance.new
   end
 
   def create
+    redirect_to edit_minute_url(@minute), alert: "You cannot attend finished meeting!" if @minute.already_finished?
+
     @attendance = @minute.attendances.new(attendance_params)
     @attendance.member_id = current_member.id
 

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -2,4 +2,8 @@ class Minute < ApplicationRecord
   belongs_to :course
   has_many :topics, dependent: :destroy
   has_many :attendances
+
+  def already_finished?
+    meeting_date.before?(Time.zone.today)
+  end
 end


### PR DESCRIPTION
## Issue
- #90 

## 概要
すでに終了したミーティングの議事録に対して、出席登録や出席編集をできないようにした。
すでに終了したミーティングの議事録の出席登録ページや出席編集ページにアクセスすると、リダイレクトされる。

## Screenshot
- 議事録編集ページにアクセスした場合

[![Image from Gyazo](https://i.gyazo.com/368009b881fd1c389cb6179e7d5be416.gif)](https://gyazo.com/368009b881fd1c389cb6179e7d5be416)

- 議事録登録ページにアクセスした場合

[![Image from Gyazo](https://i.gyazo.com/5fab0472bd57d5b601975c9e8570ebea.gif)](https://gyazo.com/5fab0472bd57d5b601975c9e8570ebea)
