### PR TITLE
不要となったヘルパーメソッドを削除

### DIFF
--- a/app/helpers/minutes_helper.rb
+++ b/app/helpers/minutes_helper.rb
@@ -1,5 +1,0 @@
-module MinutesHelper
-  def minute_title(minute)
-    "ふりかえり・計画ミーティング#{minute.meeting_date.strftime('%Y年%m月%d日')}"
-  end
-end

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -7,7 +7,7 @@
     <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
   <% end %>
 
-  <h1><%= minute_title(@minute) %></h1>
+  <h1><%= @minute.title %></h1>
 
   <h1>ふりかえり</h1>
 

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -4,7 +4,7 @@
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
 
-    <h1 class="mb-8 text-4xl font-bold"><%= minute_title(@minute) %></h1>
+    <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>
 
     <%= content_tag :div, id: 'markdown_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 


### PR DESCRIPTION
## Issue
なし

## 概要
議事録のタイトルを返すメソッドが以下の二箇所で定義されていたため、モデルのインスタンスメソッドを利用するように統一し、ヘルパーメソッドを削除した。

- `app/helpers/minutes_helper.rb`
- `app/models/minute.rb`
