### PR TITLE
管理者が出席登録ページにアクセスすると、リダイレクトするようにした

### DIFF
--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Minutes::AttendancesController < Minutes::ApplicationController
+  before_action :redirect_admin_access, only: %i[new create]
+
   def new
     redirect_to edit_minute_url(@minute), alert: 'すでに出席を登録済みです' if already_registered_attendance
     redirect_to edit_minute_url(@minute), alert: '終了したミーティングには出席できません' if @minute.already_finished?
@@ -30,5 +32,9 @@ class Minutes::AttendancesController < Minutes::ApplicationController
 
   def already_registered_attendance
     @minute.attendances.where(member_id: current_member.id).any?
+  end
+
+  def redirect_admin_access
+    redirect_to edit_minute_url(@minute) if admin_signed_in?
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -276,4 +276,19 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
   end
+
+  context 'when admin' do
+    let!(:rails_course) { FactoryBot.create(:rails_course) }
+    let(:admin) { FactoryBot.create(:admin) }
+    let(:minute) { FactoryBot.create(:minute, course: rails_course) }
+
+    before do
+      login_as_admin admin
+    end
+
+    scenario 'admin cannot access create attendance page' do
+      visit new_minute_attendance_path(minute)
+      expect(current_path).to eq edit_minute_path(minute)
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #151 

## 概要
管理者が出席登録ページにアクセスすると、議事録編集ページに遷移するように変更した。
また、`Minutes::AttendancesController`の中で不正なアクセスな場合はリダイレクトを行うようにしていたが、リダイレクト処理の後`return`をしていなかったので続くコントローラーの処理も実行されるようになっていた。
(参考 : https://qiita.com/jerrywdlee/items/2b2ea9c7275ea3b6d572)

これを解決するため、`before_action`を使ってリダイレクト処理を記述し直している。
> 「before系」アクションコールバックによってビューのレンダリングやリダイレクトが行われると、コントローラのこのアクションは実行されなくなります。

https://railsguides.jp/action_controller_overview.html#%E3%82%A2%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%B3%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF

## Screenshot
[![Image from Gyazo](https://i.gyazo.com/b9b5389def16c73ac8d3a8f0b6c5f83a.gif)](https://gyazo.com/b9b5389def16c73ac8d3a8f0b6c5f83a)

