### PR TITLE
話題にしたいこと・心配事の具体例のスタイルを警告のような見た目から変更

### DIFF
--- a/app/views/minutes/_topic_example.html.erb
+++ b/app/views/minutes/_topic_example.html.erb
@@ -1,40 +1,37 @@
-<div class="text-sm p-4 bg-yellow-50 rounded relative">
-  <svg class="w-6 h-6 text-yellow-300 dark:text-white absolute top-1 left-1" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-    <path fill-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10S2 17.523 2 12Zm11-4a1 1 0 1 0-2 0v5a1 1 0 1 0 2 0V8Zm-1 7a1 1 0 1 0 0 2h.01a1 1 0 1 0 0-2H12Z" clip-rule="evenodd" />
-  </svg>
+<div class="text-sm p-4 bg-green-50 rounded">
   <ul class="!mb-0">
-    <li class="text-yellow-500">
+    <li class="text-green-700">
       <span class="font-bold">こうしたら作業がうまく進んだ</span>
       <ul>
-        <li class="text-yellow-500">モブプロをやってみたら自分が知らない知識を得ることができて、とても勉強になりました！</li>
-        <li class="text-yellow-500">⚪︎⚪︎のリファレンスとても参考になりました、おすすめです〜</li>
+        <li class="text-green-700">モブプロをやってみたら自分が知らない知識を得ることができて、とても勉強になりました！</li>
+        <li class="text-green-700">⚪︎⚪︎のリファレンスとても参考になりました、おすすめです〜</li>
       </ul>
     </li>
-    <li class="text-yellow-500">
-      <span class="text-yellow-500 font-bold">作業のここがうまくいかなかった</span>
+    <li class="text-green-700">
+      <span class="text-green-700 font-bold">作業のここがうまくいかなかった</span>
       <ul>
-        <li class="text-yellow-500">コードの理解に時間がかかりました。コードを読むときに気をつけていることがあれば教えて欲しいです</li>
+        <li class="text-green-700">コードの理解に時間がかかりました。コードを読むときに気をつけていることがあれば教えて欲しいです</li>
         <li>⚪︎⚪︎について調べていたが、あまり情報を見つけることができませんでした。検索方法や対象についてアドバイスが欲しいです</li>
       </ul>
     </li>
-    <li class="text-yellow-500">
-      <span class="text-yellow-500 font-bold">発生している問題</span>
+    <li class="text-green-700">
+      <span class="text-green-700 font-bold">発生している問題</span>
       <ul>
-        <li class="text-yellow-500">CIでテストが落ちてしまいます。皆さんはいかがでしょうか？</li>
+        <li class="text-green-700">CIでテストが落ちてしまいます。皆さんはいかがでしょうか？</li>
       </ul>
     </li>
-    <li class="text-yellow-500">
-      <span class="text-yellow-500 font-bold">チームメンバーの良かったところ・チームメンバーに対する感謝</span>
+    <li class="text-green-700">
+      <span class="text-green-700 font-bold">チームメンバーの良かったところ・チームメンバーに対する感謝</span>
       <ul>
-        <li class="text-yellow-500">⚪︎⚪︎さんのコードのここが勉強になりました！/⚪︎⚪︎さんのレビューのここが参考になりました！</li>
-        <li class="text-yellow-500">詰まっていた箇所を一緒にペアプロしてくださった⚪︎⚪︎さんに感謝です</li>
+        <li class="text-green-700">⚪︎⚪︎さんのコードのここが勉強になりました！/⚪︎⚪︎さんのレビューのここが参考になりました！</li>
+        <li class="text-green-700">詰まっていた箇所を一緒にペアプロしてくださった⚪︎⚪︎さんに感謝です</li>
       </ul>
     </li>
-    <li class="text-yellow-500">
-      <span class="text-yellow-500 font-bold">技術的な関心ごと・イベント</span>
+    <li class="text-green-700">
+      <span class="text-green-700 font-bold">技術的な関心ごと・イベント</span>
       <ul>
-        <li class="text-yellow-500">Railsの次のバージョンについて発表がありました </li>
-        <li class="text-yellow-500">⚪︎⚪︎日に地域.rbイベントが開催されるみたいです！</li>
+        <li class="text-green-700">Railsの次のバージョンについて発表がありました </li>
+        <li class="text-green-700">⚪︎⚪︎日に地域.rbイベントが開催されるみたいです！</li>
       </ul>
     </li>
   </ul>


### PR DESCRIPTION
## Issue
- #178 

## 概要
議事録編集ページの話題にしたいこと・心配事の項目には具体例が表示してあるが、見た目が警告文のような見た目であったため、見た目を修正した。

## Screenshot
変更前
![66BF313A-AC1C-49C1-8EDF-8B7811BF23AD_1_105_c](https://github.com/user-attachments/assets/890edd98-67ed-4eba-a1cc-18e4f43f8c28)

変更後
![F2DC3B68-C51F-4637-B215-B211F618A78F](https://github.com/user-attachments/assets/1c7a6e73-f8c6-4fe9-94a0-e5c71632e468)
