### PR TITLE
議事録をエクスポート時のリダイレクト先を修正

### DIFF
--- a/app/controllers/minutes/exports_controller.rb
+++ b/app/controllers/minutes/exports_controller.rb
@@ -6,6 +6,6 @@ class Minutes::ExportsController < Minutes::ApplicationController
   def create
     GithubWikiManager.export_minute(@minute)
     @minute.update!(exported: true) unless @minute.exported?
-    redirect_to minutes_path, notice: 'GitHub Wikiに議事録を反映させました'
+    redirect_to course_minutes_path(@minute.course), notice: 'GitHub Wikiに議事録を反映させました'
   end
 end


### PR DESCRIPTION
## Issue
#104 

## 概要
議事録一覧機能の実装に伴い、議事録一覧表示がコースに紐づくようになったため、議事録をエクスポートした際のリダイレクトするパスを`course/:course_id/minutes`となるように修正した。
