### PR TITLE
ボタンに適用されていた不要なスタイルを削除

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -20,10 +20,10 @@
         display: inline;
     }
     .button {
-        @apply text-white bg-blue-600 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800;
+        @apply text-white bg-blue-600 hover:bg-blue-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
     }
     .button_danger {
-        @apply text-white bg-red-600 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2 dark:bg-red-600 dark:hover:bg-red-700 focus:outline-none dark:focus:ring-red-800;
+        @apply text-white bg-red-600 hover:bg-red-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
     }
     .input_type_text {
         @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;


### PR DESCRIPTION
## Issue
- #161 

## 概要
ボタンに適用されていたfocus時とdark modeのCSSが不要であったため、削除した。

## Screenshot

![F5983FF8-5575-4CCB-85DA-DB39A496E3C5_4_5005_c](https://github.com/user-attachments/assets/8e7013c5-0cb1-4f9e-a97c-a912c5eb00a6)

![3A85C25E-0A86-4DA9-908A-5A392F4988DC_4_5005_c](https://github.com/user-attachments/assets/5745eb69-f86a-443f-86de-c49610963b74)
