### PR TITLE
ユーザーの状態名を変更

### DIFF
--- a/app/controllers/members/hibernations_controller.rb
+++ b/app/controllers/members/hibernations_controller.rb
@@ -6,7 +6,7 @@ class Members::HibernationsController < Members::ApplicationController
 
   def create
     @member.hibernations.create!
-    redirect_to course_members_path(@member.course, status: 'hibernated'), notice: "#{@member.name}を休止中にしました"
+    redirect_to course_members_path(@member.course, status: 'hibernated'), notice: "#{@member.name}をチームメンバーから外しました"
   end
 
   private
@@ -14,6 +14,6 @@ class Members::HibernationsController < Members::ApplicationController
   def prohibit_duplicate_hibernations
     return unless @member.hibernated?
 
-    redirect_to course_members_path(@member.course, status: 'hibernated'), alert: "#{@member.name}さんはすでに休止中です"
+    redirect_to course_members_path(@member.course, status: 'hibernated'), alert: "#{@member.name}さんはすでにチームメンバーから外れています"
   end
 end

--- a/app/javascript/components/AllAttendanceTable.jsx
+++ b/app/javascript/components/AllAttendanceTable.jsx
@@ -9,7 +9,7 @@ export default function AllAttendanceTable({ attendances }) {
       {attendancesPerYear.map((annualAttendances) => (
         <div
           key={annualAttendances.year}
-          className="my-8"
+          className="mb-8"
           data-meeting-year={annualAttendances.year}
         >
           <p className="mb-2 text-xl">{annualAttendances.year}年</p>

--- a/app/javascript/components/HibernationButton.jsx
+++ b/app/javascript/components/HibernationButton.jsx
@@ -11,7 +11,7 @@ export default function HibernationButton({ member_id, member_name }) {
         className="button_danger open_modal"
         onClick={() => setOpenModal(true)}
       >
-        休止中にする
+        チームメンバーから外す
       </button>
       <Modal
         show={openModal}
@@ -22,7 +22,9 @@ export default function HibernationButton({ member_id, member_name }) {
         <ModalBody>
           <div className="text-center">
             <p className="my-8 text-xl">
-              {member_name}さんを休止中にします。よろしいですか？
+              {member_name}さんをチームメンバーから外します。
+              <br />
+              よろしいですか？
             </p>
             <div>
               <SubmitForm memberId={member_id} />
@@ -66,7 +68,7 @@ function SubmitForm({ memberId }) {
       />
       <input
         type="submit"
-        value="休止中にする"
+        value="チームメンバーから外す"
         id="accept_modal"
         className="button_danger"
       />

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -2,10 +2,10 @@
   <% if course.members.any? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
       <li class="me-2">
-        <%= link_to '活動中', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'small_tab_item' %>
+        <%= link_to '現役', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'small_tab_item' %>
       </li>
       <li class="me-2">
-        <%= link_to '休止中', course_members_path(course, status: 'hibernated'), class: active_tab == 'hibernated' ? 'active_small_tab_item' : 'small_tab_item' %>
+        <%= link_to '休会', course_members_path(course, status: 'hibernated'), class: active_tab == 'hibernated' ? 'active_small_tab_item' : 'small_tab_item' %>
       </li>
     </ul>
   <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -19,7 +19,7 @@
               <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>
             <% end %>
             <% if member.hibernated? %>
-              <p class="mt-2 text-sm"><%= member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休止中</p>
+              <p class="mt-2 text-sm"><%= member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休会</p>
             <% end %>
             <%= content_tag :div, class: 'recent_attendances mt-4', data: {attendances: member.all_attendances.pop(12)}.to_json do %><% end %>
           </li>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,9 +1,14 @@
 <div class="w-full">
-  <h1 class="font-bold text-4xl">
+  <h1 class="font-bold text-4xl mb-8">
     <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>
   </h1>
 
-  <%= content_tag :div, id: 'all_attendance_table', class: "my-8", data: {attendances: @member.all_attendances}.to_json do %><% end %>
+  <div class="mb-8">
+    <% if @member.hibernated? %>
+      <p class="mb-2"><%= @member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休会</p>
+    <% end %>
+    <%= content_tag :div, id: 'all_attendance_table', data: {attendances: @member.all_attendances}.to_json do %><% end %>
+  </div>
 
   <% if @member == current_development_member %>
     <div class="mt-4 text-center">

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -142,4 +142,4 @@ ja:
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
-      hibernated_member_access: 休会中のメンバーはトップページから再度ログインをお願いします
+      hibernated_member_access: チームメンバーから外れているため、再度ログインをお願いします。

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -75,7 +75,7 @@ ja:
     omniauth_callbacks:
       failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
       success: "%{kind} アカウントによる認証に成功しました。"
-      success_with_hibernation: "休止から復帰しました。"
+      success_with_hibernation: "チーム開発に復帰しました。"
     passwords:
       edit:
         change_my_password: パスワードを変更する

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Hibernations', type: :system do
 
     visit course_members_path(rails_course)
     expect(current_path).to eq root_path
-    expect(page).to have_content '休会中のメンバーはトップページから再度ログインをお願いします'
+    expect(page).to have_content 'チームメンバーから外れているため、再度ログインをお願いします。'
     expect(page).not_to have_content 'aliceさんの出席一覧(Railsエンジニアコース)'
     expect(page).to have_button 'Railsエンジニアコースで登録'
   end

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Hibernations', type: :system do
     expect(member.reload.hibernated?).to be true
 
     click_button 'Railsエンジニアコースで登録'
-    expect(page).to have_content '休止から復帰しました。'
+    expect(page).to have_content 'チーム開発に復帰しました。'
     expect(member.reload.hibernated?).to be false
   end
 

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -200,14 +200,14 @@ RSpec.describe 'Members', type: :system do
       admin = FactoryBot.create(:admin)
       login_as_admin admin
       visit course_members_path(rails_course)
-      expect(page).to have_link '活動中'
-      expect(page).to have_link '休止中'
+      expect(page).to have_link '現役', href: course_members_path(rails_course, status: 'active')
+      expect(page).to have_link '休会', href: course_members_path(rails_course, status: 'hibernated')
 
-      click_link '休止中'
+      click_link '休会'
       expect(page).to have_content 'alice'
       expect(page).to have_content '2025/01/01から休止中'
 
-      click_link '活動中'
+      click_link '現役'
       expect(page).not_to have_content 'alice'
     end
 
@@ -217,8 +217,8 @@ RSpec.describe 'Members', type: :system do
       another_member = FactoryBot.create(:member, :another_member, course: rails_course)
       login_as another_member
       visit course_members_path(rails_course)
-      expect(page).not_to have_link '活動中', href: course_members_path(rails_course, status: 'active')
-      expect(page).not_to have_link '休止中', href: course_members_path(rails_course, status: 'hibernated')
+      expect(page).not_to have_link '現役', href: course_members_path(rails_course, status: 'active')
+      expect(page).not_to have_link '休会', href: course_members_path(rails_course, status: 'hibernated')
       expect(page).not_to have_content 'alice'
 
       visit course_members_path(rails_course, status: 'hibernated')

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -232,14 +232,14 @@ RSpec.describe 'Members', type: :system do
       expect do
         within("li[data-member='#{member.id}']") do
           expect(page).to have_content 'alice'
-          expect(page).to have_selector 'button.open_modal', text: '休止中にする'
-          click_button '休止中にする'
+          expect(page).to have_selector 'button.open_modal', text: 'チームメンバーから外す'
+          click_button 'チームメンバーから外す'
         end
         find('#accept_modal').click
       end.to change(member.hibernations, :count).by(1)
       # expect(current_page)だとクエリ部分が無視されてしまうため、expect(page).to have_current_pathでテストする
       expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
-      expect(page).to have_content 'aliceを休止中にしました'
+      expect(page).to have_content 'aliceをチームメンバーから外しました'
       expect(page).to have_content 'alice'
       expect(page).to have_content "#{Time.zone.today.strftime('%Y/%m/%d')}から休止中"
     end
@@ -252,12 +252,12 @@ RSpec.describe 'Members', type: :system do
       FactoryBot.create(:hibernation, member:)
       expect do
         within("li[data-member='#{member.id}']") do
-          click_button '休止中にする'
+          click_button 'チームメンバーから外す'
         end
         find('#accept_modal').click
       end.not_to change(member.hibernations, :count)
       expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
-      expect(page).to have_content 'aliceさんはすでに休止中です'
+      expect(page).to have_content 'aliceさんはすでにチームメンバーから外れています'
     end
   end
 end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe 'Members', type: :system do
 
       click_link '休会'
       expect(page).to have_content 'alice'
-      expect(page).to have_content '2025/01/01から休止中'
+      expect(page).to have_content '2025/01/01から休会'
 
       click_link '現役'
       expect(page).not_to have_content 'alice'
@@ -241,7 +241,7 @@ RSpec.describe 'Members', type: :system do
       expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
       expect(page).to have_content 'aliceをチームメンバーから外しました'
       expect(page).to have_content 'alice'
-      expect(page).to have_content "#{Time.zone.today.strftime('%Y/%m/%d')}から休止中"
+      expect(page).to have_content "#{Time.zone.today.strftime('%Y/%m/%d')}から休会"
     end
 
     scenario 'admin cannot make member hibernated who already hibernated' do


### PR DESCRIPTION
## Issue
- #188 

## 概要
ユーザーの状態を表す表現を、bootcampアプリと同じになるようにした。

| 変更前 | 変更後 | 
| ------ | ------ | 
| 活動中 | 現役   | 
| 休止中 | 休会   | 

## Screenshot
- メンバー一覧ページの切り替えボタン
- チームメンバーから外すボタン

![45F4F21E-B675-469E-BA08-C28C1AFDBAFA](https://github.com/user-attachments/assets/074c20df-db9d-4327-91f6-53583347593f)

- チームメンバーから外すボタンをクリック時のダイアログ

![A181B224-C323-4C8E-8449-03993058102E](https://github.com/user-attachments/assets/42331a5b-93a4-4d55-beff-354db70c1626)

- チームメンバー一覧ページ・詳細ページに表示している、休会開始日
  - チームメンバー詳細ページに休会開始日を表示するように、このPRで追加している

![DAE0DA4D-066D-4385-A03B-9FCECD2EE59E](https://github.com/user-attachments/assets/54ac19ea-5d26-4a06-8ec2-6db263967c5d)

![6FBE0B14-4D0E-4E29-857C-6B696125AE19](https://github.com/user-attachments/assets/bdda397d-bd2d-4144-8446-08c7f3cdb988)

- メンバーをチームメンバーから外した時のメッセージ
- メンバーをチームメンバーを外した際、すでに外れていた場合のメッセージ

![B540659E-A018-4825-A8E6-DFC7B67444A3_4_5005_c](https://github.com/user-attachments/assets/ec6852d4-940a-456d-a9f3-ace666deb545)

![B9FEAA8F-F995-410A-967E-C9C49D0D18C5_4_5005_c](https://github.com/user-attachments/assets/9eb1557b-8970-4036-9dc3-fe0459824607)

- チームメンバーから外れている状態で、アプリにアクセスした時のメッセージ

![F9F6A132-EE7E-4FC9-A02B-71AE1B3B611B_4_5005_c](https://github.com/user-attachments/assets/5de17d5a-538b-48c5-b3b9-8e3a073d68fe)

- チームメンバーから外れている状態で、ログインを行った時のメッセージ

![039B1037-DE4D-44F2-84C9-10E1EFB0AAB9_4_5005_c](https://github.com/user-attachments/assets/c08dfeb0-b134-4017-bfac-d6fd366528e2)

