### PR TITLE
メンバー一覧ページで、離脱中のメンバーはテキストで離脱中と表示するように修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -58,10 +58,4 @@
     .flash_alert {
         @apply py-2.5 px-4 text-red-500 bg-red-100 mb-5 font-medium rounded-lg inline-block;
     }
-    .member_icon {
-        @apply w-12 h-12 inline-block rounded-full border-2 border-green-400;
-    }
-    .inactive_member_icon {
-        @apply w-12 h-12 inline-block rounded-full border-2 border-red-400;
-    }
 }

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -15,6 +15,9 @@
           <li class="mb-4" data-member="<%= member.id %>">
             <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
             <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
+            <% if member.hibernated? %>
+              <span class="text-sm text-gray-500">離脱中</span>
+            <% end %>
             <% if admin_signed_in? && !member.hibernated? %>
               <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>
             <% end %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -13,7 +13,7 @@
       <ul class="list-disc list-inside">
         <% @members.each do |member| %>
           <li class="mb-4" data-member="<%= member.id %>">
-            <%= image_tag member.avatar_url, class: member.hibernated? ? 'inactive_member_icon' : 'member_icon' %>
+            <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
             <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
             <% if admin_signed_in? && !member.hibernated? %>
               <%= content_tag :div, class: 'hibernation_button inline-block', data: {member_id: member.id, member_name: member.name}.to_json do %><% end %>

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -209,7 +209,10 @@ RSpec.describe 'Members', type: :system do
 
       click_link '全て'
       expect(page).to have_content 'alice'
-      expect(page).to have_content hibernated_member.name
+      within("li[data-member='#{hibernated_member.id}']") do
+        expect(page).to have_content hibernated_member.name
+        expect(page).to have_content '離脱中'
+      end
     end
 
     scenario 'member can view only active member' do


### PR DESCRIPTION
## Issue
- #207 

## 概要
メンバー一覧ページで、メンバーの表示を以下の様に修正した。

修正前
- 現役のメンバーは、アイコンを緑の枠線で囲う
- 離脱中のメンバーは、アイコンを赤の枠線で囲う

修正後
- 全てのメンバーのアイコンを灰色の枠線で囲う(アイコンの見やすさのため)
- 離脱中のメンバーは、メンバー名の隣に`離脱中`と表示

## Screenshot
修正前
![F564D574-DC19-4194-A173-8C1B4CB99FF3](https://github.com/user-attachments/assets/a522cc8b-89cf-4a0b-bfe9-06b60fc84f9c)

修正後
![09A28E92-808E-4D5F-83FD-0189CA6D43DE](https://github.com/user-attachments/assets/399639b4-894f-4d93-8a49-dbd68dd3bf2d)

