### PR TITLE
Markdownプレビューの表示が崩れている問題を修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,7 +4,7 @@
 
 @layer base {
     ul {
-        @apply list-disc list-inside pl-8 [&_ul]:list-[revert];
+        @apply list-disc pl-8 [&_ul]:list-[revert];
     }
     ol {
         @apply list-decimal list-inside pl-8;

--- a/app/javascript/components/MarkdownPreview.jsx
+++ b/app/javascript/components/MarkdownPreview.jsx
@@ -4,7 +4,9 @@ import DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 
 export default function MarkdownPreview({ markdown }) {
-  const sanitizedHTML = { __html: DOMPurify.sanitize(marked.parse(markdown)) }
+  const sanitizedHTML = {
+    __html: DOMPurify.sanitize(marked.parse(markdown, [{ gfm: true }])),
+  }
 
   return (
     <Tabs aria-label="Default tabs" variant="default" theme={customTheme}>

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -64,7 +64,9 @@ function EditForm({ minuteId, content }) {
 }
 
 function Other({ content }) {
-  const sanitizedHTML = { __html: DOMPurify.sanitize(marked.parse(content)) }
+  const sanitizedHTML = {
+    __html: DOMPurify.sanitize(marked.parse(content, [{ gfm: true }])),
+  }
 
   return <div dangerouslySetInnerHTML={sanitizedHTML} />
 }


### PR DESCRIPTION
## Issue
- #116 

## 概要
議事録詳細ページのMarkdownプレビューの表示が崩れていたため、以下の修正を行なった。

- Markdownをパースする際、GFMの仕様を使うようにした
  - https://marked.js.org/using_advanced#options
  - [GFMに完全に対応しているわけではない](https://github.com/markedjs/marked/discussions/1202#discussioncomment-4192078)ようだが、`<li>`タグなど必要なタグはGFMの仕様に対応しているため、このオプションを利用することにした
- `list-style-position: inside`を削除した
  - 検証ツールで確認したところこのCSSが原因で表示が崩れていたため、削除した 

## Screenshot

![8D264858-93F9-4A8B-8465-18E29610DEB2](https://github.com/user-attachments/assets/0455797a-1c1d-47d2-b621-4d9886667b8e)
