### PR TITLE
ヘッダーを追加

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,25 @@
+<nav id="header" class="bg-white border-gray-200 border-b-2">
+  <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
+    <a href="/" class="flex items-center space-x-3">
+      <span class="self-center text-2xl font-semibold whitespace-nowrap">Fjord Minutes</span>
+    </a>
+
+    <% if development_member_signed_in? %>
+      <div class="block w-auto">
+        <ul class="font-medium flex items-center flex-row p-0 rounded-lg space-x-8 !list-none">
+          <li class="block">
+            <%= link_to '議事録', member_signed_in? ? course_minutes_path(current_member.course) : course_minutes_path(Course.first) %>
+          </li>
+          <li class="block">
+            <%= link_to 'メンバー', member_signed_in? ? course_members_path(current_member.course) : course_members_path(Course.first) %>
+          </li>
+          <li class="block">
+            <a href="/" class="navbar_item">
+              <%= image_tag(current_development_member.avatar_url, class: "w-8 h-8 rounded-full") %>
+            </a>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+  </div>
+</nav>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <nav id="header" class="bg-white border-gray-200 border-b-2">
-  <div class="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
+  <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto p-4">
     <a href="/" class="flex items-center space-x-3">
       <span class="self-center text-2xl font-semibold whitespace-nowrap">Fjord Minutes</span>
     </a>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,7 +15,7 @@
           </li>
           <li class="block">
             <a href="/" class="navbar_item">
-              <%= image_tag(current_development_member.avatar_url, class: "w-8 h-8 rounded-full") %>
+              <%= image_tag(current_development_member.avatar_url, alt: 'ログインしているユーザーの画像', class: "w-8 h-8 rounded-full") %>
             </a>
           </li>
         </ul>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<nav id="header" class="bg-white border-gray-200 border-b-2">
+<nav id="header" class="border-b-2 border-gray-200">
   <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto p-4">
     <a href="/" class="flex items-center space-x-3">
       <span class="self-center text-2xl font-semibold whitespace-nowrap">Fjord Minutes</span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,8 @@
   </head>
 
   <body>
-    <main class="container mx-auto mt-12 px-5 max-w-5xl">
+    <%= render 'layouts/header' %>
+    <main class="container mx-auto mt-5 px-5 max-w-5xl">
       <%= render 'layouts/flash' %>
       <%= yield %>
     </main>

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -13,24 +13,39 @@ RSpec.describe 'Homes', type: :system do
     expect(page).to have_button 'フロントエンドエンジニアコースでログイン'
   end
 
-  scenario 'header content changes whether the member logged in' do
-    member = FactoryBot.create(:member)
+  context 'with header' do
+    scenario 'header content changes whether the member logged in' do
+      member = FactoryBot.create(:member)
 
-    visit root_path
-    within('nav#header') do
-      expect(page).to have_link 'Fjord Minutes', href: root_path
-      expect(page).not_to have_link '議事録', href: course_minutes_path(member.course)
-      expect(page).not_to have_link 'メンバー', href: course_members_path(member.course)
-      expect(page).not_to have_selector("img[src$='#{member.avatar_url}']")
+      visit root_path
+      within('nav#header') do
+        expect(page).to have_link 'Fjord Minutes', href: root_path
+        expect(page).not_to have_link '議事録', href: course_minutes_path(member.course)
+        expect(page).not_to have_link 'メンバー', href: course_members_path(member.course)
+        expect(page).not_to have_selector("img[src$='#{member.avatar_url}']")
+      end
+
+      login_as member
+      visit root_path
+      within('nav#header') do
+        expect(page).to have_link 'Fjord Minutes', href: root_path
+        expect(page).to have_link '議事録', href: course_minutes_path(member.course)
+        expect(page).to have_link 'メンバー', href: course_members_path(member.course)
+        expect(page).to have_selector("img[src$='#{member.avatar_url}']")
+      end
     end
 
-    login_as member
-    visit root_path
-    within('nav#header') do
-      expect(page).to have_link 'Fjord Minutes', href: root_path
-      expect(page).to have_link '議事録', href: course_minutes_path(member.course)
-      expect(page).to have_link 'メンバー', href: course_members_path(member.course)
-      expect(page).to have_selector("img[src$='#{member.avatar_url}']")
+    scenario "admin's header displays the links to first course minutes and first course members" do
+      first_course = FactoryBot.create(:rails_course)
+      second_course = FactoryBot.create(:front_end_course)
+      admin = FactoryBot.create(:admin)
+      login_as_admin admin
+      within('nav#header') do
+        expect(page).to have_link '議事録', href: course_minutes_path(first_course)
+        expect(page).to have_link 'メンバー', href: course_members_path(first_course)
+        expect(page).not_to have_link '議事録', href: course_minutes_path(second_course)
+        expect(page).not_to have_link 'メンバー', href: course_members_path(second_course)
+      end
     end
   end
 end

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -12,4 +12,25 @@ RSpec.describe 'Homes', type: :system do
     expect(page).to have_button 'Railsエンジニアコースでログイン'
     expect(page).to have_button 'フロントエンドエンジニアコースでログイン'
   end
+
+  scenario 'header content changes whether the member logged in' do
+    member = FactoryBot.create(:member)
+
+    visit root_path
+    within('nav#header') do
+      expect(page).to have_link 'Fjord Minutes', href: root_path
+      expect(page).not_to have_link '議事録', href: course_minutes_path(member.course)
+      expect(page).not_to have_link 'メンバー', href: course_members_path(member.course)
+      expect(page).not_to have_selector("img[src$='#{member.avatar_url}']")
+    end
+
+    login_as member
+    visit root_path
+    within('nav#header') do
+      expect(page).to have_link 'Fjord Minutes', href: root_path
+      expect(page).to have_link '議事録', href: course_minutes_path(member.course)
+      expect(page).to have_link 'メンバー', href: course_members_path(member.course)
+      expect(page).to have_selector("img[src$='#{member.avatar_url}']")
+    end
+  end
 end


### PR DESCRIPTION
## Issue
- #169 

## 概要
アプリにヘッダーを追加した。
非ログイン時とログイン時で表示が変わるようになっている。

## Screenshot
- 非ログイン時

![733EF10E-DC21-48F5-8D11-7CC097C75275](https://github.com/user-attachments/assets/2d81195c-8da2-4266-8a83-e9c2346cb14d)


- ログイン時

![01DF49F6-A82B-44DC-80EF-7C5A6416CF75](https://github.com/user-attachments/assets/52f2c27d-5278-400a-ae79-a32c365b6427)

## 備考

左側に表示している`Fjord Minutes`の文字列は暫定的なもので、サービスのロゴが完成次第サービスのロゴを表示するようにする。

