### PR TITLE
議事録一覧ページに議事録表示機能を追加した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -31,6 +31,12 @@
     .textarea {
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
+    .large_tab {
+        @apply inline-block p-4 rounded-t-lg text-gray-500 border border-gray-300 hover:text-gray-600 hover:bg-gray-50;
+    }
+    .active_large_tab {
+        @apply inline-block p-4 rounded-t-lg text-white font-bold bg-gray-600 border border-gray-300;
+    }
     .small_tab {
         @apply inline-block px-4 py-2 text-gray-600 border border-gray-600 rounded-3xl;
     }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -31,16 +31,16 @@
     .textarea {
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
-    .large_tab {
+    .large_tab_item {
         @apply inline-block p-4 rounded-t-lg text-gray-500 border border-gray-300 hover:text-gray-600 hover:bg-gray-50;
     }
-    .active_large_tab {
+    .active_large_tab_item {
         @apply inline-block p-4 rounded-t-lg text-white font-bold bg-gray-600 border border-gray-300;
     }
-    .small_tab {
+    .small_tab_item {
         @apply inline-block px-4 py-2 text-gray-600 border border-gray-600 rounded-3xl;
     }
-    .active_small_tab {
+    .active_small_tab_item {
         @apply inline-block px-4 py-2 text-white bg-gray-600 border border-gray-600 rounded-3xl;
     }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -31,4 +31,10 @@
     .textarea {
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
+    .small_tab {
+        @apply inline-block px-4 py-2 text-gray-600 border border-gray-600 rounded-3xl;
+    }
+    .active_small_tab {
+        @apply inline-block px-4 py-2 text-white bg-gray-600 border border-gray-600 rounded-3xl;
+    }
 }

--- a/app/controllers/courses/application_controller.rb
+++ b/app/controllers/courses/application_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Courses::ApplicationController < ApplicationController
+  before_action :set_course
+
+  private
+
+  def set_course
+    @course = Course.find(params[:course_id])
+  end
+end

--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Courses::MinutesController < Courses::ApplicationController
+  def index
+    @minutes = @course.minutes.order(:created_at)
+  end
+end

--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -2,7 +2,7 @@
 
 class Courses::MinutesController < Courses::ApplicationController
   def index
-    year = params[:year] ? params[:year].to_i : @course.meeting_years.last
+    year = params[:year] ? params[:year].to_i : @course.meeting_years.max
     @minutes = @course.minutes.where(meeting_date: Time.zone.local(year, 1, 1, 0, 0, 0)..Time.zone.local(year, 12, 31, 23, 59, 59)).order(:created_at)
   end
 end

--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -2,6 +2,7 @@
 
 class Courses::MinutesController < Courses::ApplicationController
   def index
-    @minutes = @course.minutes.order(:created_at)
+    year = params[:year] ? params[:year].to_i : @course.meeting_years.last
+    @minutes = @course.minutes.where(meeting_date: Time.zone.local(year, 1, 1, 0, 0, 0)..Time.zone.local(year, 12, 31, 23, 59, 59)).order(:created_at)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,6 +7,6 @@ class Course < ApplicationRecord
   has_many :members, dependent: :restrict_with_exception
 
   def meeting_years
-    minutes.map { |minute| minute.meeting_date.year }.uniq.sort
+    minutes.map { |minute| minute.meeting_date.year }.uniq
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -5,4 +5,8 @@ class Course < ApplicationRecord
 
   has_many :minutes, dependent: :restrict_with_exception
   has_many :members, dependent: :restrict_with_exception
+
+  def meeting_years
+    minutes.map { |minute| minute.meeting_date.year }.uniq.sort
+  end
 end

--- a/app/views/courses/minutes/_course_tab.html.erb
+++ b/app/views/courses/minutes/_course_tab.html.erb
@@ -2,7 +2,7 @@
   <ul class="flex flex-wrap text-sm text-center border-b border-gray-200 !list-none">
     <% Course.all.each do |course| %>
       <li class="me-2">
-        <%= link_to course.name, course_minutes_path(course), class: active_tab == course ? 'active_large_tab' : 'large_tab' %>
+        <%= link_to course.name, course_minutes_path(course), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>
       </li>
     <% end %>
   </ul>

--- a/app/views/courses/minutes/_course_tab.html.erb
+++ b/app/views/courses/minutes/_course_tab.html.erb
@@ -1,0 +1,9 @@
+<div class="mb-4">
+  <ul class="flex flex-wrap text-sm text-center border-b border-gray-200 !list-none">
+    <% Course.all.each do |course| %>
+      <li class="me-2">
+        <%= link_to course.name, course_minutes_path(course), class: active_tab == course ? 'active_large_tab' : 'large_tab' %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/courses/minutes/_course_tab.html.erb
+++ b/app/views/courses/minutes/_course_tab.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-4">
+<div class="mb-8">
   <ul class="flex flex-wrap text-sm text-center border-b border-gray-200 !list-none">
     <% Course.all.each do |course| %>
       <li class="me-2">

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="mb-4">
   <% if course.minutes.any? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
       <% course.meeting_years.sort.each do |year| %>

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -3,7 +3,7 @@
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
       <% course.meeting_years.sort.each do |year| %>
         <li class="me-2">
-          <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab' : 'small_tab' %>
+          <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab_item' : 'small_tab_item' %>
         </li>
       <% end %>
     </ul>

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -1,7 +1,7 @@
 <div>
   <% if course.minutes.any? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
-      <% course.meeting_years.each do |year| %>
+      <% course.meeting_years.sort.each do |year| %>
         <li class="me-2">
           <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab' : 'small_tab' %>
         </li>

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -1,0 +1,11 @@
+<div>
+  <% if course.minutes.any? %>
+    <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
+      <% course.meeting_years.each do |year| %>
+        <li class="me-2">
+          <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab' : 'small_tab' %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -4,6 +4,8 @@
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
 
+    <%= render partial: 'course_tab', locals: { active_tab: @course } %>
+
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
 
     <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.last %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -8,7 +8,7 @@
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
 
-    <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.last %>
+    <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>
     <%= render partial: 'years_tab', locals: { course: @course, active_tab: active_tab } %>
 
     <div>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -11,6 +11,11 @@
         <% @minutes.each do |minute| %>
           <li class="mb-4">
             <%= link_to "#{minute.title}", minute, class: "py-3 inline-block hover:underline" %>
+            <% if minute.exported? %>
+              <span class="ml-2">
+                <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow", class: 'text-sky-600 hover:underline' %>
+              </span>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -6,6 +6,9 @@
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
 
+    <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.last %>
+    <%= render partial: 'years_tab', locals: { course: @course, active_tab: active_tab } %>
+
     <div>
       <ul class="list-disc list-inside text-sky-600">
         <% @minutes.each do |minute| %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,0 +1,19 @@
+<div class="mx-auto w-full">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
+
+    <div>
+      <ul class="list-disc list-inside text-sky-600">
+        <% @minutes.each do |minute| %>
+          <li class="mb-4">
+            <%= link_to "#{minute.title}", minute, class: "py-3 inline-block hover:underline" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
     resources :exports, only: [ :create ], module: :minutes
   end
   resources :attendances, only: [ :edit, :update ]
+  resources :courses, only: [] do
+    resources :minutes, only: [:index], module: :courses
+  end
 
   namespace :api do
     resources :minutes, only: [ :update ] do

--- a/spec/factories/minutes.rb
+++ b/spec/factories/minutes.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     meeting_date { Time.zone.local(2024, 10, 2) }
     next_meeting_date { Time.zone.local(2024, 10, 16) }
     notified_at { nil }
+    exported { false }
     association :course, factory: :rails_course
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Course, type: :model do
+  describe '#meeting_years' do
+    let(:course) { FactoryBot.build(:rails_course) }
+
+    it 'returns all years which the meeting was held' do
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), course:)
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course:)
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2026, 1, 1), course:)
+      expect(course.meeting_years).to eq [2024, 2025, 2026]
+    end
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Course, type: :model do
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), course:)
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course:)
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2026, 1, 1), course:)
-      expect(course.meeting_years).to eq [2024, 2025, 2026]
+      expect(course.meeting_years).to contain_exactly(2024, 2025, 2026)
     end
   end
 end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe 'Minutes', type: :system do
   context 'when list the minutes' do
     let(:rails_course) { FactoryBot.create(:rails_course) }
     let(:front_end_course) { FactoryBot.create(:front_end_course) }
-    let(:member) { FactoryBot.create(:member) }
+    let(:member) { FactoryBot.create(:member, course: rails_course) }
 
     before do
       login_as member
@@ -230,6 +230,21 @@ RSpec.describe 'Minutes', type: :system do
       visit course_minutes_path(rails_course)
       expect(page).to have_link 'GitHub Wikiで確認', href: github_wiki_url(exported_minute)
       expect(page).not_to have_link 'GitHub Wikiで確認', href: github_wiki_url(not_exported_minute)
+    end
+
+    scenario 'can access minutes list for each course by tab' do
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 2), course: rails_course)
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 9), course: front_end_course)
+
+      visit course_minutes_path(rails_course)
+      expect(page).to have_link 'Railsエンジニアコース'
+      expect(page).to have_link 'フロントエンドエンジニアコース'
+
+      click_link 'Railsエンジニアコース'
+      expect(current_path).to eq course_minutes_path(rails_course)
+
+      click_link 'フロントエンドエンジニアコース'
+      expect(current_path).to eq course_minutes_path(front_end_course)
     end
   end
 end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -3,171 +3,233 @@
 require 'rails_helper'
 
 RSpec.describe 'Minutes', type: :system do
-  context 'when as admin' do
-    let!(:rails_course) { FactoryBot.create(:rails_course) }
-    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
-    let(:admin) { FactoryBot.create(:admin) }
+  include MinutesHelper
 
-    before do
-      login_as_admin admin
-      visit edit_minute_path(minute)
+  context 'when edit the minutes' do
+    context 'when as admin' do
+      let!(:rails_course) { FactoryBot.create(:rails_course) }
+      let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+      let(:admin) { FactoryBot.create(:admin) }
+
+      before do
+        login_as_admin admin
+        visit edit_minute_path(minute)
+      end
+
+      scenario 'can access all edit form', :js do
+        within('#release_branch_form') do
+          expect(page).to have_selector 'button', text: '編集'
+        end
+        within('#release_note_form') do
+          expect(page).to have_selector 'button', text: '編集'
+        end
+        within('#topics') do
+          expect(page).to have_selector 'button', text: '作成'
+        end
+        within('#other_form') do
+          expect(page).to have_selector 'textarea'
+          expect(page).to have_selector 'button', text: '更新'
+        end
+        within('#next_meeting_date_form') do
+          expect(page).to have_selector 'button', text: '編集'
+        end
+      end
+
+      scenario 'can edit release branch and release note', :js do
+        within('#release_branch_form') do
+          expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/1000'
+
+          click_button '編集'
+          fill_in 'release_branch_field', with: 'https://example.com/fjordllc/bootcamp/pull/9999'
+          click_button '更新'
+          expect(page).not_to have_selector 'input'
+          expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/9999'
+        end
+
+        within('#release_note_form') do
+          expect(page).to have_content 'https://example.com/announcements/100'
+
+          click_button '編集'
+          fill_in 'release_note_field', with: 'https://example.com/fjordllc/bootcamp/pull/999'
+          click_button '更新'
+          expect(page).not_to have_selector 'input'
+          expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/999'
+        end
+      end
+
+      scenario 'can create, edit and delete topic', :js do
+        within('#topics') do
+          expect(find('button', text: '作成')).to be_disabled
+          fill_in 'new_topic_field', with: '今週ミートアップがありますのでぜひご参加を！'
+          click_button '作成'
+          expect(page).to have_selector 'li', text: '今週ミートアップがありますのでぜひご参加を！(admin)'
+          expect(page).to have_selector 'button', text: '編集'
+          expect(page).to have_selector 'button', text: '削除'
+
+          click_button '編集'
+          fill_in 'edit_topic_field', with: 'Issueが完了したら必ずcloseするようにしましょう'
+          click_button '更新'
+          expect(page).to have_selector 'li', text: 'Issueが完了したら必ずcloseするようにしましょう(admin)'
+
+          click_button '削除'
+          expect(page).not_to have_selector 'li', text: 'Issueが完了したら必ずcloseするようにしましょう(admin)'
+        end
+      end
+
+      scenario 'can edit other', :js do
+        within('#other_form') do
+          expect(page).to have_selector 'textarea', text: '連絡事項は特にありません'
+          fill_in 'other_field', with: '次のリリースは午前中に行いますのでご注意ください'
+          click_button '更新'
+        end
+        expect(page).to have_content '次のリリースは午前中に行いますのでご注意ください' # 非同期で議事録の更新が行われるまで待つ
+        expect(minute.reload.other).to eq '次のリリースは午前中に行いますのでご注意ください'
+      end
+
+      scenario 'can edit next meeting date', :js do
+        within('#next_meeting_date_form') do
+          expect(page).to have_content '2024年10月16日'
+
+          click_button '編集'
+          # 日付編集フォームの実装はflowbite-reactのDatepickerを使っているが、このコンポーネントは<input type="text">を返すようになっている
+          # 以下の手順で日付編集フォームを操作することができたので、一旦以下の方法でテストを実装する
+          # fill_in で日付編集フォームの日付選択欄を開く
+          # click_buttonで日付を選択する
+          fill_in 'next_meeting_date_field', with: Date.new(2024, 10, 23)
+          click_button '23日'
+          click_button '更新'
+          expect(page).not_to have_selector 'input'
+          expect(page).to have_content '2024年10月23日'
+        end
+      end
     end
 
-    scenario 'can access all edit form', :js do
-      within('#release_branch_form') do
-        expect(page).to have_selector 'button', text: '編集'
-      end
-      within('#release_note_form') do
-        expect(page).to have_selector 'button', text: '編集'
-      end
-      within('#topics') do
-        expect(page).to have_selector 'button', text: '作成'
-      end
-      within('#other_form') do
-        expect(page).to have_selector 'textarea'
-        expect(page).to have_selector 'button', text: '更新'
-      end
-      within('#next_meeting_date_form') do
-        expect(page).to have_selector 'button', text: '編集'
-      end
-    end
+    context 'when as member' do
+      let!(:rails_course) { FactoryBot.create(:rails_course) }
+      let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+      let(:member) { FactoryBot.create(:member, course: rails_course) }
 
-    scenario 'can edit release branch and release note', :js do
-      within('#release_branch_form') do
-        expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/1000'
-
-        click_button '編集'
-        fill_in 'release_branch_field', with: 'https://example.com/fjordllc/bootcamp/pull/9999'
-        click_button '更新'
-        expect(page).not_to have_selector 'input'
-        expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/9999'
+      before do
+        login_as member
       end
 
-      within('#release_note_form') do
-        expect(page).to have_content 'https://example.com/announcements/100'
-
-        click_button '編集'
-        fill_in 'release_note_field', with: 'https://example.com/fjordllc/bootcamp/pull/999'
-        click_button '更新'
-        expect(page).not_to have_selector 'input'
-        expect(page).to have_content 'https://example.com/fjordllc/bootcamp/pull/999'
+      scenario 'can access only topic edit form', :js do
+        visit edit_minute_path(minute)
+        within('#release_branch_form') do
+          expect(page).not_to have_selector 'button', text: '編集'
+        end
+        within('#release_note_form') do
+          expect(page).not_to have_selector 'button', text: '編集'
+        end
+        within('#topics') do
+          expect(page).to have_selector 'button', text: '作成'
+        end
+        within('#other_form') do
+          expect(page).not_to have_selector 'textarea'
+          expect(page).not_to have_selector 'button', text: '更新'
+        end
+        within('#next_meeting_date_form') do
+          expect(page).not_to have_selector 'button', text: '編集'
+        end
       end
     end
 
-    scenario 'can create, edit and delete topic', :js do
-      within('#topics') do
-        expect(find('button', text: '作成')).to be_disabled
-        fill_in 'new_topic_field', with: '今週ミートアップがありますのでぜひご参加を！'
-        click_button '作成'
-        expect(page).to have_selector 'li', text: '今週ミートアップがありますのでぜひご参加を！(admin)'
-        expect(page).to have_selector 'button', text: '編集'
-        expect(page).to have_selector 'button', text: '削除'
+    context 'when topic form' do
+      let!(:rails_course) { FactoryBot.create(:rails_course) }
+      let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+      let(:member) { FactoryBot.create(:member, course: rails_course) }
+      let(:another_member) { FactoryBot.create(:member, :another_member, course: rails_course) }
 
-        click_button '編集'
-        fill_in 'edit_topic_field', with: 'Issueが完了したら必ずcloseするようにしましょう'
-        click_button '更新'
-        expect(page).to have_selector 'li', text: 'Issueが完了したら必ずcloseするようにしましょう(admin)'
+      before do
+        login_as another_member
+      end
 
-        click_button '削除'
-        expect(page).not_to have_selector 'li', text: 'Issueが完了したら必ずcloseするようにしましょう(admin)'
+      scenario 'cannot edit and destroy topic created by others', :js do
+        minute.topics.create(content: 'テストが通らないのでどなたかペアプロをお願いします！', topicable: member)
+
+        visit edit_minute_path(minute)
+        within('#topics') do
+          expect(page).to have_selector 'li', text: 'テストが通らないのでどなたかペアプロをお願いします！(alice)'
+          expect(page).not_to have_selector 'button', text: '編集'
+          expect(page).not_to have_selector 'button', text: '削除'
+        end
       end
     end
 
-    scenario 'can edit other', :js do
-      within('#other_form') do
-        expect(page).to have_selector 'textarea', text: '連絡事項は特にありません'
-        fill_in 'other_field', with: '次のリリースは午前中に行いますのでご注意ください'
-        click_button '更新'
+    context 'when next meeting date form' do
+      let!(:rails_course) { FactoryBot.create(:rails_course) }
+      let(:minute) { FactoryBot.create(:minute, next_meeting_date: Time.zone.local(2024, 10, 14), course: rails_course) }
+      let(:member) { FactoryBot.create(:member, course: rails_course) }
+
+      before do
+        login_as member
+        visit edit_minute_path(minute)
       end
-      expect(page).to have_content '次のリリースは午前中に行いますのでご注意ください' # 非同期で議事録の更新が行われるまで待つ
-      expect(minute.reload.other).to eq '次のリリースは午前中に行いますのでご注意ください'
-    end
 
-    scenario 'can edit next meeting date', :js do
-      within('#next_meeting_date_form') do
-        expect(page).to have_content '2024年10月16日'
-
-        click_button '編集'
-        # 日付編集フォームの実装はflowbite-reactのDatepickerを使っているが、このコンポーネントは<input type="text">を返すようになっている
-        # 以下の手順で日付編集フォームを操作することができたので、一旦以下の方法でテストを実装する
-        # fill_in で日付編集フォームの日付選択欄を開く
-        # click_buttonで日付を選択する
-        fill_in 'next_meeting_date_field', with: Date.new(2024, 10, 23)
-        click_button '23日'
-        click_button '更新'
-        expect(page).not_to have_selector 'input'
-        expect(page).to have_content '2024年10月23日'
+      scenario 'display message when next meeting is holiday' do
+        within('#next_meeting_date_form') do
+          expect(page).to have_content '2024年10月14日'
+          expect(page).to have_content '次回開催日はスポーツの日です。もしミーティングをお休みにする場合は、開催日を変更しましょう。'
+        end
       end
     end
   end
 
-  context 'when as member' do
-    let!(:rails_course) { FactoryBot.create(:rails_course) }
-    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
-    let(:member) { FactoryBot.create(:member, course: rails_course) }
+  context 'when list the minutes' do
+    let(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:front_end_course) { FactoryBot.create(:front_end_course) }
+    let(:member) { FactoryBot.create(:member) }
 
     before do
       login_as member
     end
 
-    scenario 'can access only topic edit form', :js do
-      visit edit_minute_path(minute)
-      within('#release_branch_form') do
-        expect(page).not_to have_selector 'button', text: '編集'
-      end
-      within('#release_note_form') do
-        expect(page).not_to have_selector 'button', text: '編集'
-      end
-      within('#topics') do
-        expect(page).to have_selector 'button', text: '作成'
-      end
-      within('#other_form') do
-        expect(page).not_to have_selector 'textarea'
-        expect(page).not_to have_selector 'button', text: '更新'
-      end
-      within('#next_meeting_date_form') do
-        expect(page).not_to have_selector 'button', text: '編集'
-      end
-    end
-  end
+    scenario 'display minutes by course' do
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 2), course: rails_course)
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 9), course: front_end_course)
 
-  context 'when topic form' do
-    let!(:rails_course) { FactoryBot.create(:rails_course) }
-    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
-    let(:member) { FactoryBot.create(:member, course: rails_course) }
-    let(:another_member) { FactoryBot.create(:member, :another_member, course: rails_course) }
+      visit course_minutes_path(rails_course)
+      expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月02日'
+      expect(page).not_to have_link 'ふりかえり・計画ミーティング2024年10月09日'
 
-    before do
-      login_as another_member
+      visit course_minutes_path(front_end_course)
+      expect(page).not_to have_link 'ふりかえり・計画ミーティング2024年10月02日'
+      expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月09日'
     end
 
-    scenario 'cannot edit and destroy topic created by others', :js do
-      minute.topics.create(content: 'テストが通らないのでどなたかペアプロをお願いします！', topicable: member)
+    scenario 'display minutes by year' do
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), course: rails_course)
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
 
-      visit edit_minute_path(minute)
-      within('#topics') do
-        expect(page).to have_selector 'li', text: 'テストが通らないのでどなたかペアプロをお願いします！(alice)'
-        expect(page).not_to have_selector 'button', text: '編集'
-        expect(page).not_to have_selector 'button', text: '削除'
-      end
-    end
-  end
+      visit course_minutes_path(rails_course)
+      expect(page).to have_link '2024年'
+      expect(page).to have_link '2025年'
 
-  context 'when next meeting date form' do
-    let!(:rails_course) { FactoryBot.create(:rails_course) }
-    let(:minute) { FactoryBot.create(:minute, next_meeting_date: Time.zone.local(2024, 10, 14), course: rails_course) }
-    let(:member) { FactoryBot.create(:member, course: rails_course) }
+      click_link '2024年'
+      expect(page).to have_link 'ふりかえり・計画ミーティング2024年01月01日'
+      expect(page).not_to have_link 'ふりかえり・計画ミーティング2025年01月01日'
 
-    before do
-      login_as member
-      visit edit_minute_path(minute)
+      click_link '2025年'
+      expect(page).not_to have_link 'ふりかえり・計画ミーティング2024年01月01日'
+      expect(page).to have_link 'ふりかえり・計画ミーティング2025年01月01日'
     end
 
-    scenario 'display message when next meeting is holiday' do
-      within('#next_meeting_date_form') do
-        expect(page).to have_content '2024年10月14日'
-        expect(page).to have_content '次回開催日はスポーツの日です。もしミーティングをお休みにする場合は、開催日を変更しましょう。'
-      end
+    scenario 'display latest year minutes when year is not specified' do
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), course: rails_course)
+      FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
+
+      visit course_minutes_path(rails_course)
+      expect(page).not_to have_link 'ふりかえり・計画ミーティング2024年01月01日'
+      expect(page).to have_link 'ふりかえり・計画ミーティング2025年01月01日'
+    end
+
+    scenario 'display github wiki link when the minute is exported' do
+      exported_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), exported: true, course: rails_course)
+      not_exported_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 15), course: rails_course)
+
+      visit course_minutes_path(rails_course)
+      expect(page).to have_link 'GitHub Wikiで確認', href: github_wiki_url(exported_minute)
+      expect(page).not_to have_link 'GitHub Wikiで確認', href: github_wiki_url(not_exported_minute)
     end
   end
 end


### PR DESCRIPTION
## Issue
- #104 

## 概要
議事録一覧ページに以下の機能を追加した。

- コースに紐づいた議事録一覧が表示される
- コースのタブがあり、コースごとに表示を切り替えられる
- 年度のタブがあり、議事録を年度ごとに表示できる

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/7b7bfa95a1b4606c2608865bb96ab464.gif)](https://gyazo.com/7b7bfa95a1b4606c2608865bb96ab464)


