### PR TITLE
管理者のダッシュボードで発生しているN+1問題を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
+  gem 'bullet'
   gem 'erb_lint', require: false
   gem 'rubocop', require: false
   gem 'rubocop-fjord', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
     brakeman (6.2.1)
       racc
     builder (3.3.0)
+    bullet (8.0.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -387,6 +390,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
+    uniform_notifier (1.16.0)
     uri (0.13.1)
     useragent (0.16.10)
     version_gem (1.1.4)
@@ -418,6 +422,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
+  bullet
   capybara
   debug
   devise

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,7 @@ class HomeController < ApplicationController
   def index
     if current_development_member
       if admin_login?
+        @courses = Course.includes(:minutes).order(:id)
         render 'admin_dashboard'
       else
         @member = current_development_member

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full">
   <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
 
-  <% Course.all.each do |course| %>
+  <% @courses.each do |course| %>
     <div class="mb-10" data-course="<%= course.id %>">
       <h2 class="text-2xl font-bold mb-4"><%= course.name %></h2>
       <p class="mb-2">議事録</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,5 +21,5 @@ Rails.application.configure do
   config.content_security_policy_nonce_directives = [ "script-src", "style-src" ]
 
   # Report violations without enforcing the policy.
-  # config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = true if Rails.env.development?
 end


### PR DESCRIPTION
## Issue
- #196 

## 概要
管理者のダッシュボードでbulletの警告があったため、N+1問題の修正を行った。

## Screenshot
修正前
[![Image from Gyazo](https://i.gyazo.com/b07fd99a24b075154c3a5aa0e11351ce.gif)](https://gyazo.com/b07fd99a24b075154c3a5aa0e11351ce)

修正後
[![Image from Gyazo](https://i.gyazo.com/bf8523d5e3eee4f284b83531bb7abc83.gif)](https://gyazo.com/bf8523d5e3eee4f284b83531bb7abc83)

## 備考
N+1問題の検知を行うために[bullet](https://github.com/flyerhzm/bullet)をアプリに導入したのだが、bulletのJavaScriptの警告モーダルが表示されない問題が発生した。

(コンソールに表示されたエラーメッセージ)
![8B759E32-3A05-49FF-84D2-5DB257F0485E](https://github.com/user-attachments/assets/3c9d62eb-0ff1-43fe-beaf-a2d6ef2ac7e2)


Content-Security-Policyのscript-srcの設定が原因でこの問題が発生していた。
bulletのIssueで紹介されていた[対処法](https://github.com/flyerhzm/bullet/issues/478)を実行したが問題が解消しなかったため、開発環境では`config.content_security_policy_report_only = true`を設定して、違反があっても報告するだけで強制はしない設定に変更した。

https://railsguides.jp/security.html#%E9%81%95%E5%8F%8D%E3%82%92%E3%83%AC%E3%83%9D%E3%83%BC%E3%83%88%E3%81%99%E3%82%8B
