### PR TITLE
出席登録機能のテストを追加

### DIFF
--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -7,6 +7,7 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   end
 
   def create
+    redirect_to edit_minute_url(@minute), alert: "You already registered attendance!" if already_registered_attendance
     redirect_to edit_minute_url(@minute), alert: "You cannot attend finished meeting!" if @minute.already_finished?
 
     @attendance = @minute.attendances.new(attendance_params)

--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -12,7 +12,7 @@ export default function AbsenteesList({ minuteId, currentMemberId, isAdmin }) {
   if (isLoading) return <p>読み込み中</p>
 
   return (
-    <ul>
+    <ul id="absentees">
       {data.absentees.map((absentee) => (
         <Absentee
           key={absentee.attendance_id}

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -16,7 +16,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
       <li>
         プログラマー
         <ul>
-          <li>
+          <li id="day_attendees">
             昼
             <ul>
               {data.day_attendees.map((attendee) => (
@@ -29,7 +29,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
               ))}
             </ul>
           </li>
-          <li>
+          <li id="night_attendees">
             夜
             <ul>
               {data.night_attendees.map((attendee) => (

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :member do
+    email { 'alice@example.com' }
+    password { 'password' }
+    provider { 'github' }
+    uid { 111111 }
+    name { 'alice' }
+    avatar_url { 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' }
+    association :course, factory: :rails_course
+  end
+end

--- a/spec/factories/minutes.rb
+++ b/spec/factories/minutes.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :minute do
+    release_branch { '' }
+    release_note { '' }
+    other { '' }
+    meeting_date { Date.new(2024, 10, 02) }
+    next_meeting_date { Date.new(2024, 10, 16) }
+    notified_at { nil }
+    association :course, factory: :rails_course
+  end
+end

--- a/spec/models/minute_spec.rb
+++ b/spec/models/minute_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Minute, type: :model do
+  context '#already_finished?' do
+    before do
+      @minute = FactoryBot.build(:minute)
+    end
+
+    it 'returns false if today is before the meeting date' do
+      travel_to @minute.meeting_date.days_ago(1) do
+        expect(@minute.already_finished?).to be false
+      end
+    end
+
+    it 'returns false if today is the meeting date' do
+      travel_to @minute.meeting_date do
+        expect(@minute.already_finished?).to be false
+      end
+    end
+
+    it 'returns true if today is after the meeting date' do
+      travel_to @minute.meeting_date.days_since(1) do
+        expect(@minute.already_finished?).to be true
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,14 @@
+module LoginSupport
+  def login_as(member)
+    OmniAuth.config.add_mock(:github, { uid: member.uid,
+                                        info: { nickname: member.name,
+                                                email: member.email,
+                                                image: member.avatar_url } })
+    visit root_path
+    click_button "#{member.course.name}でログイン"
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -92,5 +92,34 @@ RSpec.describe "Attendances", type: :system do
         expect(page).to have_content 'You cannot attend finished meeting!'
       end
     end
+
+    scenario 'user cannot create attendance with invalid input', js: true do
+      login_as @member
+      travel_to @minute.meeting_date.days_ago(1) do
+        visit new_minute_attendance_path(@minute)
+
+        click_button '出席を登録'
+        expect(page).to have_content 'Status can\'t be blank'
+
+        choose '欠席'
+        fill_in '欠席理由', with: '仕事の都合。'
+        fill_in '進捗報告', with: '今週の進捗は特にありません。'
+        choose '出席'
+        click_button '出席を登録'
+        expect(page).to have_content 'Time can\'t be blank'
+        expect(page).to have_content 'Absence reason must be blank'
+        expect(page).to have_content 'Progress report must be blank'
+
+        choose '出席'
+        choose '昼の部'
+        choose '欠席'
+        fill_in '欠席理由', with: ''
+        fill_in '進捗報告', with: ''
+        click_button '出席を登録'
+        expect(page).to have_content 'Time must be blank'
+        expect(page).to have_content 'Absence reason can\'t be blank'
+        expect(page).to have_content 'Progress report can\'t be blank'
+      end
+    end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -69,5 +69,19 @@ RSpec.describe "Attendances", type: :system do
         end
       end
     end
+
+    scenario 'user cannot create attendance twice' do
+      login_as @member
+      travel_to @minute.meeting_date.days_ago(1) do
+        visit new_minute_attendance_path(@minute)
+        choose '出席'
+        choose '昼の部'
+        click_button '出席を登録'
+
+        visit new_minute_attendance_path(@minute)
+        expect(current_path).to eq edit_minute_path(@minute)
+        expect(page).to have_content 'You already registered attendance!'
+      end
+    end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Attendances", type: :system do
+  scenario 'not logged in user cannot access create attendance page' do
+    minute = FactoryBot.create(:minute)
+    visit new_minute_attendance_path(minute)
+
+    expect(current_path).to eq root_path
+    expect(page).to have_content 'You need to sign in or sign up before continuing.'
+  end
+end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Attendances", type: :system do
       login_as @member
     end
 
-    scenario 'user can create day attendance', js: true do
+    scenario 'member can create day attendance', js: true do
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '出席'
@@ -33,7 +33,7 @@ RSpec.describe "Attendances", type: :system do
       end
     end
 
-    scenario 'user can create night attendance', js: true do
+    scenario 'member can create night attendance', js: true do
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '出席'
@@ -49,7 +49,7 @@ RSpec.describe "Attendances", type: :system do
       end
     end
 
-    scenario 'user can create absence', js: true do
+    scenario 'member can create absence', js: true do
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '欠席'
@@ -68,7 +68,7 @@ RSpec.describe "Attendances", type: :system do
       end
     end
 
-    scenario 'user cannot create attendance twice' do
+    scenario 'member cannot create attendance twice' do
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '出席'
@@ -81,7 +81,7 @@ RSpec.describe "Attendances", type: :system do
       end
     end
 
-    scenario 'user cannot create attendance to already finished meeting' do
+    scenario 'member cannot create attendance to already finished meeting' do
       travel_to @minute.meeting_date.days_since(1) do
         visit new_minute_attendance_path(@minute)
         expect(current_path).to eq edit_minute_path(@minute)
@@ -89,7 +89,7 @@ RSpec.describe "Attendances", type: :system do
       end
     end
 
-    scenario 'user cannot create attendance with invalid input', js: true do
+    scenario 'member cannot create attendance with invalid input', js: true do
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
 

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "Attendances", type: :system do
       rails_course = FactoryBot.create(:rails_course)
       @minute = FactoryBot.create(:minute, course: rails_course)
       @member = FactoryBot.create(:member, course: rails_course)
+      login_as @member
     end
 
     scenario 'user can create day attendance', js: true do
-      login_as @member
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '出席'
@@ -34,7 +34,6 @@ RSpec.describe "Attendances", type: :system do
     end
 
     scenario 'user can create night attendance', js: true do
-      login_as @member
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '出席'
@@ -51,7 +50,6 @@ RSpec.describe "Attendances", type: :system do
     end
 
     scenario 'user can create absence', js: true do
-      login_as @member
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '欠席'
@@ -71,7 +69,6 @@ RSpec.describe "Attendances", type: :system do
     end
 
     scenario 'user cannot create attendance twice' do
-      login_as @member
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
         choose '出席'
@@ -85,7 +82,6 @@ RSpec.describe "Attendances", type: :system do
     end
 
     scenario 'user cannot create attendance to already finished meeting' do
-      login_as @member
       travel_to @minute.meeting_date.days_since(1) do
         visit new_minute_attendance_path(@minute)
         expect(current_path).to eq edit_minute_path(@minute)
@@ -94,7 +90,6 @@ RSpec.describe "Attendances", type: :system do
     end
 
     scenario 'user cannot create attendance with invalid input', js: true do
-      login_as @member
       travel_to @minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(@minute)
 

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -83,5 +83,14 @@ RSpec.describe "Attendances", type: :system do
         expect(page).to have_content 'You already registered attendance!'
       end
     end
+
+    scenario 'user cannot create attendance to already finished meeting' do
+      login_as @member
+      travel_to @minute.meeting_date.days_since(1) do
+        visit new_minute_attendance_path(@minute)
+        expect(current_path).to eq edit_minute_path(@minute)
+        expect(page).to have_content 'You cannot attend finished meeting!'
+      end
+    end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -8,4 +8,66 @@ RSpec.describe "Attendances", type: :system do
     expect(current_path).to eq root_path
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
   end
+
+  context 'logged in user' do
+    before do
+      rails_course = FactoryBot.create(:rails_course)
+      @minute = FactoryBot.create(:minute, course: rails_course)
+      @member = FactoryBot.create(:member, course: rails_course)
+    end
+
+    scenario 'user can create day attendance', js: true do
+      login_as @member
+      travel_to @minute.meeting_date.days_ago(1) do
+        visit new_minute_attendance_path(@minute)
+        choose '出席'
+        choose '昼の部'
+        click_button '出席を登録'
+
+        expect(current_path).to eq edit_minute_path(@minute)
+        expect(page).to have_content 'Attendance was successfully created.'
+        expect(page).to have_link '出席編集' # Reactコンポーネントの表示を待つため、先に出席編集ボタンの表示を確認する
+        within('#day_attendees') do
+          have_selector 'li', text: @member.name
+        end
+      end
+    end
+
+    scenario 'user can create night attendance', js: true do
+      login_as @member
+      travel_to @minute.meeting_date.days_ago(1) do
+        visit new_minute_attendance_path(@minute)
+        choose '出席'
+        choose '夜の部'
+        click_button '出席を登録'
+
+        expect(current_path).to eq edit_minute_path(@minute)
+        expect(page).to have_content 'Attendance was successfully created.'
+        expect(page).to have_link '出席編集'
+        within('#night_attendees') do
+          have_selector 'li', text: @member.name
+        end
+      end
+    end
+
+    scenario 'user can create absence', js: true do
+      login_as @member
+      travel_to @minute.meeting_date.days_ago(1) do
+        visit new_minute_attendance_path(@minute)
+        choose '欠席'
+        fill_in '欠席理由', with: '仕事の都合のため。'
+        fill_in '進捗報告', with: '今週は依頼されたIssueを進めていました。来週にはPRを提出できそうです。'
+        click_button '出席を登録'
+
+        expect(current_path).to eq edit_minute_path(@minute)
+        expect(page).to have_content 'Attendance was successfully created.'
+        expect(page).to have_link '出席編集'
+        within('#absentees') do
+          have_selector 'li', text: @member.name
+          have_selector 'li', text: '欠席理由: 仕事の都合のため。'
+          have_selector 'li', text: '今週は依頼されたIssueを進めていました。来週にはPRを提出できそうです。'
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #108 

## 概要
出席登録が成功するケースと失敗するケースを確認するテストを追加した。
テスト内でログインするヘルパーメソッドを追加している。
また、コントローラー内で早期リターンの抜け漏れがあった箇所を修正した。

## Screenshot
![8B2C4717-DCB7-4E37-A43F-679E62B5270B](https://github.com/user-attachments/assets/38a418d5-d3f5-4878-935d-c8e52c36fa82)


