### PR TITLE
議事録編集のテストを追加

### DIFF
--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -90,6 +90,7 @@ function EditForm({ minuteId, date, setIsEditing }) {
         showTodayButton={false}
         value={selectedDate}
         onChange={(date) => handleInput(date)}
+        id="next_meeting_date_field"
       />
       <button type="button" onClick={handleClick} className="button mt-2">
         更新

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -54,6 +54,7 @@ function EditForm({ minuteId, content }) {
       <textarea
         value={inputValue}
         onChange={handleChange}
+        id="other_field"
         className="textarea"
       />
       <button type="button" onClick={handleClick} className="button">

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -83,6 +83,7 @@ function EditForm({ minuteId, description, content, setIsEditing }) {
         type="text"
         value={inputValue}
         onChange={handleInput}
+        id={`release_${description}_field`}
         className="input_type_text"
       />
       <button type="button" onClick={handleClick} className="button">

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -142,6 +142,7 @@ function EditForm({ minuteId, topicId, content, setIsEditing }) {
         type="text"
         value={inputValue}
         onChange={handleInput}
+        id="edit_topic_field"
         className="input_type_text max-w-[800px]"
       />
       <button
@@ -192,6 +193,7 @@ function CreateForm({ minuteId }) {
         type="text"
         value={inputValue}
         onChange={handleInput}
+        id="new_topic_field"
         className="input_type_text"
       />
       <button

--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :admin do
+    email { 'admin@example.com' }
+    password { 'password' }
+    provider { 'github' }
+    uid { 123_456 }
+    name { 'admin' }
+    avatar_url { 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' }
+  end
+end

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -9,5 +9,11 @@ FactoryBot.define do
     name { 'alice' }
     avatar_url { 'https://gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3' }
     association :course, factory: :rails_course
+
+    trait :another_member do
+      email { 'bob@example.com' }
+      uid { 222_222 }
+      name { 'bob' }
+    end
   end
 end

--- a/spec/factories/minutes.rb
+++ b/spec/factories/minutes.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :minute do
-    release_branch { '' }
-    release_note { '' }
-    other { '' }
+    release_branch { 'https://example.com/fjordllc/bootcamp/pull/1000' }
+    release_note { 'https://example.com/announcements/100' }
+    other { '連絡事項は特にありません' }
     meeting_date { Time.zone.local(2024, 10, 2) }
     next_meeting_date { Time.zone.local(2024, 10, 16) }
     notified_at { nil }

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -9,6 +9,17 @@ module LoginSupport
     visit root_path
     click_button "#{member.course.name}でログイン"
   end
+
+  def login_as_admin(admin)
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('KASSY_EMAIL', 'no_email').and_return(admin.email)
+    OmniAuth.config.add_mock(:github, { uid: admin.uid,
+                                        info: { nickname: admin.name,
+                                                email: admin.email,
+                                                image: admin.avatar_url } })
+    visit root_path
+    click_button 'Railsエンジニアコースでログイン'
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe 'Minutes', type: :system do
 
     before do
       login_as_admin admin
+      visit edit_minute_path(minute)
     end
 
     it 'can access all edit form', :js do
-      visit edit_minute_path(minute)
       within('#release_branch_form') do
         expect(page).to have_selector 'button', text: '編集'
       end
@@ -29,6 +29,28 @@ RSpec.describe 'Minutes', type: :system do
       end
       within('#next_meeting_date_form') do
         expect(page).to have_selector 'button', text: '編集'
+      end
+    end
+
+    it 'can edit release branch and release note', :js do
+      within('#release_branch_form') do
+        expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/1000'
+
+        click_button '編集'
+        fill_in 'release_branch_field', with: 'https://example.com/fjordllc/bootcamp/pull/9999'
+        click_button '更新'
+        expect(page).not_to have_selector 'input'
+        expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/9999'
+      end
+
+      within('#release_note_form') do
+        expect(page).to have_content 'https://example.com/announcements/100'
+
+        click_button '編集'
+        fill_in 'release_note_field', with: 'https://example.com/fjordllc/bootcamp/pull/999'
+        click_button '更新'
+        expect(page).not_to have_selector 'input'
+        expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/999'
       end
     end
   end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Minutes', type: :system do
+  context 'when as admin' do
+    let!(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+    let(:admin) { FactoryBot.create(:admin) }
+
+    before do
+      login_as_admin admin
+    end
+
+    it 'can access all edit form', :js do
+      visit edit_minute_path(minute)
+      within('#release_branch_form') do
+        expect(page).to have_selector 'button', text: '編集'
+      end
+      within('#release_note_form') do
+        expect(page).to have_selector 'button', text: '編集'
+      end
+      within('#topics') do
+        expect(page).to have_selector 'button', text: '作成'
+      end
+      within('#other_form') do
+        expect(page).to have_selector 'textarea'
+        expect(page).to have_selector 'button', text: '更新'
+      end
+      within('#next_meeting_date_form') do
+        expect(page).to have_selector 'button', text: '編集'
+      end
+    end
+  end
+
+  context 'when as member' do
+    let!(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+    let(:member) { FactoryBot.create(:member, course: rails_course) }
+
+    before do
+      login_as member
+    end
+
+    it 'can access only topic edit form', :js do
+      visit edit_minute_path(minute)
+      within('#release_branch_form') do
+        expect(page).not_to have_selector 'button', text: '編集'
+      end
+      within('#release_note_form') do
+        expect(page).not_to have_selector 'button', text: '編集'
+      end
+      within('#topics') do
+        expect(page).to have_selector 'button', text: '作成'
+      end
+      within('#other_form') do
+        expect(page).not_to have_selector 'textarea'
+        expect(page).not_to have_selector 'button', text: '更新'
+      end
+      within('#next_meeting_date_form') do
+        expect(page).not_to have_selector 'button', text: '編集'
+      end
+    end
+  end
+end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -152,4 +152,22 @@ RSpec.describe 'Minutes', type: :system do
       end
     end
   end
+
+  context 'when next meeting date form' do
+    let!(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:minute) { FactoryBot.create(:minute, next_meeting_date: Time.zone.local(2024, 10, 14), course: rails_course) }
+    let(:member) { FactoryBot.create(:member, course: rails_course) }
+
+    before do
+      login_as member
+      visit edit_minute_path(minute)
+    end
+
+    it 'display message when next meeting is holiday' do
+      within('#next_meeting_date_form') do
+        expect(page).to have_content '2024年10月14日'
+        expect(page).to have_content '次回開催日はスポーツの日です。もしミーティングをお休みにする場合は、開催日を変更しましょう。'
+      end
+    end
+  end
 end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -130,4 +130,26 @@ RSpec.describe 'Minutes', type: :system do
       end
     end
   end
+
+  context 'when topic form' do
+    let!(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+    let(:member) { FactoryBot.create(:member, course: rails_course) }
+    let(:another_member) { FactoryBot.create(:member, :another_member, course: rails_course) }
+
+    before do
+      login_as another_member
+    end
+
+    it 'cannot edit and destroy topic created by others', :js do
+      minute.topics.create(content: 'テストが通らないのでどなたかペアプロをお願いします！', topicable: member)
+
+      visit edit_minute_path(minute)
+      within('#topics') do
+        expect(page).to have_selector 'li', text: 'テストが通らないのでどなたかペアプロをお願いします！(alice)'
+        expect(page).not_to have_selector 'button', text: '編集'
+        expect(page).not_to have_selector 'button', text: '削除'
+      end
+    end
+  end
 end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -63,6 +63,23 @@ RSpec.describe 'Minutes', type: :system do
       expect(page).to have_content '次のリリースは午前中に行いますのでご注意ください' # 非同期で議事録の更新が行われるまで待つ
       expect(minute.reload.other).to eq '次のリリースは午前中に行いますのでご注意ください'
     end
+
+    it 'can edit next meeting date', :js do
+      within('#next_meeting_date_form') do
+        expect(page).to have_content '2024年10月16日'
+
+        click_button '編集'
+        # 日付編集フォームの実装はflowbite-reactのDatepickerを使っているが、このコンポーネントは<input type="text">を返すようになっている
+        # 以下の手順で日付編集フォームを操作することができたので、一旦以下の方法でテストを実装する
+        # fill_in で日付編集フォームの日付選択欄を開く
+        # click_buttonで日付を選択する
+        fill_in 'next_meeting_date_field', with: Date.new(2024, 10, 23)
+        click_button '23日'
+        click_button '更新'
+        expect(page).not_to have_selector 'input'
+        expect(page).to have_content '2024年10月23日'
+      end
+    end
   end
 
   context 'when as member' do

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -54,6 +54,25 @@ RSpec.describe 'Minutes', type: :system do
       end
     end
 
+    it 'can create, edit and delete topic', :js do
+      within('#topics') do
+        expect(find('button', text: '作成')).to be_disabled
+        fill_in 'new_topic_field', with: '今週ミートアップがありますのでぜひご参加を！'
+        click_button '作成'
+        expect(page).to have_selector 'li', text: '今週ミートアップがありますのでぜひご参加を！(admin)'
+        expect(page).to have_selector 'button', text: '編集'
+        expect(page).to have_selector 'button', text: '削除'
+
+        click_button '編集'
+        fill_in 'edit_topic_field', with: 'Issueが完了したら必ずcloseするようにしましょう'
+        click_button '更新'
+        expect(page).to have_selector 'li', text: 'Issueが完了したら必ずcloseするようにしましょう(admin)'
+
+        click_button '削除'
+        expect(page).not_to have_selector 'li', text: 'Issueが完了したら必ずcloseするようにしましょう(admin)'
+      end
+    end
+
     it 'can edit other', :js do
       within('#other_form') do
         expect(page).to have_selector 'textarea', text: '連絡事項は特にありません'

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe 'Minutes', type: :system do
         expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/999'
       end
     end
+
+    it 'can edit other', :js do
+      within('#other_form') do
+        expect(page).to have_selector 'textarea', text: '連絡事項は特にありません'
+        fill_in 'other_field', with: '次のリリースは午前中に行いますのでご注意ください'
+        click_button '更新'
+      end
+      expect(page).to have_content '次のリリースは午前中に行いますのでご注意ください' # 非同期で議事録の更新が行われるまで待つ
+      expect(minute.reload.other).to eq '次のリリースは午前中に行いますのでご注意ください'
+    end
   end
 
   context 'when as member' do


### PR DESCRIPTION
## Issue
- #100

## 概要
以下の項目をテストするsystem specを追加した。
- 管理者とメンバーで表示される編集フォームが異なる

- 議事録の各項目が編集できる
    - リリース情報
      - リリースブランチ
      - リリースノート
    - 話題にしたいこと・心配事
      - 作成(ユーザー名も表示される)
      - 編集(自分だけ)
      - 削除(自分だけ)
    - その他
    - 次回開催日
      - 次回開催日が祝日である場合、その旨を表示する

## Screenshot
![6D708AF4-29EA-4A5C-A0D0-05C55B7DB89F](https://github.com/user-attachments/assets/8d4353a4-40b9-4dc1-8b47-a5f404a3fdd6)

