### PR TITLE
出席編集のテストを追加

### DIFF
--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :attendance do
+    status { :present }
+    time { :day }
+    absence_reason { nil }
+    progress_report { nil }
+    association :member, factory: :member
+    association :minute, factory: :minute
+
+    trait :night do
+      time { :night }
+    end
+
+    trait :absence do
+      status { :absent }
+      time { nil }
+      absence_reason { '体調不良のため。' }
+      progress_report { 'PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。' }
+    end
+  end
+end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -164,5 +164,31 @@ RSpec.describe 'Attendances', type: :system do
         end
       end
     end
+
+    scenario 'member can edit absence to attendance', :js do
+      attendance = minute.attendances.create(status: :absent, absence_reason: '仕事の都合のため。', progress_report: '今週の進捗はありません。', member_id: member.id)
+      travel_to minute.meeting_date.days_ago(1) do
+        visit edit_minute_path(minute)
+        within('#absentees') do
+          click_link '出席編集'
+        end
+        expect(current_path).to eq edit_attendance_path(attendance)
+        choose '欠席'
+        fill_in '欠席理由', with: ''
+        fill_in '進捗報告', with: ''
+        choose '出席'
+        choose '夜の部'
+        click_button '出席を更新'
+
+        expect(current_path).to eq edit_minute_path(minute)
+        expect(page).to have_content '出席を更新しました'
+        within('#absentees', visible: false) do
+          expect(page).not_to have_selector 'li', text: member.name
+        end
+        within('#night_attendees') do
+          expect(page).to have_selector 'li', text: member.name
+        end
+      end
+    end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Attendances', type: :system do
     end
 
     scenario 'member can edit attendance to absence', :js do
-      attendance = minute.attendances.create(status: :present, time: :day, member_id: member.id)
+      attendance = FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         within('#day_attendees') do
@@ -166,7 +166,7 @@ RSpec.describe 'Attendances', type: :system do
     end
 
     scenario 'member can edit absence to attendance', :js do
-      attendance = minute.attendances.create(status: :absent, absence_reason: '仕事の都合のため。', progress_report: '今週の進捗はありません。', member_id: member.id)
+      attendance = FactoryBot.create(:attendance, :absence, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         within('#absentees') do
@@ -216,7 +216,7 @@ RSpec.describe 'Attendances', type: :system do
     end
 
     scenario 'member cannot update attendance with invalid input' do
-      minute.attendances.create(status: :present, time: :day, member_id: member.id)
+      FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         within('#day_attendees') do
@@ -242,7 +242,7 @@ RSpec.describe 'Attendances', type: :system do
     end
 
     scenario 'member cannot create attendance to already finished meeting' do
-      attendance = minute.attendances.create(status: :present, time: :day, member_id: member.id)
+      attendance = FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date + 1.day do
         visit edit_attendance_path(attendance)
         expect(current_path).to eq edit_minute_path(minute)

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -240,5 +240,14 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '進捗報告を入力してください'
       end
     end
+
+    scenario 'member cannot create attendance to already finished meeting' do
+      attendance = minute.attendances.create(status: :present, time: :day, member_id: member.id)
+      travel_to minute.meeting_date + 1.day do
+        visit edit_attendance_path(attendance)
+        expect(current_path).to eq edit_minute_path(minute)
+        expect(page).to have_content '終了したミーティングの出席は変更できません'
+      end
+    end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -214,5 +214,31 @@ RSpec.describe 'Attendances', type: :system do
         end
       end
     end
+
+    scenario 'member cannot update attendance with invalid input' do
+      minute.attendances.create(status: :present, time: :day, member_id: member.id)
+      travel_to minute.meeting_date.days_ago(1) do
+        visit edit_minute_path(minute)
+        within('#day_attendees') do
+          click_link '出席編集'
+        end
+        choose '欠席'
+        fill_in '欠席理由', with: '体調不良のため。'
+        fill_in '進捗報告', with: '今週の進捗はありません。'
+        choose '出席'
+        choose '夜の部'
+        click_button '出席を更新'
+        expect(page).to have_content '欠席理由は入力しないでください'
+        expect(page).to have_content '進捗報告は入力しないでください'
+
+        choose '欠席'
+        fill_in '欠席理由', with: ''
+        fill_in '進捗報告', with: ''
+        click_button '出席を更新'
+        expect(page).to have_content '出席時間帯は入力しないでください'
+        expect(page).to have_content '欠席理由を入力してください'
+        expect(page).to have_content '進捗報告を入力してください'
+      end
+    end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -190,5 +190,29 @@ RSpec.describe 'Attendances', type: :system do
         end
       end
     end
+
+    scenario 'member treated as unexcused absentee can create attendance', :js do
+      travel_to minute.meeting_date.days_ago(1) do
+        visit edit_minute_path(minute)
+        within('#unexcused_absentees') do
+          expect(page).to have_selector 'li', text: member.name
+          expect(page).to have_selector 'a', text: '出席登録'
+          click_link '出席登録'
+        end
+        expect(current_path).to eq new_minute_attendance_path(minute)
+        choose '出席'
+        choose '昼の部'
+        click_button '出席を登録'
+
+        expect(current_path).to eq edit_minute_path(minute)
+        expect(page).to have_content '出席を登録しました'
+        within('#unexcused_absentees', visible: false) do
+          expect(page).not_to have_selector 'li', text: member.name
+        end
+        within('#day_attendees') do
+          expect(page).to have_selector 'li', text: member.name
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Issue
- #100 

## 概要
以下を確認するテストを追加した。

- 出席→欠席に変更できる
- 欠席→出席に変更できる
- 出席登録をしていないユーザー→出席に変更できる
- バリデーションエラーが発生する
- 終了しているミーティングの出席は編集できない

## Screenshot
![81993B72-5ED9-4AD5-B6B9-68EDDB5F2032](https://github.com/user-attachments/assets/88562295-d774-4576-8139-4bd09432eb5b)


