### PR TITLE
リンクの色を統一した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -3,6 +3,9 @@
 @tailwind utilities;
 
 @layer base {
+    a {
+        @apply text-markdownAnchorBlue hover:underline;
+    }
     ul {
         @apply list-disc pl-8 [&_ul]:list-[revert];
     }

--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -28,12 +28,7 @@ export default function AbsenteesList({ minuteId, currentMemberId, isAdmin }) {
 function Absentee({ absentee, currentMemberId, isAdmin }) {
   return (
     <li className="mb-4">
-      <a
-        href={`https://github.com/${absentee.name}`}
-        className="text-sky-600 underline"
-      >
-        {`@${absentee.name}`}
-      </a>
+      <a href={`https://github.com/${absentee.name}`}>{`@${absentee.name}`}</a>
       {!isAdmin && currentMemberId === absentee.member_id && (
         <a
           href={`/attendances/${absentee.attendance_id}/edit`}

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -48,12 +48,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
         プロダクトオーナー
         <ul>
           <li>
-            <a
-              href="https://github.com/machida"
-              className="text-sky-600 underline"
-            >
-              @machida
-            </a>
+            <a href="https://github.com/machida">@machida</a>
           </li>
         </ul>
       </li>
@@ -61,12 +56,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
         スクラムマスター
         <ul>
           <li>
-            <a
-              href="https://github.com/komagata"
-              className="text-sky-600 underline"
-            >
-              @komagata
-            </a>
+            <a href="https://github.com/komagata">@komagata</a>
           </li>
         </ul>
       </li>
@@ -77,10 +67,7 @@ export default function AttendeesList({ minuteId, currentMemberId, isAdmin }) {
 function Attendee({ attendee, currentMemberId, isAdmin }) {
   return (
     <li key={attendee.attendance_id}>
-      <a
-        href={`https://github.com/${attendee.name}`}
-        className="text-sky-600 underline"
-      >{`@${attendee.name}`}</a>
+      <a href={`https://github.com/${attendee.name}`}>{`@${attendee.name}`}</a>
       {!isAdmin && currentMemberId === attendee.member_id && (
         <a
           href={`/attendances/${attendee.attendance_id}/edit`}

--- a/app/javascript/components/UnexcusedAbsenteesList.jsx
+++ b/app/javascript/components/UnexcusedAbsenteesList.jsx
@@ -21,7 +21,6 @@ export default function UnexcusedAbsenteesList({
         <li key={absentee.member_id} className="mb-4">
           <a
             href={`https://github.com/${absentee.name}`}
-            className="text-sky-600 underline"
           >{`@${absentee.name}`}</a>
           {!isAdmin && currentMemberId === absentee.member_id && (
             <a

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -14,7 +14,7 @@
         <% @members.each do |member| %>
           <li class="mb-4" data-member="<%= member.id %>">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
-            <%= link_to "#{member.name}", member, class: "text-sky-600 py-3 inline-block hover:underline" %>
+            <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
             <% if admin_signed_in? && !member.hibernated? %>
               <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>
             <% end %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -8,13 +8,13 @@
     <%= render 'years_tab', course: @course, active_tab: active_tab %>
 
     <div>
-      <ul class="list-disc list-inside text-sky-600">
+      <ul class="list-disc list-inside">
         <% @minutes.each do |minute| %>
           <li class="mb-4">
-            <%= link_to "#{minute.title}", minute, class: "py-3 inline-block hover:underline" %>
+            <%= link_to "#{minute.title}", minute, class: "py-3 inline-block" %>
             <% if minute.exported? %>
               <span class="ml-2">
-                <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow", class: 'text-sky-600 hover:underline' %>
+                <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>
               </span>
             <% end %>
           </li>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -43,7 +43,7 @@
   </div>
 
   <div class="my-8 text-center">
-    <%= link_to '議事録のプレビュー', @minute, class: "ml-4 text-blue-600 hover:underline" %>
-    <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4 text-blue-600 hover:underline" %>
+    <%= link_to '議事録のプレビュー', @minute, class: "ml-4" %>
+    <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4" %>
   </div>
 </div>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -10,13 +10,13 @@
 
     <% if @minute.exported? %>
       <div class="text-center my-2">
-        <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow", class: 'text-sky-600 hover:underline' %>
+        <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow" %>
       </div>
     <% end %>
 
     <div class="my-8 text-center">
-      <%= link_to '議事録を編集する', edit_minute_path(@minute), class: "ml-4 text-blue-600 hover:underline" %>
-      <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4 text-blue-600 hover:underline" %>
+      <%= link_to '議事録を編集する', edit_minute_path(@minute), class: "ml-4" %>
+      <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4" %>
     </div>
   </div>
 </div>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -16,6 +16,9 @@ module.exports = {
         sans: ['Inter var', ...defaultTheme.fontFamily.sans],
       },
     },
+    colors: {
+      markdownAnchorBlue: '#0969da',
+    },
   },
   plugins: [
     require('@tailwindcss/forms'),


### PR DESCRIPTION
## Issue
- #163 

## 概要
アプリ内のリンクの色が統一されていなかったため、統一するようにスタイルを追加した。
リンクの色はgithub-markdown.cssの色を採用している。

## 備考
カスタムカラーの設定方法。
- https://tailwindcss.com/docs/customizing-colors#using-custom-colors

