### PR TITLE
管理者を判別する際Deviseのヘルパーメソッドを利用するように修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,10 +13,6 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def admin_login?
-    development_member_signed_in? && current_development_member.is_a?(Admin)
-  end
-
   def prohibit_hibernated_member_access
     return unless member_signed_in? && current_member.hibernated?
 

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -14,7 +14,7 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
     if @member_or_admin.persisted?
       sign_in_and_redirect @member_or_admin
       remember_me @member_or_admin
-      if @member_or_admin.admin? || !@member_or_admin.hibernated?
+      if admin_signed_in? || !@member_or_admin.hibernated?
         set_flash_message(:notice, :success, kind: 'GitHub')
         return
       end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
 
   def index
     if current_development_member
-      if admin_login?
+      if admin_signed_in?
         @courses = Course.includes(:minutes).order(:id)
         render 'admin_dashboard'
       else

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,14 +4,12 @@ class HomeController < ApplicationController
   skip_before_action :authenticate_development_member!, only: %i[index pp terms_of_service]
 
   def index
-    if current_development_member
-      if admin_signed_in?
-        @courses = Course.includes(:minutes).order(:id)
-        render 'admin_dashboard'
-      else
-        @member = current_development_member
-        render 'members/show'
-      end
+    if admin_signed_in?
+      @courses = Course.includes(:minutes).order(:id)
+      render 'admin_dashboard'
+    elsif member_signed_in?
+      @member = current_development_member
+      render 'members/show'
     else
       render 'index'
     end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -16,8 +16,4 @@ class Admin < ApplicationRecord
       member.password = Devise.friendly_token[0, 20]
     end
   end
-
-  def admin?
-    true
-  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -23,10 +23,6 @@ class Member < ApplicationRecord
     end
   end
 
-  def admin?
-    false
-  end
-
   def hibernated?
     hibernations.where(finished_at: nil).any?
   end

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -5,7 +5,7 @@
     <h1>ふりかえり</h1>
 
     <h2>メンバー</h2>
-    <%= content_tag :div, id: 'attendees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'attendees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: admin_signed_in?}.to_json do %><% end %>
 
     <h2>デモ</h2>
     <p>
@@ -14,8 +14,8 @@
 
     <h2>今週のリリースの確認</h2>
     <p>木曜日の15時頃リリースします。</p>
-    <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: current_development_member.admin?}.to_json do %><% end %>
-    <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: admin_signed_in?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: admin_signed_in?}.to_json do %><% end %>
 
     <h2>話題にしたいこと・心配事</h2>
     <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>
@@ -27,10 +27,10 @@
                                                 currentDevelopmentMemberType: current_development_member.class.name}.to_json do %><% end %>
 
     <h2>その他</h2>
-    <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'other_form', data: {minuteId: @minute.id, content: @minute.other, isAdmin: admin_signed_in?}.to_json do %><% end %>
 
     <h1>次回のMTG</h1>
-    <%= content_tag :div, id: 'next_meeting_date_form', data: {minuteId: @minute.id, nextMeetingDate: @minute.next_meeting_date, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'next_meeting_date_form', data: {minuteId: @minute.id, nextMeetingDate: @minute.next_meeting_date, isAdmin: admin_signed_in?}.to_json do %><% end %>
 
     <h1>計画ミーティング</h1>
     <ul>
@@ -38,10 +38,10 @@
     </ul>
 
     <h1>欠席者</h1>
-    <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: admin_signed_in?}.to_json do %><% end %>
 
     <h2>連絡なし</h2>
-    <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: current_development_member.admin?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: admin_signed_in?}.to_json do %><% end %>
   </div>
 
   <div class="my-8 text-center">

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -4,7 +4,7 @@
 
     <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 
-    <% if current_development_member.admin? %>
+    <% if admin_signed_in? %>
       <%= button_to 'GitHub Wiki にエクスポート', minute_exports_path(@minute), form: { class: 'text-center' },  class: 'button m-auto' %>
     <% end %>
 


### PR DESCRIPTION
## Issue
- #187 

## 概要
管理者でログインしていることはDeviseが提供してくれる`admin_signed_in?`を利用すれば事足りるので、自前で実装していた箇所を削除した。

上記の修正に伴い、`HomeController#index`の条件分岐で冗長な箇所があったので、こちらも一緒に修正している。

