### PR TITLE
メンバー一覧ページを追加

### DIFF
--- a/app/controllers/courses/members_controller.rb
+++ b/app/controllers/courses/members_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Courses::MembersController < Courses::ApplicationController
+  def index
+    @members = Member.active.where(course: @course).order(:created_at)
+  end
+end

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -3,6 +3,7 @@ import { Turbo } from '@hotwired/turbo-rails'
 Turbo.session.drive = false
 
 import mountComponent from './mountComponent.jsx'
+import mountMultipleComponents from './mountMultipleComponents.jsx'
 import AttendeesList from './components/AttendeesList.jsx'
 import ReleaseInformationForm from './components/ReleaseInformationForm.jsx'
 import TopicList from './components/TopicList.jsx'
@@ -12,6 +13,7 @@ import AbsenteesList from './components/AbsenteesList.jsx'
 import UnexcusedAbsenteesList from './components/UnexcusedAbsenteesList.jsx'
 import MinutePreview from './components/MinutePreview.jsx'
 import AllAttendanceTable from './components/AllAttendanceTable.jsx'
+import AttendanceTable from './components/AttendanceTable.jsx'
 import './toggleAttendanceForm'
 
 import 'flowbite'
@@ -26,3 +28,5 @@ mountComponent('absentees_list', AbsenteesList)
 mountComponent('unexcused_absentees_list', UnexcusedAbsenteesList)
 mountComponent('minute_preview', MinutePreview)
 mountComponent('all_attendance_table', AllAttendanceTable)
+
+mountMultipleComponents('recent_attendances', AttendanceTable)

--- a/app/javascript/components/AllAttendanceTable.jsx
+++ b/app/javascript/components/AllAttendanceTable.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import { Table, Tooltip } from 'flowbite-react'
+import AttendanceTable from './AttendanceTable.jsx'
 
 export default function AllAttendanceTable({ attendances }) {
   const attendancesPerYear = separateAttendancesByYear(attendances)
@@ -35,56 +35,6 @@ export default function AllAttendanceTable({ attendances }) {
   )
 }
 
-function AttendanceTable({ attendances }) {
-  return (
-    <div className="overflow-x-auto mb-2">
-      <Table theme={customTableTheme}>
-        <Table.Head>
-          {attendances.map((attendance) => (
-            <Table.HeadCell key={attendance.minute_id}>
-              <span data-table-head={attendance.date}>
-                {formatDate(attendance.date)}
-              </span>
-            </Table.HeadCell>
-          ))}
-        </Table.Head>
-        <Table.Body className="divide-y">
-          <Table.Row>
-            {attendances.map((attendance) => (
-              <Table.Cell key={attendance.minute_id}>
-                <AttendanceTableData
-                  date={attendance.date}
-                  status={attendance.status}
-                  time={attendance.time}
-                  absence_reason={attendance.absence_reason}
-                />
-              </Table.Cell>
-            ))}
-          </Table.Row>
-        </Table.Body>
-      </Table>
-    </div>
-  )
-}
-
-function AttendanceTableData({ date, status, time, absence_reason }) {
-  if (status === 'present') {
-    return (
-      <span data-table-data={date}>{{ day: '昼', night: '夜' }[time]}</span>
-    )
-  } else if (status === 'absent') {
-    return (
-      <Tooltip content={absence_reason} theme={customTooltipTheme}>
-        <span data-table-data={date}>欠席</span>
-      </Tooltip>
-    )
-  } else if (status === 'hibernation') {
-    return <span data-table-data={date}>休止</span>
-  } else {
-    return <span data-table-data={date}>---</span>
-  }
-}
-
 function separateAttendancesByYear(attendances) {
   return attendances.reduce((attendancesPerYear, attendance) => {
     const year = attendance.date.slice(0, 4)
@@ -100,47 +50,6 @@ function separateAttendancesByYear(attendances) {
   }, [])
 }
 
-function formatDate(date) {
-  const matched_date = date.match(/\d{4}-(\d{2})-(\d{2})/)
-  return `${matched_date[1]}/${matched_date[2]}`
-}
-
-const customTableTheme = {
-  root: {
-    base: 'text-left text-sm',
-    shadow:
-      'absolute left-0 top-0 -z-10 h-full w-full rounded-lg bg-white drop-shadow-md',
-    wrapper: 'relative',
-  },
-  body: {
-    base: 'group/body',
-    cell: {
-      base: 'px-2 py-2 border border-gray-400 w-16 h-10 text-center',
-    },
-  },
-  head: {
-    base: 'group/head text-xs uppercase text-gray-700',
-    cell: {
-      base: 'bg-gray-200 px-2 py-2 border border-gray-400 w-16 h-10 text-center',
-    },
-  },
-}
-
-const customTooltipTheme = {
-  target: '', // デフォルトで設定されているw-fitを削除
-}
-
 AllAttendanceTable.propTypes = {
   attendances: PropTypes.array,
-}
-
-AttendanceTable.propTypes = {
-  attendances: PropTypes.array,
-}
-
-AttendanceTableData.propTypes = {
-  date: PropTypes.string,
-  status: PropTypes.string,
-  time: PropTypes.string,
-  absence_reason: PropTypes.string,
 }

--- a/app/javascript/components/AttendanceTable.jsx
+++ b/app/javascript/components/AttendanceTable.jsx
@@ -1,0 +1,93 @@
+import PropTypes from 'prop-types'
+import { Table, Tooltip } from 'flowbite-react'
+
+export default function AttendanceTable({ attendances }) {
+  return (
+    <div className="overflow-x-auto mb-2">
+      <Table theme={customTableTheme}>
+        <Table.Head>
+          {attendances.map((attendance) => (
+            <Table.HeadCell key={attendance.minute_id}>
+              <span data-table-head={attendance.date}>
+                {formatDate(attendance.date)}
+              </span>
+            </Table.HeadCell>
+          ))}
+        </Table.Head>
+        <Table.Body className="divide-y">
+          <Table.Row>
+            {attendances.map((attendance) => (
+              <Table.Cell key={attendance.minute_id}>
+                <AttendanceTableData
+                  date={attendance.date}
+                  status={attendance.status}
+                  time={attendance.time}
+                  absence_reason={attendance.absence_reason}
+                />
+              </Table.Cell>
+            ))}
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+function AttendanceTableData({ date, status, time, absence_reason }) {
+  if (status === 'present') {
+    return (
+      <span data-table-data={date}>{{ day: '昼', night: '夜' }[time]}</span>
+    )
+  } else if (status === 'absent') {
+    return (
+      <Tooltip content={absence_reason} theme={customTooltipTheme}>
+        <span data-table-data={date}>欠席</span>
+      </Tooltip>
+    )
+  } else if (status === 'hibernation') {
+    return <span data-table-data={date}>休止</span>
+  } else {
+    return <span data-table-data={date}>---</span>
+  }
+}
+
+function formatDate(date) {
+  const matched_date = date.match(/\d{4}-(\d{2})-(\d{2})/)
+  return `${matched_date[1]}/${matched_date[2]}`
+}
+
+const customTableTheme = {
+  root: {
+    base: 'text-left text-sm',
+    shadow:
+      'absolute left-0 top-0 -z-10 h-full w-full rounded-lg bg-white drop-shadow-md',
+    wrapper: 'relative',
+  },
+  body: {
+    base: 'group/body',
+    cell: {
+      base: 'px-2 py-2 border border-gray-400 w-16 h-10 text-center',
+    },
+  },
+  head: {
+    base: 'group/head text-xs uppercase text-gray-700',
+    cell: {
+      base: 'bg-gray-200 px-2 py-2 border border-gray-400 w-16 h-10 text-center',
+    },
+  },
+}
+
+const customTooltipTheme = {
+  target: '', // デフォルトで設定されているw-fitを削除
+}
+
+AttendanceTable.propTypes = {
+  attendances: PropTypes.array,
+}
+
+AttendanceTableData.propTypes = {
+  date: PropTypes.string,
+  status: PropTypes.string,
+  time: PropTypes.string,
+  absence_reason: PropTypes.string,
+}

--- a/app/javascript/mountMultipleComponents.jsx
+++ b/app/javascript/mountMultipleComponents.jsx
@@ -1,0 +1,19 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+export default function mountComponent(className, Component) {
+  const elements = document.getElementsByClassName(className)
+  if (elements.length === 0) {
+    return null
+  }
+
+  Array.from(elements).forEach((element) => {
+    const root = createRoot(element)
+    const props = JSON.parse(element.getAttribute('data'))
+    root.render(
+      <StrictMode>
+        <Component {...props} />
+      </StrictMode>
+    )
+  })
+}

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -11,7 +11,7 @@
     <div>
       <ul class="list-disc list-inside">
         <% @members.each do |member| %>
-          <li class="mb-4">
+          <li class="mb-4" data-member="<%= member.id %>">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
             <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
             <%= content_tag :div, class: 'recent_attendances mt-4', data: {attendances: member.all_attendances.pop(12)}.to_json do %><% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -9,11 +9,11 @@
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>
 
     <div>
-      <ul class="list-disc list-inside text-sky-600">
+      <ul class="list-disc list-inside">
         <% @members.each do |member| %>
           <li class="mb-4">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
-            <%= link_to "#{member.name}", member, class: "py-3 inline-block hover:underline" %>
+            <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
             <%= content_tag :div, class: 'recent_attendances mt-4', data: {attendances: member.all_attendances.pop(12)}.to_json do %><% end %>
           </li>
         <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,0 +1,20 @@
+<div class="mx-auto w-full">
+  <div class="mx-auto">
+    <% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+    <% end %>
+
+    <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>
+
+    <div>
+      <ul class="list-disc list-inside text-sky-600">
+        <% @members.each do |member| %>
+          <li class="mb-4">
+            <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
+            <%= link_to "#{member.name}", member, class: "py-3 inline-block hover:underline" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -14,6 +14,7 @@
           <li class="mb-4">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
             <%= link_to "#{member.name}", member, class: "py-3 inline-block hover:underline" %>
+            <%= content_tag :div, class: 'recent_attendances mt-4', data: {attendances: member.all_attendances.pop(12)}.to_json do %><% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -4,6 +4,8 @@
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
 
+    <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
+
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>
 
     <div>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -4,7 +4,7 @@
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
 
-    <%= render partial: 'course_tab', locals: { active_tab: @course } %>
+    <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
 

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -2,7 +2,7 @@
   <ul class="flex flex-wrap text-sm text-center border-b border-gray-200 !list-none">
     <% Course.all.each do |course| %>
       <li class="me-2">
-        <%= link_to course.name, course_minutes_path(course), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>
+        <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>
       </li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   end
   resources :attendances, only: [ :edit, :update ]
   resources :courses, only: [] do
+    resources :members, only: [:index], module: :courses
     resources :minutes, only: [:index], module: :courses
   end
   resources :members, only: [:show]

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -27,5 +27,11 @@ FactoryBot.define do
       uid { 444_444 }
       name { 'unexcused_absentee' }
     end
+
+    trait :sample_member do
+      sequence(:email) { |n| "member-#{n}@example.com" }
+      sequence(:uid) { |n| n }
+      sequence(:name) { |n| "member-#{n}" }
+    end
   end
 end


### PR DESCRIPTION
## Issue
- #142 

## 概要
コースごとに所属するメンバーを一覧で表示するようにし、各メンバーの直近半年の出席も表示するようにした。
ただし、現時点では休止中ではないメンバーを表示するようにしている。

## Screenshot
- 各コースに所属するメンバーが一覧で表示される
- メンバーの名前をクリックすると、詳細ページに遷移できる
- 各メンバーの直近半年の出席(12回)が表示される
  -  総出席数が12回に満たない場合は、全ての出席が表示される

[![Image from Gyazo](https://i.gyazo.com/4c3c38ae7023a274c8970b6bcde358b1.gif)](https://gyazo.com/4c3c38ae7023a274c8970b6bcde358b1)


