### PR TITLE
出席編集ページのテキスト入力欄にスタイルを追加

### DIFF
--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -33,12 +33,12 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :absence_reason %>
-        <%= form.text_field :absence_reason %>
+        <%= form.text_field :absence_reason, class: 'input_type_text' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report %>
-        <%= form.text_field :progress_report %>
+        <%= form.text_field :progress_report, class: 'input_type_text' %>
       </div>
 
       <div class="text-center">


### PR DESCRIPTION
## Issue
- #124 

## 概要
出席編集ページのテキスト入力欄にスタイルの追加漏れがあったため、追加した。

## Screenshot
修正前
![64E10C4F-B8CD-4FC4-A5ED-CEE68FA92BE9](https://github.com/user-attachments/assets/29e2be26-3b9b-4840-ba9f-655984f3e32a)


修正後
![23F945C0-1C6A-4FE3-88D7-98A90A355897](https://github.com/user-attachments/assets/d2f54849-726c-45ac-a062-e6efe6b56a27)



