### PR TITLE
休止中のユーザーは、議事録編集ページに表示しないようにした

### DIFF
--- a/app/controllers/api/minutes/attendances_controller.rb
+++ b/app/controllers/api/minutes/attendances_controller.rb
@@ -3,7 +3,6 @@
 class API::Minutes::AttendancesController < API::Minutes::ApplicationController
   def index
     @attendances = @minute.attendances.includes(:member).order(:member_id)
-    # 休止機能を実装した際、無断欠席者から休止者は除外するようにする
-    @unexcused_absentees = Member.where(course_id: @minute.course_id).where.not(id: @attendances.pluck(:member_id)).order(:id)
+    @unexcused_absentees = Member.active.where(course_id: @minute.course_id).where.not(id: @attendances.pluck(:member_id)).order(:id)
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -11,6 +11,9 @@ class Member < ApplicationRecord
   has_many :topics, as: :topicable, dependent: :destroy
   has_many :hibernations, dependent: :destroy
 
+  scope :active, -> { where.not(id: hibernated.pluck(:id)) }
+  scope :hibernated, -> { joins(:hibernations).where(hibernations: { finished_at: nil }) }
+
   def self.from_omniauth(auth, params)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|
       member.email = auth.info.email

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -78,6 +78,32 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
+    scenario 'hibernated member is not displayed as present, absent or unexcused absent', :js do
+      member.hibernations.create!
+      expect(member.hibernated?).to be true
+
+      visit edit_minute_path(minute)
+      within('#day_attendees') do
+        expect(page).not_to have_selector 'li', text: member.name
+      end
+      within('#night_attendees') do
+        expect(page).not_to have_selector 'li', text: member.name
+      end
+      within('#absentees', visible: false) do
+        expect(page).not_to have_selector 'li', text: member.name
+      end
+      within('#unexcused_absentees', visible: false) do
+        expect(page).not_to have_selector 'li', text: member.name
+      end
+
+      member.hibernations.last.update!(finished_at: Time.zone.today)
+      expect(member.hibernated?).to be false
+      visit edit_minute_path(minute)
+      within('#unexcused_absentees') do
+        expect(page).to have_selector 'li', text: member.name
+      end
+    end
+
     scenario 'member cannot create attendance twice' do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)


### PR DESCRIPTION
## Issue
- #138 

## 概要
議事録に出席登録をしていないメンバーは`連絡なし`として表示されるが、休止中のメンバーは`連絡なし`として表示されないようにした。


