### PR TITLE
不要なぼっち演算子を削除した

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -50,7 +50,7 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
     error   = exception.error_reason if exception.respond_to?(:error_reason)
     error ||= exception.error        if exception.respond_to?(:error)
     error ||= (request.respond_to?(:get_header) ? request.get_header('omniauth.error.type') : request.env['omniauth.error.type']).to_s
-    error.to_s&.humanize if error # rubocop:disable Style/SafeNavigation
+    error.to_s.humanize if error # rubocop:disable Style/SafeNavigation
   end
 
   def translation_scope


### PR DESCRIPTION
## Issue
なし

## 概要
該当のコードはOmniAuthエラー時の処理を担う箇所で、Deviseで実装されている処理をそのまま追加している。
該当のコードにもrubocopの指摘が入ったので修正を試みたが、修正してコードが変わってしまうと、自分が書いたコードなのかDeviseから持ってきたコードなのか分かりづらくなってしまうのではないかと考えた。
そこで、Deviseから持ってきたコードはそのままにして、コメントでrubocopの検査対象から除外する対応を行なっている。
(該当のコミット : 0095854ae2f2af9e215e01519ab6a39296fcbbaf)

ただ、Deviseのコードで修正を行なっている箇所があったため、元のDeviseのコードに戻した。
