### PR TITLE
メンバーが休止できるようにした

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -14,6 +14,7 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
     if @member_or_admin.persisted?
       sign_in_and_redirect @member_or_admin
       remember_me @member_or_admin
+      @member_or_admin.hibernations.last.update!(finished_at: Time.zone.today) if @member_or_admin.is_a?(Member) && @member_or_admin.hibernated?
       set_flash_message(:notice, :success, kind: 'GitHub') if is_navigational_format?
     else
       session['devise.github_data'] = request.env['omniauth.auth'].except(:extra)

--- a/app/controllers/members/sessions_controller.rb
+++ b/app/controllers/members/sessions_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Members::SessionsController < Devise::SessionsController
+end

--- a/app/controllers/members/sessions_controller.rb
+++ b/app/controllers/members/sessions_controller.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
 class Members::SessionsController < Devise::SessionsController
+  # Devise::SessionsController#destroyを元に作成
+  def destroy
+    member = current_member
+    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    if signed_out
+      set_flash_message! :notice, :signed_out
+      member.hibernations.create!
+    end
+    respond_to_on_destroy
+  end
 end

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -1,3 +1,7 @@
+import { Turbo } from '@hotwired/turbo-rails'
+
+Turbo.session.drive = false
+
 import mountComponent from './mountComponent.jsx'
 import AttendeesList from './components/AttendeesList.jsx'
 import ReleaseInformationForm from './components/ReleaseInformationForm.jsx'

--- a/app/models/hibernation.rb
+++ b/app/models/hibernation.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Hibernation < ApplicationRecord
+  belongs_to :member
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -24,4 +24,8 @@ class Member < ApplicationRecord
   def admin?
     false
   end
+
+  def hibernated?
+    hibernations.where(finished_at: nil).any?
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -9,6 +9,7 @@ class Member < ApplicationRecord
   belongs_to :course
   has_many :attendances, dependent: :destroy
   has_many :topics, as: :topicable, dependent: :destroy
+  has_many :hibernations, dependent: :destroy
 
   def self.from_omniauth(auth, params)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,7 @@
 <div>
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
   <% if alert.present? %>
     <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
   <% end %>

--- a/app/views/home/member_dashboard.html.erb
+++ b/app/views/home/member_dashboard.html.erb
@@ -13,5 +13,12 @@
     <% end %>
 
     <p>所属コース : <%= current_member.course.name %></p>
+
+    <div class="mt-4 text-center">
+      <%= link_to 'チーム開発を抜ける', logout_path, class: "text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm p-4 focus:outline-none",
+                                                  data: { turbo: true,
+                                                          turbo_method: :delete,
+                                                          turbo_confirm: "どちらかのケースに当てはまる場合に、チーム開発を抜けてください。\n\n・チーム開発を修了した\n・フィヨルドブートキャンプを休会したことに伴って、チーム開発をお休みする" } %>
+    </div>
   </div>
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,144 @@
+ja:
+  activerecord:
+    attributes:
+      member:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      member: メンバー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+      success_with_hibernation: "休止から復帰しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   devise_for :admins, skip: :all
   devise_scope :member do
     get "/auth/:provider/callback" => "authentications#create"
+    delete "logout", to: "members/sessions#destroy", as: "logout"
   end
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20241103220952_create_hibernations.rb
+++ b/db/migrate/20241103220952_create_hibernations.rb
@@ -1,0 +1,10 @@
+class CreateHibernations < ActiveRecord::Migration[7.2]
+  def change
+    create_table :hibernations do |t|
+      t.date :finished_at
+      t.references :member, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_28_232014) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_03_220952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_28_232014) do
     t.integer "meeting_week"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "hibernations", force: :cascade do |t|
+    t.date "finished_at"
+    t.bigint "member_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["member_id"], name: "index_hibernations_on_member_id"
   end
 
   create_table "members", force: :cascade do |t|
@@ -91,6 +99,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_28_232014) do
 
   add_foreign_key "attendances", "members"
   add_foreign_key "attendances", "minutes"
+  add_foreign_key "hibernations", "members"
   add_foreign_key "members", "courses"
   add_foreign_key "minutes", "courses"
   add_foreign_key "topics", "minutes"

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Member, type: :model do
+  let(:member) { FactoryBot.create(:member) }
+
+  describe '#hibernated?' do
+    it 'returns true when member is not returned from hibernation' do
+      member.hibernations.create(finished_at: nil)
+      expect(member.hibernated?).to be true
+    end
+
+    it 'returns false when member does not hibernate' do
+      expect(member.hibernated?).to be false
+    end
+
+    it 'returns false when member is returned from hibernation' do
+      member.hibernations.create(finished_at: Time.zone.today)
+      expect(member.hibernated?).to be false
+    end
+  end
+end

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Hibernations', type: :system do
+  let(:rails_course) { FactoryBot.create(:rails_course) }
+  let(:member) { FactoryBot.create(:member, course: rails_course) }
+
+  before do
+    login_as member
+  end
+
+  scenario 'member can hibernate and return from hibernation', :js do
+    visit root_path
+    expect(page).to have_link 'チーム開発を抜ける'
+    expect(member.hibernated?).to be false
+
+    page.accept_confirm do
+      click_link 'チーム開発を抜ける'
+    end
+    expect(current_path).to eq root_path
+    expect(page).to have_content 'ログアウトしました'
+    expect(member.reload.hibernated?).to be true
+
+    click_button 'Railsエンジニアコースでログイン'
+    expect(page).to have_content '休止から復帰しました。'
+    expect(member.reload.hibernated?).to be false
+  end
+end


### PR DESCRIPTION
## Issue
- #137 

## 概要
メンバーのトップページにログアウト用のリンクを追加し、ログアウトすると休止状態になるようにした。
休止状態のメンバーは、再度ログインを行うと休止状態から復帰することが可能。

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/94f8e35f8b4324c4c88fa54b89db14f6.gif)](https://gyazo.com/94f8e35f8b4324c4c88fa54b89db14f6)



