### PR TITLE
次回ミーティング開催日が休日だった時の警告メッセージの見た目を変更

### DIFF
--- a/app/javascript/components/NextMeetingDateForm.jsx
+++ b/app/javascript/components/NextMeetingDateForm.jsx
@@ -117,7 +117,7 @@ function NextMeetingDate({ date, setIsEditing, isAdmin }) {
         </button>
       )}
       {isHoliday && (
-        <p className="flex !m-0 pl-2">
+        <p className="flex !m-0 pl-2 py-2 bg-yellow-50 rounded">
           <svg
             className="w-6 h-6 text-yellow-300 dark:text-white inline-block mr-1"
             aria-hidden="true"
@@ -133,7 +133,7 @@ function NextMeetingDate({ date, setIsEditing, isAdmin }) {
               clipRule="evenodd"
             />
           </svg>
-          <span className="underline">
+          <span className="text-yellow-500 font-bold">
             次回開催日は{holidayJP.holidays[date].name}
             です。もしミーティングをお休みにする場合は、開催日を変更しましょう。
           </span>


### PR DESCRIPTION
## Issue
なし

## 概要
議事録編集ページで、次回ミーティング開催日が休日だったときに警告メッセージが表示されるが、その見た目を変更した。
#176 で追加した話題にしたいこと・心配事の記入例と、見た目を揃えるようにしている。

## Screenshot
変更前
![E4E0B446-7AFB-400D-ADD7-11ADB55E7639](https://github.com/user-attachments/assets/eb6059c6-8350-47b1-a211-d56f0121ceec)

変更後
![6DCB795D-8227-4ECF-A59F-C464FCF775D3](https://github.com/user-attachments/assets/93ace5e4-6612-4eb2-8a14-88f24f2d5fd1)





