### PR TITLE
トップページにデザインを追加

### DIFF
--- a/app/views/home/_developer_login_button.html.erb
+++ b/app/views/home/_developer_login_button.html.erb
@@ -1,0 +1,7 @@
+<div class="flex justify-center mt-12">
+  <% Course.all.each do |course| %>
+    <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
+      <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mx-10"><%= course.name %>でログイン(開発環境用)</button>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -39,12 +39,6 @@
   </p>
 
   <% if Rails.env.development? %>
-    <div class="flex justify-center mt-12">
-      <% Course.all.each do |course| %>
-        <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-          <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mx-10"><%= course.name %>でログイン(開発環境用)</button>
-        <% end %>
-      <% end %>
-    </div>
+    <%= render 'developer_login_button' %>
   <% end %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,23 +1,48 @@
 <div>
-  <h1 class="font-bold text-4xl text-blue-700">Fjord Minutes</h1>
-  <p>フィヨルドブートキャンプのチーム開発プラクティスで行われているミーティングの議事録を作成するアプリケーションです。</p>
+  <h1 class="font-bold text-2xl text-center my-12">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理でより効率的に</h1>
 
-  <div class="flex justify-center my-4">
+  <div class="flex justify-evenly mb-12">
+    <div class="py-4 border border-gray-400 rounded-md w-72 flex flex-col items-center">
+      <svg class="w-20 h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 5V4a1 1 0 0 0-1-1H8.914a1 1 0 0 0-.707.293L4.293 7.207A1 1 0 0 0 4 7.914V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-5M9 3v4a1 1 0 0 1-1 1H4m11.383.772 2.745 2.746m1.215-3.906a2.089 2.089 0 0 1 0 2.953l-6.65 6.646L9 17.95l.739-3.692 6.646-6.646a2.087 2.087 0 0 1 2.958 0Z" />
+      </svg>
+      <p class="mt-2">議事録を自動で作成</p>
+    </div>
+    <div class="py-4 border border-gray-400 rounded-md w-72 flex flex-col items-center">
+      <svg class="w-20 h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 10V4a1 1 0 0 0-1-1H9.914a1 1 0 0 0-.707.293L5.293 7.207A1 1 0 0 0 5 7.914V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2M10 3v4a1 1 0 0 1-1 1H5m5 6h9m0 0-2-2m2 2-2 2" />
+      </svg>
+      <p class="text-center mt-2">議事録の内容からMarkdownを<br>作成し、GitHub Wikiに出力</p>
+    </div>
+    <div class="py-4 border border-gray-400 rounded-md w-72 flex flex-col items-center">
+      <svg class="w-20 h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z" />
+      </svg>
+      <p class="text-center mt-2">チームメンバーのミーティング<br>出席状況を一括表示</p>
+    </div>
+  </div>
+
+  <div class="flex justify-center mb-2">
     <% Course.all.order(id: :asc).each do |course| %>
       <%= form_tag("/auth/github?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-        <button type='submit' class="ml-2 py-1 px-2 border border-black hover:text-white hover:bg-black">
-          <%= "#{course.name}でログイン" %>
+        <button type='submit' class="text-white bg-blue-600 hover:bg-blue-700 font-medium rounded-lg text-sm px-6 py-4 mx-10">
+          <%= "#{course.name}で登録" %>
         </button>
       <% end %>
     <% end %>
   </div>
+  <p class="text-red-700 text-sm text-center">
+    <a href="https://github.com/fjordllc/bootcamp" class="text-red-700">bootcampリポジトリ</a>
+    または
+    <a href="https://github.com/fjordllc/agent" class="text-red-700">agentリポジトリ</a>
+    のコラボレーターの方だけメンバー登録をお願いします。
+  </p>
 
   <% if Rails.env.development? %>
-    <div>
-      <p>Developerでログイン</p>
+    <div class="flex justify-center mt-12">
       <% Course.all.each do |course| %>
         <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-          <button type='submit' class="ml-2 mt-2 py-1 px-2 border border-black hover:text-white hover:bg-black"><%= course.name %></button>
+          <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mx-10"><%= course.name %>でログイン(開発環境用)</button>
         <% end %>
       <% end %>
     </div>

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -7,7 +7,7 @@ module LoginSupport
                                                 email: member.email,
                                                 image: member.avatar_url } })
     visit root_path
-    click_button "#{member.course.name}でログイン"
+    click_button "#{member.course.name}で登録"
   end
 
   def login_as_admin(admin)
@@ -18,7 +18,7 @@ module LoginSupport
                                                 email: admin.email,
                                                 image: admin.avatar_url } })
     visit root_path
-    click_button 'Railsエンジニアコースでログイン'
+    click_button 'Railsエンジニアコースで登録'
   end
 end
 

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Hibernations', type: :system do
     expect(page).to have_content 'ログアウトしました'
     expect(member.reload.hibernated?).to be true
 
-    click_button 'Railsエンジニアコースでログイン'
+    click_button 'Railsエンジニアコースで登録'
     expect(page).to have_content '休止から復帰しました。'
     expect(member.reload.hibernated?).to be false
   end
@@ -33,6 +33,6 @@ RSpec.describe 'Hibernations', type: :system do
     expect(current_path).to eq root_path
     expect(page).to have_content '休会中のメンバーはトップページから再度ログインをお願いします'
     expect(page).not_to have_content 'aliceさんの出席一覧(Railsエンジニアコース)'
-    expect(page).to have_button 'Railsエンジニアコースでログイン'
+    expect(page).to have_button 'Railsエンジニアコースで登録'
   end
 end

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'Homes', type: :system do
     FactoryBot.create(:front_end_course)
 
     visit root_path
-    expect(page).to have_content 'Fjord Minutes'
-    expect(page).to have_button 'Railsエンジニアコースでログイン'
-    expect(page).to have_button 'フロントエンドエンジニアコースでログイン'
+    expect(page).to have_selector 'h1', text: "フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを\n議事録の自動作成と出席管理でより効率的に"
+    expect(page).to have_button 'Railsエンジニアコースで登録'
+    expect(page).to have_button 'フロントエンドエンジニアコースで登録'
   end
 
   context 'with header' do

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'user can log in as member of the Rails course' do
       visit root_path
-      click_button 'Railsエンジニアコースでログイン'
+      click_button 'Railsエンジニアコースで登録'
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: 'aliceさんの出席一覧(Railsエンジニアコース)'
@@ -27,7 +27,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'user can log in as member of the front end course' do
       visit root_path
-      click_button 'フロントエンドエンジニアコースでログイン'
+      click_button 'フロントエンドエンジニアコースで登録'
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: 'aliceさんの出席一覧(フロントエンドエンジニアコース)'
@@ -48,7 +48,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'user can log in as admin' do
       visit root_path
-      click_button 'Railsエンジニアコースでログイン'
+      click_button 'Railsエンジニアコースで登録'
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_content '管理者用のダッシュボード'
@@ -64,7 +64,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'redirect root page when login fails' do
       visit root_path
-      click_button 'Railsエンジニアコースでログイン'
+      click_button 'Railsエンジニアコースで登録'
 
       expect(current_path).to eq root_path
       expect(page).to have_content 'GitHub アカウントによる認証に失敗しました。'


### PR DESCRIPTION
## Issue
- #171 

## 概要
アプリのトップページにデザインを追加した。

## Screenshot
デザイン追加後のトップページ。

![620F03B8-9C6B-4A30-B652-60D00B369056](https://github.com/user-attachments/assets/af675861-4c7d-4e50-bacf-8e2f6a8c4042)

## 備考
開発環境のみ、開発環境用のログインのボタンを表示するようにしている。

![F9A3BF24-C429-475B-A4D7-1732A56E38FA](https://github.com/user-attachments/assets/e4d8abeb-c948-40f1-bd9e-bf3897789057)


