### PR TITLE
無断欠席の表示のテストを追加

### DIFF
--- a/app/javascript/components/UnexcusedAbsenteesList.jsx
+++ b/app/javascript/components/UnexcusedAbsenteesList.jsx
@@ -16,7 +16,7 @@ export default function UnexcusedAbsenteesList({
   if (isLoading) return <p>読み込み中</p>
 
   return (
-    <ul>
+    <ul id="unexcused_absentees">
       {data.unexcused_absentees.map((absentee) => (
         <li key={absentee.member_id} className="mb-4">
           <a

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '出席を登録しました'
         expect(page).to have_link '出席編集' # Reactコンポーネントの表示を待つため、先に出席編集ボタンの表示を確認する
         within('#day_attendees') do
-          have_selector 'li', text: member.name
+          expect(page).to have_selector 'li', text: member.name
         end
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '出席を登録しました'
         expect(page).to have_link '出席編集'
         within('#night_attendees') do
-          have_selector 'li', text: member.name
+          expect(page).to have_selector 'li', text: member.name
         end
       end
     end
@@ -64,9 +64,9 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '出席を登録しました'
         expect(page).to have_link '出席編集'
         within('#absentees') do
-          have_selector 'li', text: member.name
-          have_selector 'li', text: '欠席理由: 仕事の都合のため。'
-          have_selector 'li', text: '今週は依頼されたIssueを進めていました。来週にはPRを提出できそうです。'
+          expect(page).to have_selector 'li', text: member.name
+          expect(page).to have_selector 'li', text: '欠席理由: 仕事の都合のため。'
+          expect(page).to have_selector 'li', text: '今週は依頼されたIssueを進めていました。来週にはPRを提出できそうです。'
         end
       end
     end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
+    scenario 'treated as unexcused absentees if member create neither attendance nor absence', :js do
+      visit edit_minute_path(minute)
+      within('#unexcused_absentees') do
+        expect(page).to have_selector 'li', text: 'alice'
+      end
+    end
+
     scenario 'member cannot create attendance twice' do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)


### PR DESCRIPTION
## Issue
- #100 

## 概要
議事録に出席登録をしていない場合は、無断欠席として表示されることのテストを追加した。
また、出席テスト内で`expect`が呼ばれていない箇所があったため、そこの修正も行なっている。

## Screenshot
![AD08BED6-0712-495D-B725-B7033E3BC740](https://github.com/user-attachments/assets/8eb0b693-1c9b-4455-a07d-58195c97017e)

