### PR TITLE
GitHub認証機能のテストを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,4 +76,5 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "launchy"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -152,6 +154,9 @@ GEM
     jwt (2.9.3)
       base64
     language_server-protocol (3.17.0.3)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -412,6 +417,7 @@ DEPENDENCIES
   factory_bot_rails
   jbuilder
   jsbundling-rails
+  launchy
   omniauth
   omniauth-github
   omniauth-rails_csrf_protection

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,5 +1,4 @@
 class AuthenticationsController < Devise::OmniauthCallbacksController
-  ADMIN_EMAILS = [ ENV["KOMAGATA_EMAIL"], ENV["MACHIDATA_EMAIL"], ENV["KASSY_EMAIL"] ].freeze
   include Devise::Controllers::Rememberable
   skip_before_action :verify_authenticity_token, only: [ :create ]
 
@@ -31,7 +30,8 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
   private
 
   def admin?(email)
-    ADMIN_EMAILS.include? email
+    admin_emails = [ ENV.fetch("KOMAGATA_EMAIL", "no_email"), ENV.fetch("MACHIDA_EMAIL", "no_email"), ENV.fetch("KASSY_EMAIL", "no_email") ]
+    admin_emails.include? email
   end
 
   protected

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :rails_course, class: 'Course' do
+    name { 'Railsエンジニアコース' }
+    meeting_week { 0 }
+  end
+
+  factory :front_end_course, class: 'Course' do
+    name { 'フロントエンドエンジニアコース' }
+    meeting_week { 1 }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless
+  end
+end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,1 @@
+OmniAuth.config.test_mode = true

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "Homes", type: :system do
+  scenario "user can access top page" do
+    FactoryBot.create(:rails_course)
+    FactoryBot.create(:front_end_course)
+
+    visit root_path
+    expect(page).to have_content 'Fjord Minutes'
+    expect(page).to have_button 'Railsエンジニアコースでログイン'
+    expect(page).to have_button 'フロントエンドエンジニアコースでログイン'
+  end
+end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -1,11 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "OmniauthLogins", type: :system do
+  before do
+    FactoryBot.create(:rails_course)
+    FactoryBot.create(:front_end_course)
+  end
+
   context 'as a member' do
     before do
-      FactoryBot.create(:rails_course)
-      FactoryBot.create(:front_end_course)
-
       OmniAuth.config.add_mock(:github, { uid: '123456',
                                           info: { nickname: 'alice',
                                                   email: 'alice@example.com',
@@ -33,9 +35,6 @@ RSpec.describe "OmniauthLogins", type: :system do
 
   context 'as an admin' do
     before do
-      FactoryBot.create(:rails_course)
-      FactoryBot.create(:front_end_course)
-
       OmniAuth.config.add_mock(:github, { uid: '123456',
                                           info: { nickname: 'kassy0220',
                                                   email: 'kassy0220@example.com',
@@ -57,9 +56,6 @@ RSpec.describe "OmniauthLogins", type: :system do
 
   context 'failure login' do
     before do
-      FactoryBot.create(:rails_course)
-      FactoryBot.create(:front_end_course)
-
       Rails.application.env_config['devise.mapping'] = Devise.mappings[:member]
       OmniAuth.config.mock_auth[:github] = :invalid_credentials
     end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -1,31 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe "OmniauthLogins", type: :system do
-  before do
-    FactoryBot.create(:rails_course)
-    FactoryBot.create(:front_end_course)
+  context 'as a member' do
+    before do
+      FactoryBot.create(:rails_course)
+      FactoryBot.create(:front_end_course)
 
-    OmniAuth.config.add_mock(:github, { uid: '123456',
-                                        info: { nickname: 'alice',
-                                                email: 'alice@example.com',
-                                                image: 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' } })
+      OmniAuth.config.add_mock(:github, { uid: '123456',
+                                          info: { nickname: 'alice',
+                                                  email: 'alice@example.com',
+                                                  image: 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' } })
+    end
+
+    scenario 'user can log in as member of the Rails course' do
+      visit root_path
+      click_button 'Railsエンジニアコースでログイン'
+
+      expect(page).to have_content 'Successfully authenticated from GitHub account.'
+      expect(page).to have_content 'aliceのページ'
+      expect(page).to have_content '所属コース : Railsエンジニアコース'
+      expect(page).to have_selector("img[src$='https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3']")
+    end
+
+    scenario 'user can log in as member of the front end course' do
+      visit root_path
+      click_button 'フロントエンドエンジニアコースでログイン'
+
+      expect(page).to have_content 'Successfully authenticated from GitHub account.'
+      expect(page).to have_content '所属コース : フロントエンドエンジニアコース'
+    end
   end
 
-  scenario 'user can log in as member of the Rails course' do
-    visit root_path
-    click_button 'Railsエンジニアコースでログイン'
+  context 'as an admin' do
+    before do
+      FactoryBot.create(:rails_course)
+      FactoryBot.create(:front_end_course)
 
-    expect(page).to have_content 'Successfully authenticated from GitHub account.'
-    expect(page).to have_content 'aliceのページ'
-    expect(page).to have_content '所属コース : Railsエンジニアコース'
-    expect(page).to have_selector("img[src$='https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3']")
-  end
+      OmniAuth.config.add_mock(:github, { uid: '123456',
+                                          info: { nickname: 'kassy0220',
+                                                  email: 'kassy0220@example.com',
+                                                  image: 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' } })
 
-  scenario 'user can log in as member of the front end course' do
-    visit root_path
-    click_button 'フロントエンドエンジニアコースでログイン'
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('KASSY_EMAIL', 'no_email').and_return('kassy0220@example.com')
+    end
 
-    expect(page).to have_content 'Successfully authenticated from GitHub account.'
-    expect(page).to have_content '所属コース : フロントエンドエンジニアコース'
+    scenario 'user can log in as admin' do
+      visit root_path
+      click_button 'Railsエンジニアコースでログイン'
+
+      expect(page).to have_content 'Successfully authenticated from GitHub account.'
+      expect(page).to have_content '管理者用のダッシュボード'
+      expect(page).to have_content '管理者名 : kassy0220'
+    end
   end
 end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe "OmniauthLogins", type: :system do
       expect(page).to have_content '管理者名 : kassy0220'
     end
   end
+
+  context 'failure login' do
+    before do
+      FactoryBot.create(:rails_course)
+      FactoryBot.create(:front_end_course)
+
+      Rails.application.env_config['devise.mapping'] = Devise.mappings[:member]
+      OmniAuth.config.mock_auth[:github] = :invalid_credentials
+    end
+
+    scenario 'redirect root page when login fails' do
+      visit root_path
+      click_button 'Railsエンジニアコースでログイン'
+
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'Could not authenticate you from GitHub'
+    end
+  end
 end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "OmniauthLogins", type: :system do
+  before do
+    FactoryBot.create(:rails_course)
+    FactoryBot.create(:front_end_course)
+
+    OmniAuth.config.add_mock(:github, { uid: '123456',
+                                        info: { nickname: 'alice',
+                                                email: 'alice@example.com',
+                                                image: 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' } })
+  end
+
+  scenario 'user can log in as member of the Rails course' do
+    visit root_path
+    click_button 'Railsエンジニアコースでログイン'
+
+    expect(page).to have_content 'Successfully authenticated from GitHub account.'
+    expect(page).to have_content 'aliceのページ'
+    expect(page).to have_content '所属コース : Railsエンジニアコース'
+    expect(page).to have_selector("img[src$='https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3']")
+  end
+
+  scenario 'user can log in as member of the front end course' do
+    visit root_path
+    click_button 'フロントエンドエンジニアコースでログイン'
+
+    expect(page).to have_content 'Successfully authenticated from GitHub account.'
+    expect(page).to have_content '所属コース : フロントエンドエンジニアコース'
+  end
+end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "OmniauthLogins", type: :system do
 
   context 'as a member' do
     before do
+      Rails.application.env_config['devise.mapping'] = Devise.mappings[:member]
       OmniAuth.config.add_mock(:github, { uid: '123456',
                                           info: { nickname: 'alice',
                                                   email: 'alice@example.com',
@@ -35,6 +36,7 @@ RSpec.describe "OmniauthLogins", type: :system do
 
   context 'as an admin' do
     before do
+      Rails.application.env_config['devise.mapping'] = Devise.mappings[:member]
       OmniAuth.config.add_mock(:github, { uid: '123456',
                                           info: { nickname: 'kassy0220',
                                                   email: 'kassy0220@example.com',


### PR DESCRIPTION
## Issue
- #107 

## 概要
GitHub認証で成功するケースと、失敗するケースのテストを追加した。
テストの追加に関連して、認証時に管理者かどうかを判断する処理を修正している。
また、追加でトップページのテストも追加した。

## Screenshot
途中で`Authentication failure! invalid credentials encountered.`とあるが、これは認証失敗時のテストで意図的に発生させている。
![90687808-6AEC-4DCE-A5A3-7476652BF279](https://github.com/user-attachments/assets/e2781eea-cc4f-42fb-890e-2b185937ad24)

## 備考
- OmniAuthのテストに関しては次を参照。
  - https://github.com/omniauth/omniauth/wiki/Integration-Testing

- テスト時の環境変数のスタブに関しては次を参照。
  - https://github.com/omniauth/omniauth/wiki/Integration-Testing

- テストで利用するメールアドレスのドメインは`example.com`にすること
  - https://qiita.com/jnchito/items/198a2561a36c2c2ef5e3

- 環境変数を読み取る際は`ENV.fetch`を使う。
  - https://saiya-moebius.hatenablog.com/entry/2014/12/26/135041
