### PR TITLE
議事録詳細ページのテストを追加した

### DIFF
--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -6,7 +6,7 @@ import OtherForm from './components/OtherForm.jsx'
 import NextMeetingDateForm from './components/NextMeetingDateForm.jsx'
 import AbsenteesList from './components/AbsenteesList.jsx'
 import UnexcusedAbsenteesList from './components/UnexcusedAbsenteesList.jsx'
-import MarkdownPreview from './components/MarkdownPreview.jsx'
+import MinutePreview from './components/MinutePreview.jsx'
 import './toggleAttendanceForm'
 
 import 'flowbite'
@@ -19,4 +19,4 @@ mountComponent('other_form', OtherForm)
 mountComponent('next_meeting_date_form', NextMeetingDateForm)
 mountComponent('absentees_list', AbsenteesList)
 mountComponent('unexcused_absentees_list', UnexcusedAbsenteesList)
-mountComponent('markdown_preview', MarkdownPreview)
+mountComponent('minute_preview', MinutePreview)

--- a/app/javascript/components/MarkdownPreview.jsx
+++ b/app/javascript/components/MarkdownPreview.jsx
@@ -10,10 +10,10 @@ export default function MarkdownPreview({ markdown }) {
 
   return (
     <Tabs aria-label="Default tabs" variant="default" theme={customTheme}>
-      <Tabs.Item active title="Raw">
+      <Tabs.Item active title="Markdown">
         <pre className="p-4 border">{markdown}</pre>
       </Tabs.Item>
-      <Tabs.Item title="Markdown">
+      <Tabs.Item title="Preview">
         <div
           className="p-4 border markdown-body"
           dangerouslySetInnerHTML={sanitizedHTML}

--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -11,10 +11,13 @@ export default function MinutePreview({ markdown }) {
   return (
     <Tabs aria-label="Default tabs" variant="default" theme={customTheme}>
       <Tabs.Item active title="Markdown">
-        <pre className="p-4 border">{markdown}</pre>
+        <pre id="raw_markdown" className="p-4 border">
+          {markdown}
+        </pre>
       </Tabs.Item>
       <Tabs.Item title="Preview">
         <div
+          id="markdown_preview"
           className="p-4 border markdown-body"
           dangerouslySetInnerHTML={sanitizedHTML}
         />

--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -3,7 +3,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 
-export default function MarkdownPreview({ markdown }) {
+export default function MinutePreview({ markdown }) {
   const sanitizedHTML = {
     __html: DOMPurify.sanitize(marked.parse(markdown, [{ gfm: true }])),
   }
@@ -41,6 +41,6 @@ const customTheme = {
   },
 }
 
-MarkdownPreview.propTypes = {
+MinutePreview.propTypes = {
   markdown: PropTypes.string,
 }

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -6,7 +6,7 @@
 
     <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>
 
-    <%= content_tag :div, id: 'markdown_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
+    <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 
     <% if current_development_member.admin? %>
       <%= button_to 'GitHub Wiki にエクスポート', minute_exports_path(@minute), form: { class: 'text-center' },  class: 'button m-auto' %>

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -15,5 +15,17 @@ FactoryBot.define do
       uid { 222_222 }
       name { 'bob' }
     end
+
+    trait :absent_member do
+      email { 'absentee@example.com' }
+      uid { 333_333 }
+      name { 'absentee' }
+    end
+
+    trait :unexcused_absent_member do
+      email { 'unexcused_absentee@example.com' }
+      uid { 444_444 }
+      name { 'unexcused_absentee' }
+    end
   end
 end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :topic do
+    trait :by_admin do
+      content { '来週ミートアップがありますので、ぜひご参加を！' }
+      association :minute, factory: :minute
+      association :topicable, factory: :admin
+    end
+
+    trait :by_member do
+      content { 'gitのブランチ履歴がおかしくなってしまったので、どなたかペアプロをお願いしたいです' }
+      association :minute, factory: :minute
+      association :topicable, factory: :admin
+    end
+  end
+end

--- a/spec/models/markdown_builder_spec.rb
+++ b/spec/models/markdown_builder_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MarkdownBuilder, type: :model do
+  let(:rails_course) { FactoryBot.create(:rails_course) }
+  let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+  let(:alice) { FactoryBot.create(:member, course: rails_course) }
+  let(:bob) { FactoryBot.create(:member, :another_member, course: rails_course) }
+  let(:absentee) { FactoryBot.create(:member, :absent_member, course: rails_course) }
+
+  it 'returns markdown of minute' do
+    FactoryBot.create(:attendance, member: alice, minute:)
+    FactoryBot.create(:attendance, :night, member: bob, minute:)
+    FactoryBot.create(:attendance, :absence, member: absentee, minute:)
+    FactoryBot.create(:topic, :by_member, minute:, topicable: alice)
+
+    expected = <<~MARKDOWN
+      # ふりかえり
+
+      ## メンバー
+
+      - プログラマー
+        - 昼
+          - alice
+        - 夜
+          - bob
+      - プロダクトオーナー
+        - [@machida](https://github.com/machida)
+      - スクラムマスター
+        - [@komagata](https://github.com/komagata)
+
+      ## デモ
+
+      今回のイテレーションで実装した機能をプロダクトオーナーに向けてデモします。（画面共有使用）
+      「お客様」相手にデモをするという設定なので、MTG前に事前に準備をしておくといいかもしれません。
+      テストデータなどは事前に準備しておいてください。
+
+      ## 今週のリリースの確認
+
+      木曜日の15時頃リリースします
+
+      - リリースブランチ
+        - https://example.com/fjordllc/bootcamp/pull/1000
+      - リリースノート
+        - https://example.com/announcements/100
+
+      ## 話題にしたいこと・心配事
+
+      明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。
+
+      - gitのブランチ履歴がおかしくなってしまったので、どなたかペアプロをお願いしたいです(alice)
+
+      ## その他
+
+      連絡事項は特にありません
+
+      # 次回のMTG
+
+      - 2024年10月16日(水)
+        - 昼の部：15:00-16:00
+        - 夜の部：22:00-23:00
+
+      # 計画ミーティング
+
+      - プランニングポーカー
+
+      # 欠席者
+
+      - absentee
+        - 欠席理由 : 体調不良のため。
+        - 進捗報告 : PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。
+    MARKDOWN
+    expect(described_class.build(minute)).to eq expected
+  end
+
+  it 'warning text is added when next meeting date is holiday' do
+    minute.update!(next_meeting_date: Time.zone.local(2024, 11, 3))
+    warning_text = <<~TEXT
+      - 2024年11月03日(日)
+        - 次回開催日は文化の日です。もしミーティングをお休みにする場合は、開催日を変更しましょう。
+    TEXT
+    expect(described_class.build(minute)).to include(warning_text)
+  end
+
+  it 'does not include unexcused absentee' do
+    FactoryBot.create(:member, :unexcused_absent_member, course: rails_course)
+    expect(described_class.build(minute)).not_to include('- unexcused_absentee')
+  end
+end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -247,4 +247,36 @@ RSpec.describe 'Minutes', type: :system do
       expect(current_path).to eq course_minutes_path(front_end_course)
     end
   end
+
+  context 'when show the minute' do
+    let(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:member) { FactoryBot.create(:member, course: rails_course) }
+    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+
+    before do
+      login_as member
+    end
+
+    scenario 'show markdown and preview of the minute', :js do
+      visit minute_path(minute)
+      expect(page).to have_button 'Markdown'
+      expect(page).to have_button 'Preview'
+
+      click_button 'Markdown'
+      expect(page).to have_selector 'pre#raw_markdown'
+      expect(page).not_to have_selector 'div#markdown_preview'
+      within('#raw_markdown') do
+        expect(page).to have_content '# ふりかえり'
+        expect(page).not_to have_selector 'h1', text: 'ふりかえり'
+      end
+
+      click_button 'Preview'
+      expect(page).not_to have_selector 'pre#raw_markdown'
+      expect(page).to have_selector 'div#markdown_preview'
+      within('#markdown_preview') do
+        expect(page).not_to have_content '# ふりかえり'
+        expect(page).to have_selector 'h1', text: 'ふりかえり'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #105 

## 概要
議事録詳細ページに関連して、以下のテストを追加した。
- `MarkdownBuilder`が議事録のMarkdownを作成できる
- 議事録詳細ページで、議事録のMarkdownとプレビューをそれぞれ表示できる
- GitHub Wikiにエクスポートできる
  - 実際にpushされてしまうとテスト実行ごとにpushされてしまい困るため、push処理は実行されないようにしている

また、Markdownとプレビューを切り替えるタブの文言が不自然だったので修正している。

## screenshot
タブの文言(修正前)。
![B3E526B3-CC38-4D3B-8901-A6A83EAAE4CA_4_5005_c](https://github.com/user-attachments/assets/81df4f75-f02b-43c0-9933-3d2dfc111cfb)

タブの文言(修正後)。
![1F765658-B58C-4FD0-B459-2D6AECDCC385_4_5005_c](https://github.com/user-attachments/assets/f445fe5f-367d-4814-b1f5-aa5cf1e31b6f)

