### PR TITLE
メンバー一覧で管理者は休止中のメンバーを表示できるようにした

### DIFF
--- a/app/controllers/courses/members_controller.rb
+++ b/app/controllers/courses/members_controller.rb
@@ -2,6 +2,7 @@
 
 class Courses::MembersController < Courses::ApplicationController
   def index
-    @members = Member.active.where(course: @course).order(:created_at)
+    members = params[:status] == 'hibernated' ? Member.hibernated : Member.active
+    @members = members.where(course: @course).order(:created_at)
   end
 end

--- a/app/controllers/courses/members_controller.rb
+++ b/app/controllers/courses/members_controller.rb
@@ -3,6 +3,7 @@
 class Courses::MembersController < Courses::ApplicationController
   def index
     members = params[:status] == 'hibernated' ? Member.hibernated : Member.active
+    members = Member.active unless admin_signed_in?
     @members = members.where(course: @course).order(:created_at)
   end
 end

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -1,0 +1,12 @@
+<div class="mb-4">
+  <% if course.members.any? %>
+    <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
+      <li class="me-2">
+        <%= link_to '活動中', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'small_tab_item' %>
+      </li>
+      <li class="me-2">
+        <%= link_to '休止中', course_members_path(course, status: 'hibernated'), class: active_tab == 'hibernated' ? 'active_small_tab_item' : 'small_tab_item' %>
+      </li>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -8,6 +8,9 @@
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>
 
+    <% active_tab = params[:status] ? params[:status] : 'active' %>
+    <%= render partial: 'status_tab', locals: { course: @course, active_tab: active_tab } %>
+
     <div>
       <ul class="list-disc list-inside">
         <% @members.each do |member| %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -17,6 +17,9 @@
           <li class="mb-4" data-member="<%= member.id %>">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
             <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
+            <% if member.hibernated? %>
+              <p class="mt-2 text-sm"><%= member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休止中</p>
+            <% end %>
             <%= content_tag :div, class: 'recent_attendances mt-4', data: {attendances: member.all_attendances.pop(12)}.to_json do %><% end %>
           </li>
         <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -10,7 +10,7 @@
 
     <% if admin_signed_in? %>
       <% active_tab = params[:status] ? params[:status] : 'active' %>
-      <%= render partial: 'status_tab', locals: { course: @course, active_tab: active_tab } %>
+      <%= render 'status_tab', course: @course, active_tab: active_tab %>
     <% end %>
 
     <div>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -8,8 +8,10 @@
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>
 
-    <% active_tab = params[:status] ? params[:status] : 'active' %>
-    <%= render partial: 'status_tab', locals: { course: @course, active_tab: active_tab } %>
+    <% if admin_signed_in? %>
+      <% active_tab = params[:status] ? params[:status] : 'active' %>
+      <%= render partial: 'status_tab', locals: { course: @course, active_tab: active_tab } %>
+    <% end %>
 
     <div>
       <ul class="list-disc list-inside">

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -9,7 +9,7 @@
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
 
     <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>
-    <%= render partial: 'years_tab', locals: { course: @course, active_tab: active_tab } %>
+    <%= render 'years_tab', course: @course, active_tab: active_tab %>
 
     <div>
       <ul class="list-disc list-inside text-sky-600">


### PR DESCRIPTION
## Issue
- #140 

## 概要
管理者でログイン時のみ、メンバー一覧ページに`活動中`・`休止中`のタブを表示し、タブを選択するとそれぞれのユーザーを表示できるようにした。

また、付随してパーシャルの呼び出しの書き方の修正も行なっている。

## Screenshot
管理者でログイン時。
[![Image from Gyazo](https://i.gyazo.com/efb78efe7d458ce2de2ab964296612f5.gif)](https://gyazo.com/efb78efe7d458ce2de2ab964296612f5)

メンバーでログイン時。
クエリを渡しても、活動中のメンバーしか表示されない。
[![Image from Gyazo](https://i.gyazo.com/2ceccb4ef0c6c3bd53a83b60f845a874.gif)](https://gyazo.com/2ceccb4ef0c6c3bd53a83b60f845a874)

