### PR TITLE
「チーム開発を抜ける」リンクをボタンに修正

### DIFF
--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -1,7 +1,3 @@
-import { Turbo } from '@hotwired/turbo-rails'
-
-Turbo.session.drive = false
-
 import mountComponent from './mountComponent.jsx'
 import mountMultipleComponents from './mountMultipleComponents.jsx'
 import AttendeesList from './components/AttendeesList.jsx'

--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -15,6 +15,7 @@ import MinutePreview from './components/MinutePreview.jsx'
 import AllAttendanceTable from './components/AllAttendanceTable.jsx'
 import AttendanceTable from './components/AttendanceTable.jsx'
 import HibernationButton from './components/HibernationButton.jsx'
+import LogoutButton from './components/LogoutButton.jsx'
 import './toggleAttendanceForm'
 
 import 'flowbite'
@@ -29,6 +30,7 @@ mountComponent('absentees_list', AbsenteesList)
 mountComponent('unexcused_absentees_list', UnexcusedAbsenteesList)
 mountComponent('minute_preview', MinutePreview)
 mountComponent('all_attendance_table', AllAttendanceTable)
+mountComponent('logout_button', LogoutButton)
 
 mountMultipleComponents('recent_attendances', AttendanceTable)
 mountMultipleComponents('hibernation_button', HibernationButton)

--- a/app/javascript/components/LogoutButton.jsx
+++ b/app/javascript/components/LogoutButton.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { Modal, ModalBody } from 'flowbite-react'
+
+export default function LogoutButton() {
+  const [openModal, setOpenModal] = useState(false)
+
+  return (
+    <div>
+      <button className="button open_modal" onClick={() => setOpenModal(true)}>
+        チーム開発を抜ける
+      </button>
+      <Modal
+        show={openModal}
+        onClose={() => setOpenModal(false)}
+        popup
+        theme={customTheme}
+      >
+        <ModalBody>
+          <div>
+            <div className="my-8 text-xl">
+              <p className="mb-4">
+                どちらかのケースに当てはまる場合に、チーム開発を抜けてください。
+              </p>
+              <ul>
+                <li>チーム開発を修了した。</li>
+                <li>
+                  フィヨルドブートキャンプを休会したことに伴い、チーム開発をお休みする。
+                </li>
+              </ul>
+            </div>
+            <div className="text-center">
+              <SubmitForm />
+              <button
+                className="inline-block text-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-blue-600"
+                onClick={() => setOpenModal(false)}
+              >
+                キャンセル
+              </button>
+            </div>
+          </div>
+        </ModalBody>
+      </Modal>
+    </div>
+  )
+}
+
+function SubmitForm() {
+  const csrfToken = document.head.querySelector(
+    'meta[name=csrf-token]'
+  )?.content
+
+  const handleSubmit = function (e) {
+    e.preventDefault()
+    const form = e.target
+    form.submit()
+  }
+
+  return (
+    <form
+      action="/logout"
+      method="POST"
+      onSubmit={handleSubmit}
+      className="inline-block"
+    >
+      <input type="hidden" name="_method" value="DELETE" />
+      <input
+        type="hidden"
+        name="authenticity_token"
+        value={csrfToken}
+        autoComplete="off"
+      />
+      <input
+        type="submit"
+        value="チーム開発を抜ける"
+        id="accept_modal"
+        className="button"
+      />
+    </form>
+  )
+}
+
+const customTheme = {
+  body: {
+    popup: '', // デフォルトで設定してあるpt-0を削除
+  },
+}

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -11,10 +11,7 @@
 
   <% if @member == current_development_member %>
     <div class="mt-4 text-center">
-      <%= link_to 'チーム開発を抜ける', logout_path, class: "text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm p-4 focus:outline-none",
-                  data: { turbo: true,
-                          turbo_method: :delete,
-                          turbo_confirm: "どちらかのケースに当てはまる場合に、チーム開発を抜けてください。\n\n・チーム開発を修了した\n・フィヨルドブートキャンプを休会したことに伴って、チーム開発をお休みする" } %>
+      <%= content_tag :div, id: 'logout_button' do %><% end %>
     </div>
   <% end %>
 </div>

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -12,12 +12,11 @@ RSpec.describe 'Hibernations', type: :system do
 
   scenario 'member can hibernate and return from hibernation', :js do
     visit root_path
-    expect(page).to have_link 'チーム開発を抜ける'
+    expect(page).to have_selector 'button.open_modal', text: 'チーム開発を抜ける'
     expect(member.hibernated?).to be false
 
-    page.accept_confirm do
-      click_link 'チーム開発を抜ける'
-    end
+    click_button 'チーム開発を抜ける'
+    find('#accept_modal').click
     expect(current_path).to eq root_path
     expect(page).to have_content 'ログアウトしました'
     expect(member.reload.hibernated?).to be true

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe 'Members', type: :system do
       login_as member
       visit member_path(member)
       expect(page).to have_selector 'h1', text: 'aliceさんの出席一覧(Railsエンジニアコース)'
-      expect(page).to have_link 'チーム開発を抜ける'
+      expect(page).to have_selector 'button.open_modal', text: 'チーム開発を抜ける'
 
       visit member_path(another_member)
       expect(page).to have_selector 'h1', text: 'bobさんの出席一覧(フロントエンドエンジニアコース)'
-      expect(page).not_to have_link 'チーム開発を抜ける'
+      expect(page).not_to have_selector 'button.open_modal', text: 'チーム開発を抜ける'
     end
 
     context 'when display member attendances' do


### PR DESCRIPTION
## Issue
- #160 

## 概要
ログインしているメンバーのメンバー詳細ページに表示されていた「チーム開発を抜ける」リンクを、flowbite-reactを使ってボタンに変更した。
それに伴いTurboをアプリ内で使わなくなったため、`application.jsx`から削除している。

## Screenshot
変更前
![BA3A2A48-F573-41B1-936C-775B7D417B52](https://github.com/user-attachments/assets/3c2bce0b-5a1e-459e-ab3d-6df75940d2b0)

変更後
![8B38A913-13CE-40CD-ABF0-C900610EA795](https://github.com/user-attachments/assets/09793437-ac55-48a6-995f-eeb402dad2da)

