### PR TITLE
エクスポート済みの議事録には、GitHub Wikiに遷移するリンクを表示するようにした

### DIFF
--- a/app/controllers/minutes/exports_controller.rb
+++ b/app/controllers/minutes/exports_controller.rb
@@ -5,6 +5,7 @@ class Minutes::ExportsController < Minutes::ApplicationController
 
   def create
     GithubWikiManager.export_minute(@minute)
+    @minute.update!(exported: true) unless @minute.exported?
     redirect_to minutes_path, notice: 'GitHub Wikiに議事録を反映させました'
   end
 end

--- a/app/helpers/minutes_helper.rb
+++ b/app/helpers/minutes_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MinutesHelper
+  def github_wiki_url(minute)
+    repository_url = minute.course.name == 'Railsエンジニアコース' ? ENV.fetch('BOOTCAMP_WIKI_URL', nil) : ENV.fetch('AGENT_WIKI_URL', nil)
+    URI.join(repository_url.sub('.wiki.git', '/wiki/'), URI.encode_www_form_component(minute.title)).to_s
+  end
+end

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -14,7 +14,7 @@
 
     <% if @minute.exported? %>
       <div class="text-center my-2">
-        <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow", class: 'text-sky-600 underline' %>
+        <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow", class: 'text-sky-600 hover:underline' %>
       </div>
     <% end %>
 

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -12,6 +12,12 @@
       <%= button_to 'GitHub Wiki にエクスポート', minute_exports_path(@minute), form: { class: 'text-center' },  class: 'button m-auto' %>
     <% end %>
 
+    <% if @minute.exported? %>
+      <div class="text-center my-2">
+        <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow", class: 'text-sky-600 underline' %>
+      </div>
+    <% end %>
+
     <%= link_to "Edit this minute", edit_minute_path(@minute), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <%= link_to "Back to minutes", minutes_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">

--- a/db/migrate/20241028092105_add_exported_to_minutes.rb
+++ b/db/migrate/20241028092105_add_exported_to_minutes.rb
@@ -1,0 +1,5 @@
+class AddExportedToMinutes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :minutes, :exported, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_15_072227) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_28_092105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_15_072227) do
     t.bigint "course_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "exported", default: false
     t.index ["course_id"], name: "index_minutes_on_course_id"
   end
 


### PR DESCRIPTION
## Issue
- #111 

## 概要
議事録詳細ページで、もし議事録がGitHub Wikiにエクスポート済みであった場合、GitHub Wikiのページに遷移できるリンクを表示するようにした。

## Screenshot
GitHub Wikiにエクスポート前
![DBD73757-4948-4811-9FE9-A5DCA88B98D5](https://github.com/user-attachments/assets/cc6d8567-57dc-4f98-b086-45181cd9c6a0)

GitHub Wikiにエクスポート後
![7BF87D8B-591F-4B1A-A003-55E527B29C6D](https://github.com/user-attachments/assets/eecd1aeb-fa77-4dbc-9964-fb193a428197)

リンクを開いた時の挙動
[![Image from Gyazo](https://i.gyazo.com/195e2c90a3c32218c8af9268bb7eceb2.gif)](https://gyazo.com/195e2c90a3c32218c8af9268bb7eceb2)

## 備考
### エクスポート済みを判別する方法
エクスポート済みかどうかを判別する方法として、エクスポートする際Markdownファイルを作成してコミットするため、該当のMarkdownファイルが存在するか(またはコミットされているか)どうかを確認する方法が考えられる。

ただし、この方法は以下の理由で不可能である。

- Heorkuには`ephemeral filesystem`というファイルシステムがあり、**デプロイや定期的な再起動の際にファイルがリセット**されてしまう。
  - そのため、エクスポート時に作成されたファイルは、システムの定期的な再起動時にワークングディレクトリごと削除されてしまい、永続化しない

参考 : https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem

そこで、エクスポートしたことを議事録モデルの属性として保存し、参照する形でエクスポート済みを判別するようにした。


### リンクのオプション
リンクに設定しているオプションは以下を参照。
- https://developer.mozilla.org/ja/docs/Web/HTML/Element/a#target
- https://developer.mozilla.org/ja/docs/Web/HTML/Attributes/rel#nofollow
