### PR TITLE
API::Minutes::TopicsController内で発生していたN+1問題を修正

### DIFF
--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -37,8 +37,8 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
   end
 
   def broadcast_to_channel
+    topics = Topic.includes(:topicable).where(minute: @minute).order(:created_at)
     MinuteChannel.broadcast_to(@minute,
-                               body: { topics: @minute.topics.order(:created_at).as_json(only: %i[id content topicable_id topicable_type],
-                                                                                         include: { topicable: { only: [:name] } }) })
+                               body: { topics: topics.as_json(only: %i[id content topicable_id topicable_type], include: { topicable: { only: [:name] } }) })
   end
 end


### PR DESCRIPTION
## Issue
- #206 

## 概要
`API::Minutes::TopicsController`内でチャネルに配信を行う際、データの取得に`as_json`を使っているためN+1問題が発生していた。
この問題を回避するため、`includes(:topicable)`で話題にしたいことの作者データをあらかじめ読み込むようにしている。

## Screenshot
修正前
![2CF5454F-7DAC-4683-B7A5-81F868FBD488](https://github.com/user-attachments/assets/37460c06-bd13-45cc-b707-5781c7d2efdf)

修正後
読み込みを`IN`句で行なっており、SQLの実行が一回になっている。
![F626B4F3-B12A-4A40-B622-79F1E351ECE4](https://github.com/user-attachments/assets/898f782f-d824-4379-acba-36c5a1c4a924)



