### PR TITLE
管理者のマイページにコース情報を表示するようにした

### DIFF
--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -2,7 +2,7 @@
   <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
 
   <% Course.all.each do |course| %>
-    <div class="mb-10">
+    <div class="mb-10" data-course="<%= course.id %>">
       <h2 class="text-2xl font-bold mb-4"><%= course.name %></h2>
       <p class="mb-2">議事録</p>
       <p class="mb-2 pl-4"><%= link_to "議事録一覧", course_minutes_path(course) %></p>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,12 +1,27 @@
 <div class="w-full">
-  <h1 class="font-bold text-4xl">
-    <%= "管理者用のダッシュボード" %>
-  </h1>
+  <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
 
-  <div>
-    <p><%= Admin.human_attribute_name(:name) %> : <%= current_admin.name %></p>
-    <% if current_admin.avatar_url %>
-      <%= image_tag(current_admin.avatar_url, size: '100x100', alt: '管理者のGitHubアカウントの画像') %>
-    <% end %>
-  </div>
+  <% Course.all.each do |course| %>
+    <div class="mb-10">
+      <h2 class="text-2xl font-bold mb-4"><%= course.name %></h2>
+      <p class="mb-2">議事録</p>
+      <p class="mb-2 pl-4"><%= link_to "議事録一覧", course_minutes_path(course) %></p>
+
+      <p class="mb-2">メンバー</p>
+      <p class="mb-2 pl-4"><%= link_to "所属メンバー一覧", course_members_path(course) %></p>
+
+      <p class="mb-2">ミーティング</p>
+      <p class="mb-2 pl-4">
+        ミーティング開催週 :
+        <span class="font-bold"><%= Course.human_attribute_name("meeting_week.#{course.meeting_week}") %></span>
+      </p>
+      <p class="mb-2 pl-4">次回ミーティングの議事録 :
+        <% if course.minutes.none? %>
+          まだ議事録は作成されていません
+        <% else %>
+          <%= link_to "#{course.minutes.order(:meeting_date).last.title}", edit_minute_path(course.minutes.order(:meeting_date).last) %>
+        <% end %>
+      </p>
+    </div>
+  <% end %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,6 +33,9 @@ ja:
       course:
         name: コース名
         meeting_week: ミーティング開催週
+      course/meeting_week:
+        odd: 奇数週 (第一・第三週)
+        even: 偶数週 (第二・第四週)
       member:
         email: メールアドレス
         password: パスワード

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -48,4 +48,30 @@ RSpec.describe 'Homes', type: :system do
       end
     end
   end
+
+  scenario 'admin dashboard displays the course details' do
+    rails_course = FactoryBot.create(:rails_course)
+    front_end_course = FactoryBot.create(:front_end_course)
+    FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 2), course: rails_course)
+    rails_course_latest_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 16), course: rails_course)
+    FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 9), course: front_end_course)
+    front_end_course_latest_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 23), course: front_end_course)
+
+    admin = FactoryBot.create(:admin)
+    login_as_admin admin
+    visit root_path
+
+    within("div[data-course='#{rails_course.id}']") do
+      expect(page).to have_link '議事録一覧', href: course_minutes_path(rails_course)
+      expect(page).to have_link 'メンバー一覧', href: course_members_path(rails_course)
+      expect(page).to have_content 'ミーティング開催週 : 奇数週 (第一・第三週)'
+      expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月16日', href: edit_minute_path(rails_course_latest_minute)
+    end
+    within("div[data-course='#{front_end_course.id}']") do
+      expect(page).to have_link '議事録一覧', href: course_minutes_path(front_end_course)
+      expect(page).to have_link 'メンバー一覧', href: course_members_path(front_end_course)
+      expect(page).to have_content 'ミーティング開催週 : 偶数週 (第二・第四週)'
+      expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月23日', href: edit_minute_path(front_end_course_latest_minute)
+    end
+  end
 end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       click_button 'Railsエンジニアコースで登録'
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
-      expect(page).to have_content '管理者用のダッシュボード'
-      expect(page).to have_content '名前 : kassy0220'
+      expect(page).to have_selector 'h1', text: '管理ページ'
     end
   end
 


### PR DESCRIPTION
## Issue
- #170 

## 概要
管理者のマイページ(`/`)には、各コースの情報を表示するようにした。
コースごとに以下を表示するようにしている。

- コースの議事録一覧に遷移できるリンク
- コースのメンバー一覧に遷移できるリンク
- コースのミーティング開催週
- コースの最新の議事録の編集画面に遷移できるリンク

## Screenshot

![A245BC3C-E11A-42B3-A89A-4ABC20125570](https://github.com/user-attachments/assets/2a1d1e14-d1b0-4bb7-80ec-c306360de6a1)



