### PR TITLE
議事録編集ページの話題にしたいこと・心配事に記入例を追加

### DIFF
--- a/app/views/minutes/_topic_example.html.erb
+++ b/app/views/minutes/_topic_example.html.erb
@@ -1,0 +1,41 @@
+<div class="text-sm p-4 bg-yellow-50 rounded relative">
+  <svg class="w-6 h-6 text-yellow-300 dark:text-white absolute top-1 left-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+    <path fill-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm11-4a1 1 0 1 0-2 0v5a1 1 0 1 0 2 0V8Zm-1 7a1 1 0 1 0 0 2h.01a1 1 0 1 0 0-2H12Z" clip-rule="evenodd" />
+  </svg>
+  <ul class="!mb-0">
+    <li class="text-yellow-500">
+      <span class="font-bold">こうしたら作業がうまく進んだ</span>
+      <ul>
+        <li class="text-yellow-500">モブプロをやってみたら自分が知らない知識を得ることができて、とても勉強になりました！</li>
+        <li class="text-yellow-500">⚪︎⚪︎のリファレンスとても参考になりました、おすすめです〜</li>
+      </ul>
+    </li>
+    <li class="text-yellow-500">
+      <span class="text-yellow-500 font-bold">作業のここがうまくいかなかった</span>
+      <ul>
+        <li class="text-yellow-500">コードの理解に時間がかかりました。コードを読むときに気をつけていることがあれば教えて欲しいです</li>
+        <li>⚪︎⚪︎について調べていたが、あまり情報を見つけることができませんでした。検索方法や対象についてアドバイスが欲しいです</li>
+      </ul>
+    </li>
+    <li class="text-yellow-500">
+      <span class="text-yellow-500 font-bold">発生している問題</span>
+      <ul>
+        <li class="text-yellow-500">CIでテストが落ちてしまいます。皆さんはいかがでしょうか？</li>
+      </ul>
+    </li>
+    <li class="text-yellow-500">
+      <span class="text-yellow-500 font-bold">チームメンバーの良かったところ・チームメンバーに対する感謝</span>
+      <ul>
+        <li class="text-yellow-500">⚪︎⚪︎さんのコードのここが勉強になりました！/⚪︎⚪︎さんのレビューのここが参考になりました！</li>
+        <li class="text-yellow-500">詰まっていた箇所を一緒にペアプロしてくださった⚪︎⚪︎さんに感謝です</li>
+      </ul>
+    </li>
+    <li class="text-yellow-500">
+      <span class="text-yellow-500 font-bold">技術的な関心ごと・イベント</span>
+      <ul>
+        <li class="text-yellow-500">Railsの次のバージョンについて発表がありました </li>
+        <li class="text-yellow-500">⚪︎⚪︎日に地域.rbイベントが開催されるみたいです！</li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -19,6 +19,9 @@
 
     <h2>話題にしたいこと・心配事</h2>
     <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>
+    <p>例えば次のようなことを話します。ちょっとしたことでもいいので、気になったことがあれば書き込んでみましょう！</p>
+    <%= render 'topic_example' %>
+
     <%= content_tag :div, id: 'topics', data: { minuteId: @minute.id,
                                                 topics: @topics.as_json(only: [:id, :content, :topicable_id, :topicable_type], include: { topicable: { only: [:name] } }),
                                                 currentDevelopmentMemberId: current_development_member.id,


### PR DESCRIPTION
## Issue
- #114 

## 概要
チームメンバーが話題にしたいこと・心配事を書きやすくなるように、議事録の編集ページに話題にしたいこと・心配事の具体例を追加した。

## Screenshot

![66BF313A-AC1C-49C1-8EDF-8B7811BF23AD](https://github.com/user-attachments/assets/8dba819d-5b1d-46ac-ac53-4135b43b26d1)

## 備考
ふりかえりミーティングでは、スプリントで上手く行ったこととうまくいかなかったことを振り返る。
そのため、以下の項目は必ず必要となる。
- 今週の作業でうまくいったこと
- 今週の作業でうまくいかなかったこと
- プロダクト内で発生している問題

また、複数の本で「チームメンバーの良かったところを見つける・チームメンバーに感謝する」ことが挙げてあったため、以下の項目も追加。
- チームメンバーの良かったところ・チームメンバーに対する感謝

最後に、今までのミーティングでは技術系のイベントについて話されていたため、以下の項目を追加。
- 技術的な関心ごと・イベント

以上の項目について例を挙げるようにした。
この内容に関しては、デザインレビューの際町田さんに確認していただき、変更になる可能性がある。

参考
- [いちばんやさしいアジャイル開発の教本 人気講師が教えるDXを支える開発手法 \- インプレスブックス](https://book.impress.co.jp/books/1119101090)
- [SCRUM BOOT CAMP THE BOOK【増補改訂版】 スクラムチームではじめるアジャイル開発 電子書籍｜翔泳社の本](https://www.shoeisha.co.jp/book/detail/9784798167282)
- [アジャイルサムライ \- 達人出版会](https://tatsu-zine.com/books/agile-samurai-ja/samplepage)
- [アジャイルレトロスペクティブズ　強いチームを育てる「ふりかえり」の手引き \| コンピュータ・一般書,プログラミング・開発,開発技法 \| Ohmsha](https://shop.ohmsha.co.jp/shopdetail/000000001770/)
