### PR TITLE
管理者はメンバー一覧ページからメンバーを休止中にできるようにした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   devise_group :development_member, contains: %i[member admin]
   before_action :authenticate_development_member!
+  before_action :prohibit_hibernated_member_access
 
   def after_sign_in_path_for(_resource)
     root_path
@@ -14,5 +15,12 @@ class ApplicationController < ActionController::Base
 
   def admin_login?
     development_member_signed_in? && current_development_member.is_a?(Admin)
+  end
+
+  def prohibit_hibernated_member_access
+    return unless member_signed_in? && current_member.hibernated?
+
+    sign_out
+    redirect_to root_path, alert: t('errors.messages.hibernated_member_access')
   end
 end

--- a/app/controllers/members/application_controller.rb
+++ b/app/controllers/members/application_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Members::ApplicationController < ApplicationController
+  before_action :set_member
+
+  private
+
+  def set_member
+    @member = Member.find(params[:member_id])
+  end
+end

--- a/app/controllers/members/hibernations_controller.rb
+++ b/app/controllers/members/hibernations_controller.rb
@@ -2,9 +2,18 @@
 
 class Members::HibernationsController < Members::ApplicationController
   before_action :authenticate_admin!
+  before_action :prohibit_duplicate_hibernations
 
   def create
     @member.hibernations.create!
     redirect_to course_members_path(@member.course, status: 'hibernated'), notice: "#{@member.name}を休止中にしました"
+  end
+
+  private
+
+  def prohibit_duplicate_hibernations
+    return unless @member.hibernated?
+
+    redirect_to course_members_path(@member.course, status: 'hibernated'), alert: "#{@member.name}さんはすでに休止中です"
   end
 end

--- a/app/controllers/members/hibernations_controller.rb
+++ b/app/controllers/members/hibernations_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Members::HibernationsController < Members::ApplicationController
+  before_action :authenticate_admin!
+
+  def create
+    @member.hibernations.create!
+    redirect_to course_members_path(@member.course, status: 'hibernated'), notice: "#{@member.name}を休止中にしました"
+  end
+end

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -14,6 +14,7 @@ import UnexcusedAbsenteesList from './components/UnexcusedAbsenteesList.jsx'
 import MinutePreview from './components/MinutePreview.jsx'
 import AllAttendanceTable from './components/AllAttendanceTable.jsx'
 import AttendanceTable from './components/AttendanceTable.jsx'
+import HibernationButton from './components/HibernationButton.jsx'
 import './toggleAttendanceForm'
 
 import 'flowbite'
@@ -30,3 +31,4 @@ mountComponent('minute_preview', MinutePreview)
 mountComponent('all_attendance_table', AllAttendanceTable)
 
 mountMultipleComponents('recent_attendances', AttendanceTable)
+mountMultipleComponents('hibernation_button', HibernationButton)

--- a/app/javascript/components/HibernationButton.jsx
+++ b/app/javascript/components/HibernationButton.jsx
@@ -8,8 +8,7 @@ export default function HibernationButton({ member_id, member_name }) {
   return (
     <div>
       <button
-        id="open_modal"
-        className="button_danger"
+        className="button_danger open_modal"
         onClick={() => setOpenModal(true)}
       >
         休止中にする

--- a/app/javascript/components/HibernationButton.jsx
+++ b/app/javascript/components/HibernationButton.jsx
@@ -1,0 +1,91 @@
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+import { Modal, ModalBody } from 'flowbite-react'
+
+export default function HibernationButton({ member_id, member_name }) {
+  const [openModal, setOpenModal] = useState(false)
+
+  return (
+    <div>
+      <button
+        id="open_modal"
+        className="button_danger"
+        onClick={() => setOpenModal(true)}
+      >
+        休止中にする
+      </button>
+      <Modal
+        show={openModal}
+        onClose={() => setOpenModal(false)}
+        popup
+        theme={customTheme}
+      >
+        <ModalBody>
+          <div className="text-center">
+            <p className="my-8 text-xl">
+              {member_name}さんを休止中にします。よろしいですか？
+            </p>
+            <div>
+              <SubmitForm memberId={member_id} />
+              <button
+                className="inline-block text-red-600 hover:bg-red-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-red-600"
+                onClick={() => setOpenModal(false)}
+              >
+                キャンセル
+              </button>
+            </div>
+          </div>
+        </ModalBody>
+      </Modal>
+    </div>
+  )
+}
+
+function SubmitForm({ memberId }) {
+  const csrfToken = document.head.querySelector(
+    'meta[name=csrf-token]'
+  )?.content
+
+  const handleSubmit = function (e) {
+    e.preventDefault()
+    const form = e.target
+    form.submit()
+  }
+
+  return (
+    <form
+      action={`/members/${memberId}/hibernations`}
+      method="POST"
+      onSubmit={handleSubmit}
+      className="inline-block"
+    >
+      <input
+        type="hidden"
+        name="authenticity_token"
+        value={csrfToken}
+        autoComplete="off"
+      />
+      <input
+        type="submit"
+        value="休止中にする"
+        id="accept_modal"
+        className="button_danger"
+      />
+    </form>
+  )
+}
+
+const customTheme = {
+  body: {
+    popup: '', // デフォルトで設定してあるpt-0を削除
+  },
+}
+
+HibernationButton.propTypes = {
+  member_id: PropTypes.number,
+  member_name: PropTypes.string,
+}
+
+SubmitForm.propTypes = {
+  memberId: PropTypes.number,
+}

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -20,8 +20,7 @@
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
             <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
             <% if admin_signed_in? && !member.hibernated? %>
-              <%= link_to '休止中にする',  member_hibernations_path(member), class: "text-sky-600 pl-4 hover:underline",
-                          data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんを休止中にします。よろしいですか？" } %>
+              <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>
             <% end %>
             <% if member.hibernated? %>
               <p class="mt-2 text-sm"><%= member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休止中</p>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -3,6 +3,9 @@
     <% if notice.present? %>
       <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
     <% end %>
+    <% if alert.present? %>
+      <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
+    <% end %>
 
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
 

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -19,7 +19,7 @@
           <li class="mb-4" data-member="<%= member.id %>">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
             <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
-            <% unless member.hibernated? %>
+            <% if admin_signed_in? && !member.hibernated? %>
               <%= link_to '休止中にする',  member_hibernations_path(member), class: "text-sky-600 pl-4 hover:underline",
                           data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんを休止中にします。よろしいですか？" } %>
             <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -19,6 +19,10 @@
           <li class="mb-4" data-member="<%= member.id %>">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
             <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
+            <% unless member.hibernated? %>
+              <%= link_to '休止中にする',  member_hibernations_path(member), class: "text-sky-600 pl-4 hover:underline",
+                          data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんを休止中にします。よろしいですか？" } %>
+            <% end %>
             <% if member.hibernated? %>
               <p class="mt-2 text-sm"><%= member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休止中</p>
             <% end %>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -142,3 +142,4 @@ ja:
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+      hibernated_member_access: 休会中のメンバーはトップページから再度ログインをお願いします

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
     resources :members, only: [:index], module: :courses
     resources :minutes, only: [:index], module: :courses
   end
-  resources :members, only: [:show]
+  resources :members, only: [:show] do
+    resources :hibernations, only: [:create], module: :members
+  end
 
   namespace :api do
     resources :minutes, only: [ :update ] do

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -79,28 +79,29 @@ RSpec.describe 'Attendances', type: :system do
     end
 
     scenario 'hibernated member is not displayed as present, absent or unexcused absent', :js do
-      member.hibernations.create!
-      expect(member.hibernated?).to be true
+      hibernated_member = FactoryBot.create(:member, :another_member, course: rails_course)
+      hibernated_member.hibernations.create!
+      expect(hibernated_member.hibernated?).to be true
 
       visit edit_minute_path(minute)
       within('#day_attendees') do
-        expect(page).not_to have_selector 'li', text: member.name
+        expect(page).not_to have_selector 'li', text: hibernated_member.name
       end
       within('#night_attendees') do
-        expect(page).not_to have_selector 'li', text: member.name
+        expect(page).not_to have_selector 'li', text: hibernated_member.name
       end
       within('#absentees', visible: false) do
-        expect(page).not_to have_selector 'li', text: member.name
+        expect(page).not_to have_selector 'li', text: hibernated_member.name
       end
       within('#unexcused_absentees', visible: false) do
-        expect(page).not_to have_selector 'li', text: member.name
+        expect(page).not_to have_selector 'li', text: hibernated_member.name
       end
 
-      member.hibernations.last.update!(finished_at: Time.zone.today)
-      expect(member.hibernated?).to be false
+      hibernated_member.hibernations.last.update!(finished_at: Time.zone.today)
+      expect(hibernated_member.hibernated?).to be false
       visit edit_minute_path(minute)
       within('#unexcused_absentees') do
-        expect(page).to have_selector 'li', text: member.name
+        expect(page).to have_selector 'li', text: hibernated_member.name
       end
     end
 

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe 'Hibernations', type: :system do
     expect(page).to have_content '休止から復帰しました。'
     expect(member.reload.hibernated?).to be false
   end
+
+  scenario 'hibernated member cannot access application and must login again' do
+    FactoryBot.create(:hibernation, member:)
+
+    visit course_members_path(rails_course)
+    expect(current_path).to eq root_path
+    expect(page).to have_content '休会中のメンバーはトップページから再度ログインをお願いします'
+    expect(page).not_to have_content 'aliceさんの出席一覧(Railsエンジニアコース)'
+    expect(page).to have_button 'Railsエンジニアコースでログイン'
+  end
 end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -241,5 +241,21 @@ RSpec.describe 'Members', type: :system do
       expect(page).to have_content 'alice'
       expect(page).to have_content "#{Time.zone.today.strftime('%Y/%m/%d')}から休止中"
     end
+
+    scenario 'admin cannot make member hibernated who already hibernated' do
+      admin = FactoryBot.create(:admin)
+      login_as_admin admin
+      visit course_members_path(rails_course)
+
+      FactoryBot.create(:hibernation, member:)
+      expect do
+        within("li[data-member='#{member.id}']") do
+          click_button '休止中にする'
+        end
+        find('#accept_modal').click
+      end.not_to change(member.hibernations, :count)
+      expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
+      expect(page).to have_content 'aliceさんはすでに休止中です'
+    end
   end
 end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -229,12 +229,14 @@ RSpec.describe 'Members', type: :system do
       admin = FactoryBot.create(:admin)
       login_as_admin admin
       visit course_members_path(rails_course)
-      within("li[data-member='#{member.id}']") do
-        expect(page).to have_content 'alice'
-        expect(page).to have_button '休止中にする'
-        click_button '休止中にする'
-      end
-      find('#accept_modal').click
+      expect do
+        within("li[data-member='#{member.id}']") do
+          expect(page).to have_content 'alice'
+          expect(page).to have_button '休止中にする'
+          click_button '休止中にする'
+        end
+        find('#accept_modal').click
+      end.to change(member.hibernations, :count).by(1)
       # expect(current_page)だとクエリ部分が無視されてしまうため、expect(page).to have_current_pathでテストする
       expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
       expect(page).to have_content 'aliceを休止中にしました'

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -215,8 +215,8 @@ RSpec.describe 'Members', type: :system do
       another_member = FactoryBot.create(:member, :another_member, course: rails_course)
       login_as another_member
       visit course_members_path(rails_course)
-      expect(page).not_to have_link '活動中'
-      expect(page).not_to have_link '休止中'
+      expect(page).not_to have_link '活動中', href: course_members_path(rails_course, status: 'active')
+      expect(page).not_to have_link '休止中', href: course_members_path(rails_course, status: 'hibernated')
       expect(page).not_to have_content 'alice'
 
       visit course_members_path(rails_course, status: 'hibernated')

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Members', type: :system do
         within("li[data-member='#{member.id}']") do
           expect(page).to have_link member.name, href: member_path(member)
           expect(page).to have_selector "img[src='#{member.avatar_url}']"
-          expect(page).not_to have_button '休止中にする'
+          expect(page).not_to have_selector 'button.open_modal', text: '休止中にする'
         end
       end
       expect(page).not_to have_link 'bob', href: member_path(front_end_member)
@@ -232,7 +232,7 @@ RSpec.describe 'Members', type: :system do
       expect do
         within("li[data-member='#{member.id}']") do
           expect(page).to have_content 'alice'
-          expect(page).to have_button '休止中にする'
+          expect(page).to have_selector 'button.open_modal', text: '休止中にする'
           click_button '休止中にする'
         end
         find('#accept_modal').click

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Members', type: :system do
         within("li[data-member='#{member.id}']") do
           expect(page).to have_link member.name, href: member_path(member)
           expect(page).to have_selector "img[src='#{member.avatar_url}']"
-          expect(page).not_to have_link '休止中にする', href: member_hibernations_path(member)
+          expect(page).not_to have_button '休止中にする'
         end
       end
       expect(page).not_to have_link 'bob', href: member_path(front_end_member)
@@ -231,11 +231,10 @@ RSpec.describe 'Members', type: :system do
       visit course_members_path(rails_course)
       within("li[data-member='#{member.id}']") do
         expect(page).to have_content 'alice'
-        expect(page).to have_link '休止中にする', href: member_hibernations_path(member)
-        page.accept_confirm do
-          click_link '休止中にする'
-        end
+        expect(page).to have_button '休止中にする'
+        click_button '休止中にする'
       end
+      find('#accept_modal').click
       # expect(current_page)だとクエリ部分が無視されてしまうため、expect(page).to have_current_pathでテストする
       expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
       expect(page).to have_content 'aliceを休止中にしました'

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -99,12 +99,13 @@ RSpec.describe 'Members', type: :system do
       end
 
       scenario 'display attendances until the hibernation started if the member is hibernated', :js do
+        hibernated_member = FactoryBot.create(:member, :another_member, course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 15), course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 2, 5), course: rails_course)
-        FactoryBot.create(:hibernation, member:, created_at: Time.zone.local(2025, 2, 1))
+        FactoryBot.create(:hibernation, member: hibernated_member, created_at: Time.zone.local(2025, 2, 1))
 
-        visit member_path(member)
+        visit member_path(hibernated_member)
         expect(page).to have_selector 'span[data-table-head="2025-01-01"]', text: '01/01'
         expect(page).to have_selector 'span[data-table-head="2025-01-15"]', text: '01/15'
         expect(page).not_to have_selector 'span[data-table-head="2025-02-05"]', text: '02/15'


### PR DESCRIPTION
## Issue
- #156

## 概要
管理者でメンバー一覧ページを開くと、`休止中にする`ボタンが表示されるようになり、ボタンをクリックするとそのメンバーが休止中になるようにした。

## Screenshot
メンバーがメンバー一覧ページを開いた場合。
![D8C01BB9-E81D-446B-94D9-3717F3497B4A](https://github.com/user-attachments/assets/9a1df933-1802-4582-9da6-5362b7e150e2)


管理者がメンバー一覧ページを開き、メンバーを休止中にした場合。
[![Image from Gyazo](https://i.gyazo.com/8791d87abae1cd558b4e59de7486865e.gif)](https://gyazo.com/8791d87abae1cd558b4e59de7486865e)


すでに休止中であるメンバーを休止中にしようとした場合、リダイレクトされ警告メッセージが表示される。
滅多にないと考えているが、以下のケースを想定している。
1. 管理者がメンバー一覧ページにアクセス
2. メンバーが休止中になる
3. 管理者が2で休止中になったメンバーを休止中にする
[![Image from Gyazo](https://i.gyazo.com/2ce0390f69077e0358417fa4dd9cfbef.gif)](https://gyazo.com/2ce0390f69077e0358417fa4dd9cfbef)


## 備考
### 休止中にするボタンの実装
休止中にするボタンは、flowbite-reactのModalコンポーネントを利用して実装を行った。
最初はPOSTメソッドを送るリンクで実装を行っていたが、Reactを使うようになった経緯は以下の通り。

- 最初は次のようなリンクを実装していた

```ruby
<%= link_to '休止中にする',  member_hibernations_path(member), class: "text-sky-600 pl-4 hover:underline",
             data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんを休止中にします。よろしいですか？" } %>
```

- リンク自体は正しく動作するが、**遷移したリダイレクト先でメンバーの最近の出席が表示されない**という問題が発生していた

[![Image from Gyazo](https://i.gyazo.com/a13d466f81e4240d4caa205f59294f03.gif)](https://gyazo.com/a13d466f81e4240d4caa205f59294f03)

- ログを見るとturbo_streamフォーマットでリダイレクトリクエストが処理されていることが分かった。
- `<meta name="turbo-visit-control" content="reload">`タグを追加するとページ全体をリロードしてくれるようなので、追加した。

参考
- https://turbo.hotwired.dev/reference/attributes#meta-tags
- https://qiita.com/kaorumori/items/cc58aa9c7676e972143a#%E3%83%A1%E3%82%BF%E3%82%BF%E3%82%B0

[![Image from Gyazo](https://i.gyazo.com/d8b9dd3e481c030e2c6e9a81e20c2deb.gif)](https://gyazo.com/d8b9dd3e481c030e2c6e9a81e20c2deb)

- リダイレクト先のページで出席が表示されるようになったが、今度は**フラッシュメッセージが表示されない**という問題が発生した
- ログを確認してみると、リダイレクト先のページに2回GETリクエストが送られていることが分かった。
  - `<meta name="turbo-visit-control" content="reload">`タグを追加するとこうなるらしい
- `flash.keep`を実行するとフラッシュを2回目のGETリクエストでも持続させることが可能とあったため、`flash.keep`を実行したのだが、フラッシュメッセージを表示することはできなかった

参考
- https://www.ducktypelabs.com/turbo-break-out-and-redirect/

以上より、turboを利用したリンクを用いる場合、リダイレクト先のコンポーネントを表示できない問題は解決できたが、フラッシュメッセージが表示できない問題を解決できない。
この機能には確認のモーダルを表示させたいため、flowbite-reactとReactを使って実装を行うことにした。