### PR TITLE
チームメンバー一覧ページでメンバー表示を変更した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -58,4 +58,10 @@
     .flash_alert {
         @apply py-2.5 px-4 text-red-500 bg-red-100 mb-5 font-medium rounded-lg inline-block;
     }
+    .member_icon {
+        @apply w-12 h-12 inline-block rounded-full border-2 border-green-400;
+    }
+    .inactive_member_icon {
+        @apply w-12 h-12 inline-block rounded-full border-2 border-red-400;
+    }
 }

--- a/app/controllers/courses/members_controller.rb
+++ b/app/controllers/courses/members_controller.rb
@@ -2,7 +2,7 @@
 
 class Courses::MembersController < Courses::ApplicationController
   def index
-    members = params[:status] == 'hibernated' ? Member.hibernated : Member.active
+    members = params[:status] == 'all' ? Member.all : Member.active
     members = Member.active unless admin_signed_in?
     @members = members.where(course: @course).order(:created_at)
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -11,7 +11,7 @@ class Member < ApplicationRecord
   has_many :topics, as: :topicable, dependent: :destroy
   has_many :hibernations, dependent: :destroy
 
-  scope :active, -> { where.not(id: hibernated.pluck(:id)) }
+  scope :active, -> { where.not('EXISTS(SELECT 1 FROM hibernations WHERE member_id = members.id AND finished_at IS NULL)') }
   scope :hibernated, -> { joins(:hibernations).where(hibernations: { finished_at: nil }) }
 
   def self.from_omniauth(auth, params)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -12,7 +12,6 @@ class Member < ApplicationRecord
   has_many :hibernations, dependent: :destroy
 
   scope :active, -> { where.not('EXISTS(SELECT 1 FROM hibernations WHERE member_id = members.id AND finished_at IS NULL)') }
-  scope :hibernated, -> { joins(:hibernations).where(hibernations: { finished_at: nil }) }
 
   def self.from_omniauth(auth, params)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |member|

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -5,7 +5,7 @@
         <%= link_to '現役', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'small_tab_item' %>
       </li>
       <li class="me-2">
-        <%= link_to '休会', course_members_path(course, status: 'hibernated'), class: active_tab == 'hibernated' ? 'active_small_tab_item' : 'small_tab_item' %>
+        <%= link_to '全て', course_members_path(course, status: 'all'), class: active_tab == 'all' ? 'active_small_tab_item' : 'small_tab_item' %>
       </li>
     </ul>
   <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -18,9 +18,6 @@
             <% if admin_signed_in? && !member.hibernated? %>
               <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>
             <% end %>
-            <% if member.hibernated? %>
-              <p class="mt-2 text-sm"><%= member.hibernations.last.created_at.strftime('%Y/%m/%d') %>から休会</p>
-            <% end %>
             <%= content_tag :div, class: 'recent_attendances mt-4', data: {attendances: member.all_attendances.pop(12)}.to_json do %><% end %>
           </li>
         <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -13,7 +13,7 @@
       <ul class="list-disc list-inside">
         <% @members.each do |member| %>
           <li class="mb-4" data-member="<%= member.id %>">
-            <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block' %>
+            <%= image_tag member.avatar_url, class: member.hibernated? ? 'inactive_member_icon' : 'member_icon' %>
             <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
             <% if admin_signed_in? && !member.hibernated? %>
               <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -245,7 +245,6 @@ RSpec.describe 'Members', type: :system do
       expect(page).to have_current_path(course_members_path(rails_course, status: 'hibernated'))
       expect(page).to have_content 'aliceをチームメンバーから外しました'
       expect(page).to have_content 'alice'
-      expect(page).to have_content "#{Time.zone.today.strftime('%Y/%m/%d')}から休会"
     end
 
     scenario 'admin cannot make member hibernated who already hibernated' do


### PR DESCRIPTION
## Issue
- #193 

## 概要
メンバー一覧ページで、管理者は以下のユーザー一覧を表示できるようにした。

- 現役のメンバー一覧
- 全てのメンバー(現役 + 休会中のメンバー)一覧

また、メンバーの表示で以下を行っている。
- メンバーがチーム開発にいるかいないかを判別できるように、現役のメンバーのアイコンは緑で、休会中のメンバーのアイコンは赤で囲われる
- 休止した日付を表示しないようにした

## Screenshot

[![Image from Gyazo](https://i.gyazo.com/56df444253f34d0ec115ec6b4e539ba1.gif)](https://gyazo.com/56df444253f34d0ec115ec6b4e539ba1)


