### PR TITLE
休会中の出席は表示しないようにした

### DIFF
--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -51,12 +51,13 @@ RSpec.describe Member, type: :model do
       expect(member.all_attendances).to match_array(october_attendances)
     end
 
-    it 'attendances during hibernation period is treated as hibernation' do
+    it 'does not include attendances during hibernated period' do
       FactoryBot.create(:hibernation, finished_at: Time.zone.local(2024, 11, 30), member:, created_at: Time.zone.local(2024, 11, 1))
 
-      attendance_during_hibernation = { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), status: 'hibernation', time: nil,
-                                        absence_reason: nil }
-      expect(member.all_attendances).to include(attendance_during_hibernation)
+      attendances_dates = member.all_attendances.pluck(:date)
+      expect(attendances_dates).to include(Date.new(2024, 10, 2))
+      expect(attendances_dates).to include(Date.new(2024, 10, 16))
+      expect(attendances_dates).not_to include(Date.new(2024, 11, 1))
     end
   end
 end

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -111,17 +111,16 @@ RSpec.describe 'Members', type: :system do
         expect(page).not_to have_selector 'span[data-table-head="2025-02-05"]', text: '02/15'
       end
 
-      scenario 'display attendances as hibernation during the period member was hibernated', :js do
+      scenario 'does not display attendances during the hibernated period', :js do
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 15), course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 2, 5), course: rails_course)
         FactoryBot.create(:hibernation, finished_at: Time.zone.local(2025, 1, 31), member:, created_at: Time.zone.local(2025, 1, 1))
 
         visit member_path(member)
-        expect(page).to have_selector 'span[data-table-head="2025-01-01"]', text: '01/01'
-        expect(page).to have_selector 'span[data-table-data="2025-01-01"]', text: '休止'
-        expect(page).to have_selector 'span[data-table-head="2025-01-15"]', text: '01/15'
-        expect(page).to have_selector 'span[data-table-data="2025-01-15"]', text: '休止'
+        expect(page).not_to have_selector 'span[data-table-head="2025-01-01"]', text: '01/01'
+        expect(page).not_to have_selector 'span[data-table-head="2025-01-15"]', text: '01/15'
+        expect(page).to have_selector 'span[data-table-head="2025-02-05"]', text: '02/05'
       end
     end
   end


### PR DESCRIPTION
## Issue
- #189 

## 概要
メンバー一覧ページやメンバー詳細ページで表示する出席に関して、休会中の出席は`休止`と表示する仕様だった。
この仕様を変更し、休会中の出席は表示しないようにした。

## Screenshot
### メンバー一覧ページ
修正前
![C2DBACAC-71C6-4E4C-8873-18AE7CBD8C75_4_5005_c](https://github.com/user-attachments/assets/6fcd295c-f7ff-4330-8876-e4271490bdb4)

修正後

![E74A0CF9-9E9D-4D8D-939E-A30B9A61DF9F_4_5005_c](https://github.com/user-attachments/assets/0627e73d-0f63-4fd5-b9fa-59846cbfc655)

### メンバー詳細ページ
修正前
![DEEFAADC-5D12-44AA-A6EC-17BBFD618854](https://github.com/user-attachments/assets/d3f6fac8-67b4-443d-9a34-434df1906c31)

修正後
![6A94E789-8AC1-47C3-A01E-71F1B8195825](https://github.com/user-attachments/assets/e71a5f81-988f-48fb-bbaf-c4cd53cfe99b)


