### PR TITLE
フラッシュ表示をパーシャルに切り出した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -43,4 +43,10 @@
     .active_small_tab_item {
         @apply inline-block px-4 py-2 text-white bg-gray-600 border border-gray-600 rounded-3xl;
     }
+    .flash_notice {
+        @apply py-2.5 px-4 text-green-500 bg-green-100 mb-5 font-medium rounded-lg inline-block;
+    }
+    .flash_alert {
+        @apply py-2.5 px-4 text-red-500 bg-red-100 mb-5 font-medium rounded-lg inline-block;
+    }
 }

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,12 +1,5 @@
 <div class="mx-auto w-full">
   <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-    <% if alert.present? %>
-      <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-    <% end %>
-
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,9 +1,5 @@
 <div class="mx-auto w-full">
   <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
 
     <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,8 +1,4 @@
 <div class="w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">
     <%= "管理者用のダッシュボード" %>
   </h1>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,11 +1,4 @@
 <div>
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-  <% if alert.present? %>
-    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">Fjord Minutes</h1>
   <p>フィヨルドブートキャンプのチーム開発プラクティスで行われているミーティングの議事録を作成するアプリケーションです。</p>
 

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,8 @@
+<div class="w-full text-center">
+  <% if notice.present? %>
+    <p class="flash_notice"><%= notice %></p>
+  <% end %>
+  <% if alert.present? %>
+    <p class="flash_alert"><%= alert %></p>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,8 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-12 px-5 flex max-w-5xl">
+    <main class="container mx-auto mt-12 px-5 max-w-5xl">
+      <%= render 'layouts/flash' %>
       <%= yield %>
     </main>
   </body>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,8 +1,4 @@
 <div class="w-full">
-  <% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-  <% end %>
-
   <h1 class="font-bold text-4xl">
     <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>
   </h1>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,13 +1,5 @@
 <div class="mx-auto w-full">
   <div class="markdown-body">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-
-    <% if alert.present? %>
-      <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%= alert %></p>
-    <% end %>
-
     <h1><%= @minute.title %></h1>
 
     <h1>ふりかえり</h1>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,9 +1,5 @@
 <div class="mx-auto w-full">
   <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
-
     <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>
 
     <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>


### PR DESCRIPTION
## Issue
- #162 

## 概要
フラッシュメッセージを表示するビューをパーシャルに切り出し、`app/views/layouts/application.html.erb`内で呼び出すことで、各ページでフラッシュメッセージを表示できるようにした。

## 備考
### Tailwindの動的なクラス名の生成
以下のように、クラス名の一部を変数にして動的に作成しようとすると、Tailwindはクラス名を正しく解釈してくれない。
(`flash[:notice]`が存在する場合クラス名は`flash_notice`となるが、Tailwindは`flash_notice`のクラス名を見つけることができず、一致するCSSが生成されない)
```ruby
<p class="flash_<%= key %>"><%= value %></p>
```

https://tailwindcss.com/docs/content-configuration#dynamic-class-names

今回の実装では、noticeとalertの場合でそれぞれ記述している。
