### PR TITLE
DateクラスからTimeWithZoneクラスを使うように修正

### DIFF
--- a/app/models/meeting_date_calculator.rb
+++ b/app/models/meeting_date_calculator.rb
@@ -29,15 +29,15 @@ class MeetingDateCalculator
   def all_meeting_days_in_month(year, month)
     meeting_days = []
 
-    first_day = Date.new(year, month, 1)
+    first_day = Time.zone.local(year, month, 1)
     last_day = first_day.end_of_month
 
     meeting_day = first_day
-    meeting_day += 1 until meeting_day.wday == DAY_OF_THE_WEEK_FOR_MEETING
+    meeting_day += 1.day until meeting_day.wday == DAY_OF_THE_WEEK_FOR_MEETING
 
     while meeting_day <= last_day
       meeting_days << meeting_day.day
-      meeting_day += 7
+      meeting_day += 7.days
     end
 
     meeting_days

--- a/app/models/meeting_secretary.rb
+++ b/app/models/meeting_secretary.rb
@@ -71,7 +71,7 @@ class MeetingSecretary
   def get_latest_meeting_date_from_cloned_minutes(repository_path)
     Dir.glob('ふりかえり・計画ミーティング*', base: repository_path).map do |filename|
       _, year, month, day = *filename.match(/ふりかえり・計画ミーティング(\d{4})年(\d{2})月(\d{2})/)
-      Date.new(year.to_i, month.to_i, day.to_i)
+      Date.new(year.to_i, month.to_i, day.to_i) # Time.zone.today(返り値はDateクラス)と比較を行うために、Dateクラスでインスタンス化する
     end.max
   end
 
@@ -79,7 +79,7 @@ class MeetingSecretary
     filename = "ふりかえり・計画ミーティング#{meeting_date.strftime('%Y年%m月%d日')}.md"
     minute_content = File.read(File.join(repository_path, filename))
     _, year, month, day = *minute_content.match(/# 次回のMTG\n\n- (\d{4})年(\d{2})月(\d{2})日/)
-    Date.new(year.to_i, month.to_i, day.to_i)
+    Time.zone.local(year.to_i, month.to_i, day.to_i)
   end
 
   def webhook_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module FjordMinutes
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Asia/Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.generators do |g|

--- a/spec/factories/minutes.rb
+++ b/spec/factories/minutes.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     release_branch { '' }
     release_note { '' }
     other { '' }
-    meeting_date { Date.new(2024, 10, 2) }
-    next_meeting_date { Date.new(2024, 10, 16) }
+    meeting_date { Time.zone.local(2024, 10, 2) }
+    next_meeting_date { Time.zone.local(2024, 10, 16) }
     notified_at { nil }
     association :course, factory: :rails_course
   end

--- a/spec/models/meeting_date_calculator_spec.rb
+++ b/spec/models/meeting_date_calculator_spec.rb
@@ -8,34 +8,34 @@ RSpec.describe MeetingDateCalculator, type: :model do
     let(:front_end_course) { FactoryBot.build(:front_end_course, meeting_week: :even) }
 
     it 'returns two weeks later when meeting date is within two weeks' do
-      meeting_date = Date.new(2024, 10, 2)
-      expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Date.new(2024, 10, 16)
+      meeting_date = Time.zone.local(2024, 10, 2)
+      expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Time.zone.local(2024, 10, 16)
 
-      meeting_date = Date.new(2024, 10, 9)
-      expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Date.new(2024, 10, 23)
+      meeting_date = Time.zone.local(2024, 10, 9)
+      expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Time.zone.local(2024, 10, 23)
     end
 
     context 'when meeting date is outside two weeks' do
       it 'returns day of the first week of the next month when meeting week is odd' do
-        meeting_date = Date.new(2024, 10, 16)
-        expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Date.new(2024, 11, 6)
+        meeting_date = Time.zone.local(2024, 10, 16)
+        expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Time.zone.local(2024, 11, 6)
       end
 
       it 'returns day of the second week of the next month when meeting week is even' do
-        meeting_date = Date.new(2024, 10, 23)
-        expect(described_class.next_meeting_date(meeting_date, front_end_course.meeting_week)).to eq Date.new(2024, 11, 13)
+        meeting_date = Time.zone.local(2024, 10, 23)
+        expect(described_class.next_meeting_date(meeting_date, front_end_course.meeting_week)).to eq Time.zone.local(2024, 11, 13)
       end
     end
 
     context 'when next meeting date is next year' do
       it 'returns day of the first week of next January when meeting week is odd' do
-        meeting_date = Date.new(2024, 12, 18)
-        expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Date.new(2025, 1, 1)
+        meeting_date = Time.zone.local(2024, 12, 18)
+        expect(described_class.next_meeting_date(meeting_date, rails_course.meeting_week)).to eq Time.zone.local(2025, 1, 1)
       end
 
       it 'returns day of the second week of next January when meeting week is even' do
-        meeting_date = Date.new(2024, 12, 25)
-        expect(described_class.next_meeting_date(meeting_date, front_end_course.meeting_week)).to eq Date.new(2025, 1, 8)
+        meeting_date = Time.zone.local(2024, 12, 25)
+        expect(described_class.next_meeting_date(meeting_date, front_end_course.meeting_week)).to eq Time.zone.local(2025, 1, 8)
       end
     end
   end

--- a/spec/models/meeting_secretary_spec.rb
+++ b/spec/models/meeting_secretary_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe MeetingSecretary, type: :model do
   describe '#create_minute' do
     let(:rails_course) { FactoryBot.create(:rails_course) }
-    let(:latest_minute) { FactoryBot.create(:minute, next_meeting_date: Date.new(2024, 11, 20), course: rails_course) }
+    let(:latest_minute) { FactoryBot.create(:minute, next_meeting_date: Time.zone.local(2024, 11, 20), course: rails_course) }
     let(:meeting_secretary) { described_class.new(rails_course) }
 
     it 'create minute of next meeting' do
@@ -35,7 +35,7 @@ RSpec.describe MeetingSecretary, type: :model do
 
     before do
       allow(meeting_secretary).to receive_messages(get_latest_meeting_date_from_cloned_minutes: latest_meeting_date,
-                                                   get_next_meeting_date_from_cloned_minutes: Date.new(2024, 11, 20))
+                                                   get_next_meeting_date_from_cloned_minutes: Time.zone.local(2024, 11, 20))
       allow(Discord::Notifier).to receive(:message).and_return(nil)
     end
 


### PR DESCRIPTION
## Issue
- #130 

## 概要
日付インスタンスを作成する際、Dateクラスでインスタンス化していた箇所をTimeWithZoneクラスでインスタンス化するようにした。
また、TimeWithZoneが参照するタイムゾーンの設定も追加している。
※ 一部例外あり

## 備考
### DateクラスとTimeWithZoneクラス
DateクラスとTimeWithZoneクラスの特徴は以下の通り。

- Dateクラス
  - `Date.today`で現在の日にちが取得できる
  - 生成されたインスタンス自体はタイムゾーンを考慮しない(タイムゾーンの情報を持っていない)
- TimeWithZone
  - `config/application.rb`で設定されているタイムゾーンをタイムゾーンとして持っている  

基本的にはRailsが用意しているTimeWithZoneクラスを利用する方が良い模様。

> とりあえず、Railsの実装を見ていると日時関連の処理は TimeWithZone を積極的に使おうとしているように思います。 TimeWithZone はタイムゾーンをRuby標準のTimeクラスよりも器用に扱えるので、国際的なwebアプリケーションをターゲットにするのであれば、TimeWithZoneクラスを積極的に使うのは確かに理にかなっています。
なので、我々も 極力 TimeWithZone を使うようにした方が良い 、と考えることができます。

https://qiita.com/jnchito/items/cae89ee43c30f5d6fa2c

### 例外箇所
`MeetingSecretary`とそのテストファイル内では、例外としてDateクラスを用いている箇所がある。
![71AAB7AD-C755-452A-83F9-694415394A91](https://github.com/user-attachments/assets/8978f346-6084-4bcb-903c-e4e72fb446c3)

#### app/models/meeting_secretary.rb
`get_latest_meeting_date_from_cloned_minutes(repository_path)`内で日付を作成する際、Dateクラスをインスタンス化している。

```ruby
  def get_latest_meeting_date_from_cloned_minutes(repository_path)
    Dir.glob('ふりかえり・計画ミーティング*', base: repository_path).map do |filename|
      _, year, month, day = *filename.match(/ふりかえり・計画ミーティング(\d{4})年(\d{2})月(\d{2})/)
      Date.new(year.to_i, month.to_i, day.to_i) # Time.zone.today(返り値はDateクラス)と比較を行うために、Dateクラスでインスタンス化する
    end.max
  end
```

このメソッドの返り値は`Time.zone.today`(Dateクラス)と比較されるため、TimeWithZoneクラスを返すと意図しない挙動になってしまう。

以下のコードにあるように、同じ日付でインスタンスを作成し、`before?`で比較を行うと、同じ日付なのにtrueとなってしまう。
(おそらく、[TimeWithZone#<=>](https://api.rubyonrails.org/classes/ActiveSupport/TimeWithZone.html#method-i-3C-3D-3E)がUTCの時間で比較を行っていることが原因)
同じ日付であれば`before?`はfalseであってほしい。
```
fjord-minutes(dev)> date = Date.new(2024, 10, 10)
=> Thu, 10 Oct 2024
fjord-minutes(dev)> time_with_zone = Time.zone.local(2024, 10, 10)
=> Thu, 10 Oct 2024 00:00:00.000000000 JST +09:00
fjord-minutes(dev)> time_with_zone.before? date
=> true
```

そのため、このメソッドがDateクラスのインスタンスを返すようにDateクラスを用いる。


#### app/spec/models/meeting_secretary_spec.rb
期待値の日付をTimeWithZoneクラスで作成すると以下のエラーが発生するため、期待値の日付はDateクラスで作成している。

```
  1) MeetingSecretary#create_minute create minute of next meeting
     Failure/Error: expect(created_minute.meeting_date).to eq Time.zone.local(2024, 11, 20)
     
       expected: 2024-11-20 00:00:00.000000000 +0900
            got: Wed, 20 Nov 2024
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -Wed, 20 Nov 2024 00:00:00.000000000 JST +09:00
       +Wed, 20 Nov 2024
```
