### PR TITLE
アプリにメインカラーを反映させた

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -35,16 +35,16 @@
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
     .large_tab_item {
-        @apply inline-block p-4 rounded-t-lg text-gray-500 border border-gray-300 hover:text-gray-600 hover:bg-gray-50;
+        @apply inline-block p-4 rounded-t-lg text-gray-500 border border-b-0 border-gray-300 hover:bg-blue-50 hover:no-underline;
     }
     .active_large_tab_item {
-        @apply inline-block p-4 rounded-t-lg text-white font-bold bg-gray-600 border border-gray-300;
+        @apply inline-block p-4 rounded-t-lg text-white font-bold bg-blue-700 border border-b-0 border-gray-300 hover:no-underline;
     }
     .small_tab_item {
-        @apply inline-block px-4 py-2 text-gray-600 border border-gray-600 rounded-3xl;
+        @apply inline-block px-4 py-2 text-gray-600 border border-gray-300 rounded-3xl hover:bg-blue-50 hover:no-underline;
     }
     .active_small_tab_item {
-        @apply inline-block px-4 py-2 text-white bg-gray-600 border border-gray-600 rounded-3xl;
+        @apply inline-block px-4 py-2 text-white bg-blue-700 border border-gray-300 rounded-3xl hover:no-underline;
     }
     .flash_notice {
         @apply py-2.5 px-4 text-green-500 bg-green-100 mb-5 font-medium rounded-lg inline-block;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -25,8 +25,14 @@
     .button {
         @apply text-white bg-blue-700 hover:bg-blue-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
     }
+    .button_cancel {
+        @apply inline-block text-blue-700 hover:bg-blue-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-blue-700;
+    }
     .button_danger {
         @apply text-white bg-red-700 hover:bg-red-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
+    }
+    .button_danger_cancel {
+        @apply inline-block text-red-700 hover:bg-red-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-red-700;
     }
     .input_type_text {
         @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -23,10 +23,10 @@
         display: inline;
     }
     .button {
-        @apply text-white bg-blue-600 hover:bg-blue-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
+        @apply text-white bg-blue-700 hover:bg-blue-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
     }
     .button_danger {
-        @apply text-white bg-red-600 hover:bg-red-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
+        @apply text-white bg-red-700 hover:bg-red-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
     }
     .input_type_text {
         @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;

--- a/app/javascript/components/HibernationButton.jsx
+++ b/app/javascript/components/HibernationButton.jsx
@@ -27,7 +27,7 @@ export default function HibernationButton({ member_id, member_name }) {
             <div>
               <SubmitForm memberId={member_id} />
               <button
-                className="inline-block text-red-600 hover:bg-red-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-red-600"
+                className="button_danger_cancel"
                 onClick={() => setOpenModal(false)}
               >
                 キャンセル

--- a/app/javascript/components/LogoutButton.jsx
+++ b/app/javascript/components/LogoutButton.jsx
@@ -31,7 +31,7 @@ export default function LogoutButton() {
             <div className="text-center">
               <SubmitForm />
               <button
-                className="inline-block text-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-blue-600"
+                className="button_cancel"
                 onClick={() => setOpenModal(false)}
               >
                 キャンセル

--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -30,13 +30,13 @@ const customTheme = {
   base: 'flex flex-col gap-2',
   tablist: {
     tabitem: {
-      base: 'flex items-center justify-center rounded-t-lg p-4 text-sm font-medium first:ml-0 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:cursor-not-allowed',
+      base: 'flex items-center justify-center rounded-t-lg p-4 me-2 border border-b-0 border-gray-300 text-sm font-medium',
       variant: {
         default: {
           base: 'rounded-t-lg',
           active: {
-            on: 'bg-gray-400 text-white dark:bg-gray-800 dark:text-cyan-500',
-            off: 'text-gray-500 hover:bg-gray-50 hover:text-gray-600 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-300',
+            on: 'bg-blue-700 text-white font-bold',
+            off: 'text-gray-500 hover:bg-blue-50',
           },
         },
       },

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1 class="font-bold text-4xl">Fjord Minutes</h1>
+  <h1 class="font-bold text-4xl text-blue-700">Fjord Minutes</h1>
   <p>フィヨルドブートキャンプのチーム開発プラクティスで行われているミーティングの議事録を作成するアプリケーションです。</p>
 
   <div class="flex justify-center my-4">

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <nav id="header" class="border-b-2 border-gray-200">
   <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto p-4">
-    <a href="/" class="flex items-center space-x-3">
+    <a href="/" class="flex items-center space-x-3 !text-blue-700">
       <span class="self-center text-2xl font-semibold whitespace-nowrap">Fjord Minutes</span>
     </a>
 


### PR DESCRIPTION
## Issue
- #3 

## 概要
アプリのメインカラー・アクセントカラーを、タブやボタン等に反映させた。
今回色を適用したのは以下の通り。

- トップページのアプリ名
- ヘッダー左上のアプリ名
- ボタン
- 議事録一覧ページ・メンバー一覧ページのコース選択タブ
- 議事録一覧ページの年選択タブ
- メンバー一覧ページの活動中/休止中選択タブ
- 議事録詳細ページのMarkdown・Preview選択タブ

## Screenshot
- トップページ

![4A66A9BD-C1B2-4D32-A461-F5B53BCB94D3](https://github.com/user-attachments/assets/8fb8be6d-02de-4bd4-8d80-672762c96f5f)

- 議事録一覧ページ・メンバー一覧ページ(同じタブを使用)

![3AF5502A-B9E8-4DC3-AC90-F612BD9D2C1C](https://github.com/user-attachments/assets/23e44c2e-f095-4869-b2e6-f0548e7fb495)

- 議事録詳細ページ

![893FFD79-6984-4469-B6EB-AAB3D6433DC2](https://github.com/user-attachments/assets/9296d56a-be2b-4b8b-920e-2c1400806b10)

- ボタン

![953E4718-2059-4ED2-B6C5-8E249EFCF0F9](https://github.com/user-attachments/assets/03715129-2382-45f9-ad95-3578721e014d)

- 危険なボタン

![B240DE06-F546-4069-9C53-C6EBCFC27D67](https://github.com/user-attachments/assets/63aa6e09-7ac5-4573-b487-46df1fff1f14)

## 備考
議事録一覧ページとメンバー一覧ページのタブに、以下の修正も行っている。
- コース選択タブの、各タブのborder-bottomを削除
- タブ選択時のアンダーラインを削除
- 年選択タブ・活動中/休止中選択タブのborderの色を、コース選択タブと統一した

