### PR TITLE
textareaで発生していたエラーを修正

### DIFF
--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -27,7 +27,7 @@ export default function OtherForm({ minuteId, content, isAdmin }) {
 }
 
 function EditForm({ minuteId, content }) {
-  const [inputValue, setInputValue] = useState(content)
+  const [inputValue, setInputValue] = useState(content ?? '')
 
   const handleChange = function (e) {
     setInputValue(e.target.value)


### PR DESCRIPTION
## Issue
- #152 

## 概要
議事録編集ページの「その他」を編集するテキストエリアで、次のエラーが発生していた。

```
Warning: `value` prop on `textarea` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components. Error Component Stack
```

警告に従い、React側でtextareaの`value`propがnullである場合、空文字列をセットするように修正した。

## screenshot
「その他」に何も入力されていなくても、エラーが発生していない。
![F478F071-142C-43C0-8B76-FD75DADDDFD3](https://github.com/user-attachments/assets/87ef6b45-1d86-46b8-9454-09ad767c8f2c)
