### PR TITLE
I18nを追加した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'holiday_jp'
 
 gem 'git'
 
+gem 'rails-i18n', '~> 7.0.0'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'git'
 
 gem 'rails-i18n', '~> 7.0.0'
 
+gem 'devise-i18n'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,6 +272,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.1)
       actionpack (= 7.2.1)
       activesupport (= 7.2.1)
@@ -429,6 +432,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)
+  rails-i18n (~> 7.0.0)
   redis (>= 4.0.1)
   rspec-rails
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.12.1)
+      devise (>= 4.9.0)
     diff-lcs (1.5.1)
     dotenv (3.1.4)
     drb (2.2.1)
@@ -418,6 +420,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  devise-i18n
   dotenv
   erb_lint
   factory_bot_rails

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -3,17 +3,17 @@
 class AttendancesController < ApplicationController
   def edit
     @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: 'You cannot edit attendance of finished meeting!' if @attendance.minute.already_finished?
+    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席は変更できません' if @attendance.minute.already_finished?
   end
 
   def update
     @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: 'You cannot edit attendance of finished meeting!' if @attendance.minute.already_finished?
+    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席は変更できません' if @attendance.minute.already_finished?
 
     remove_unnecessary_values
 
     if @attendance.update(attendance_params)
-      redirect_to edit_minute_path(@attendance.minute_id), notice: 'Attendance was successfully updated.'
+      redirect_to edit_minute_path(@attendance.minute_id), notice: "#{Attendance.model_name.human}を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -2,21 +2,21 @@
 
 class Minutes::AttendancesController < Minutes::ApplicationController
   def new
-    redirect_to edit_minute_url(@minute), alert: 'You already registered attendance!' if already_registered_attendance
-    redirect_to edit_minute_url(@minute), alert: 'You cannot attend finished meeting!' if @minute.already_finished?
+    redirect_to edit_minute_url(@minute), alert: 'すでに出席を登録済みです' if already_registered_attendance
+    redirect_to edit_minute_url(@minute), alert: '終了したミーティングには出席できません' if @minute.already_finished?
 
     @attendance = Attendance.new
   end
 
   def create
-    redirect_to edit_minute_url(@minute), alert: 'You already registered attendance!' if already_registered_attendance
-    redirect_to edit_minute_url(@minute), alert: 'You cannot attend finished meeting!' if @minute.already_finished?
+    redirect_to edit_minute_url(@minute), alert: 'すでに出席を登録済みです' if already_registered_attendance
+    redirect_to edit_minute_url(@minute), alert: '終了したミーティングには出席できません' if @minute.already_finished?
 
     @attendance = @minute.attendances.new(attendance_params)
     @attendance.member_id = current_member.id
 
     if @attendance.save
-      redirect_to edit_minute_url(@minute), notice: 'Attendance was successfully created.'
+      redirect_to edit_minute_url(@minute), notice: "#{Attendance.model_name.human}を登録しました"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,11 +1,11 @@
 <div class="mx-auto w-full">
-  <h1 class="font-bold text-4xl text-center">出席編集</h1>
+  <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}編集" %></h1>
 
   <div>
     <%= form_with(model: @attendance, id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-          <h2><%= pluralize(@attendance.errors.count, "error") %> prohibited this attendance from being saved:</h2>
+          <h2>以下の項目で入力内容に誤りがあります:</h2>
 
           <ul>
             <% @attendance.errors.each do |error| %>
@@ -16,19 +16,19 @@
       <% end %>
 
       <div class="my-5 text-center">
-        <p>出欠</p>
+        <p><%= Attendance.human_attribute_name('status') %></p>
         <%= form.radio_button :status, "present" %>
-        <%= form.label :status_present, "出席", class: "mr-10" %>
+        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10" %>
         <%= form.radio_button :status, "absent" %>
-        <%= form.label :status_absent, "欠席" %>
+        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent') %>
       </div>
 
       <div class="my-5 text-center present_entry_field">
-        <p>出席時間帯</p>
+        <p><%= Attendance.human_attribute_name('time') %></p>
         <%= form.radio_button :time, "day" %>
-        <%= form.label :time_day, "昼の部", class: "mr-10" %>
+        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10" %>
         <%= form.radio_button :time, "night" %>
-        <%= form.label :time_night, "夜の部" %>
+        <%= form.label :time_night, Attendance.human_attribute_name('time.night') %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
@@ -42,7 +42,7 @@
       </div>
 
       <div class="text-center">
-        <%= form.submit '出席を更新', class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+        <%= form.submit "#{Attendance.model_name.human}を更新", class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
       </div>
     <% end %>
   </div>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -8,7 +8,7 @@
   </h1>
 
   <div>
-    <p>管理者名 : <%= current_admin.name %></p>
+    <p><%= Admin.human_attribute_name(:name) %> : <%= current_admin.name %></p>
     <% if current_admin.avatar_url %>
       <%= image_tag(current_admin.avatar_url, size: '100x100', alt: '管理者のGitHubアカウントの画像') %>
     <% end %>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,11 +1,11 @@
 <div class="mx-auto w-full">
-  <h1 class="font-bold text-4xl text-center">出席登録</h1>
+  <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
 
   <div>
     <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-          <h2><%= pluralize(@attendance.errors.count, "error") %> prohibited this attendance from being saved:</h2>
+          <h2>以下の項目で入力内容に誤りがあります:</h2>
 
           <ul>
             <% @attendance.errors.each do |error| %>
@@ -16,33 +16,33 @@
       <% end %>
 
       <div class="my-5 text-center">
-        <p>出欠</p>
+        <p><%= Attendance.human_attribute_name('status') %></p>
         <%= form.radio_button :status, "present" %>
-        <%= form.label :status_present, "出席", class: "mr-10" %>
+        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10" %>
         <%= form.radio_button :status, "absent" %>
-        <%= form.label :status_absent, "欠席" %>
+        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent') %>
       </div>
 
       <div class="my-5 text-center present_entry_field">
-        <p>出席時間帯</p>
+        <p><%= Attendance.human_attribute_name('time') %></p>
         <%= form.radio_button :time, "day" %>
-        <%= form.label :time_day, "昼の部", class: "mr-10" %>
+        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10" %>
         <%= form.radio_button :time, "night" %>
-        <%= form.label :time_night, "夜の部" %>
+        <%= form.label :time_night, Attendance.human_attribute_name('time.night') %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
-        <%= form.label :absence_reason, "欠席理由" %>
+        <%= form.label :absence_reason, Attendance.human_attribute_name('absence_reason') %>
         <%= form.text_field :absence_reason, class: 'input_type_text' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
-        <%= form.label :progress_report, "進捗報告" %>
+        <%= form.label :progress_report, Attendance.human_attribute_name('progress_report') %>
         <%= form.text_field :progress_report, class: 'input_type_text' %>
       </div>
 
       <div class="text-center">
-        <%= form.submit '出席を登録', class: "button" %>
+        <%= form.submit "#{Attendance.model_name.human}を登録", class: "button" %>
       </div>
     <% end %>
   </div>

--- a/app/views/minutes/index.html.erb
+++ b/app/views/minutes/index.html.erb
@@ -6,7 +6,7 @@
   <% content_for :title, "Minutes" %>
 
   <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl">Minutes</h1>
+    <h1 class="font-bold text-4xl"><%= "#{Minute.model_name.human}一覧" %></h1>
     <%= link_to "New minute", new_minute_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,8 @@ module FjordMinutes
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.i18n.default_locale = :ja
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,183 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    abbr_month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    order:
+      - :year
+      - :month
+      - :day
+  datetime:
+    distance_in_words:
+      about_x_hours: 約%{count}時間
+      about_x_months: 約%{count}ヶ月
+      about_x_years: 約%{count}年
+      almost_x_years: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds: "%{count}秒未満"
+      less_than_x_minutes: "%{count}分未満"
+      over_x_years: "%{count}年以上"
+      x_seconds: "%{count}秒"
+      x_minutes: "%{count}分"
+      x_days: "%{count}日"
+      x_months: "%{count}ヶ月"
+      x_years: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      in: は%{count}の範囲に含めてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      round_mode: default
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
       attendance: 出席
       course: コース
       member: メンバー
+      minute: 議事録
     attributes:
       admin:
         email: メールアドレス
@@ -35,6 +36,12 @@ ja:
         email: メールアドレス
         password: パスワード
         name: 名前
+      minute:
+        release_branch: リリースブランチ
+        release_note: リリースノート
+        other: その他
+        meeting_date: ミーティング開催日
+        next_meeting_date: 次回ミーティング開催日
   date:
     abbr_day_names:
       - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,11 +9,23 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     models:
       admin: 管理者
+      attendance: 出席
     attributes:
       admin:
         email: メールアドレス
         password: パスワード
         name: 名前
+      attendance:
+        status: 出席状況
+        time: 出席時間帯
+        absence_reason: 欠席理由
+        progress_report: 進捗報告
+      attendance/status:
+        present: 出席
+        absent: 欠席
+      attendance/time:
+        day: 昼の部
+        night: 夜の部
   date:
     abbr_day_names:
       - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
       course: コース
       member: メンバー
       minute: 議事録
+      topic: 話題にしたいこと・心配事
     attributes:
       admin:
         email: メールアドレス
@@ -42,6 +43,8 @@ ja:
         other: その他
         meeting_date: ミーティング開催日
         next_meeting_date: 次回ミーティング開催日
+      topic:
+        content: 内容
   date:
     abbr_day_names:
       - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
       admin: 管理者
       attendance: 出席
       course: コース
+      member: メンバー
     attributes:
       admin:
         email: メールアドレス
@@ -30,6 +31,10 @@ ja:
       course:
         name: コース名
         meeting_week: ミーティング開催週
+      member:
+        email: メールアドレス
+        password: パスワード
+        name: 名前
   date:
     abbr_day_names:
       - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
     models:
       admin: 管理者
       attendance: 出席
+      course: コース
     attributes:
       admin:
         email: メールアドレス
@@ -26,6 +27,9 @@ ja:
       attendance/time:
         day: 昼の部
         night: 夜の部
+      course:
+        name: コース名
+        meeting_week: ミーティング開催週
   date:
     abbr_day_names:
       - 日

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,13 @@ ja:
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
+    models:
+      admin: 管理者
+    attributes:
+      admin:
+        email: メールアドレス
+        password: パスワード
+        name: 名前
   date:
     abbr_day_names:
       - 日

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content 'Attendance was successfully created.'
+        expect(page).to have_content '出席を登録しました'
         expect(page).to have_link '出席編集' # Reactコンポーネントの表示を待つため、先に出席編集ボタンの表示を確認する
         within('#day_attendees') do
           have_selector 'li', text: member.name
@@ -44,7 +44,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content 'Attendance was successfully created.'
+        expect(page).to have_content '出席を登録しました'
         expect(page).to have_link '出席編集'
         within('#night_attendees') do
           have_selector 'li', text: member.name
@@ -61,7 +61,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content 'Attendance was successfully created.'
+        expect(page).to have_content '出席を登録しました'
         expect(page).to have_link '出席編集'
         within('#absentees') do
           have_selector 'li', text: member.name
@@ -80,7 +80,7 @@ RSpec.describe 'Attendances', type: :system do
 
         visit new_minute_attendance_path(minute)
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content 'You already registered attendance!'
+        expect(page).to have_content 'すでに出席を登録済みです'
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe 'Attendances', type: :system do
       travel_to minute.meeting_date.days_since(1) do
         visit new_minute_attendance_path(minute)
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content 'You cannot attend finished meeting!'
+        expect(page).to have_content '終了したミーティングには出席できません'
       end
     end
 
@@ -97,16 +97,16 @@ RSpec.describe 'Attendances', type: :system do
         visit new_minute_attendance_path(minute)
 
         click_button '出席を登録'
-        expect(page).to have_content 'Status can\'t be blank'
+        expect(page).to have_content '出席状況を入力してください'
 
         choose '欠席'
         fill_in '欠席理由', with: '仕事の都合。'
         fill_in '進捗報告', with: '今週の進捗は特にありません。'
         choose '出席'
         click_button '出席を登録'
-        expect(page).to have_content 'Time can\'t be blank'
-        expect(page).to have_content 'Absence reason must be blank'
-        expect(page).to have_content 'Progress report must be blank'
+        expect(page).to have_content '出席時間帯を入力してください'
+        expect(page).to have_content '欠席理由は入力しないでください'
+        expect(page).to have_content '進捗報告は入力しないでください'
 
         choose '出席'
         choose '昼の部'
@@ -114,9 +114,9 @@ RSpec.describe 'Attendances', type: :system do
         fill_in '欠席理由', with: ''
         fill_in '進捗報告', with: ''
         click_button '出席を登録'
-        expect(page).to have_content 'Time must be blank'
-        expect(page).to have_content 'Absence reason can\'t be blank'
-        expect(page).to have_content 'Progress report can\'t be blank'
+        expect(page).to have_content '出席時間帯は入力しないでください'
+        expect(page).to have_content '欠席理由を入力してください'
+        expect(page).to have_content '進捗報告を入力してください'
       end
     end
   end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Attendances', type: :system do
     visit new_minute_attendance_path(minute)
 
     expect(current_path).to eq root_path
-    expect(page).to have_content 'You need to sign in or sign up before continuing.'
+    expect(page).to have_content 'ログインもしくはアカウント登録してください。'
   end
 
   context 'when logged in user' do

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_content '管理者用のダッシュボード'
-      expect(page).to have_content '管理者名 : kassy0220'
+      expect(page).to have_content '名前 : kassy0220'
     end
   end
 

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       visit root_path
       click_button 'Railsエンジニアコースでログイン'
 
-      expect(page).to have_content 'Successfully authenticated from GitHub account.'
+      expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_content 'aliceのページ'
       expect(page).to have_content '所属コース : Railsエンジニアコース'
       expect(page).to have_selector("img[src$='https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3']")
@@ -31,7 +31,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       visit root_path
       click_button 'フロントエンドエンジニアコースでログイン'
 
-      expect(page).to have_content 'Successfully authenticated from GitHub account.'
+      expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_content '所属コース : フロントエンドエンジニアコース'
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       visit root_path
       click_button 'Railsエンジニアコースでログイン'
 
-      expect(page).to have_content 'Successfully authenticated from GitHub account.'
+      expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_content '管理者用のダッシュボード'
       expect(page).to have_content '管理者名 : kassy0220'
     end
@@ -69,7 +69,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       click_button 'Railsエンジニアコースでログイン'
 
       expect(current_path).to eq root_path
-      expect(page).to have_content 'Could not authenticate you from GitHub'
+      expect(page).to have_content 'GitHub アカウントによる認証に失敗しました。'
     end
   end
 end


### PR DESCRIPTION
## Issue
- #119 

## 概要
I18nに必要なgemを追加し、翻訳ファイルを作成して各モデルの翻訳を追加した。
画面表示で翻訳が利用できる箇所は利用を行っている。

## Screenshot
例として、出席登録ページの以下の項目で翻訳を利用している。
- フォームの各項目のラベル
- バリデーションエラーのメッセージ

[![Image from Gyazo](https://i.gyazo.com/32a167168ea84036e1a8554297c8f735.gif)](https://gyazo.com/32a167168ea84036e1a8554297c8f735)


