### PR TITLE
議事録詳細ページのタブの見た目を他のページと同じになるように変更

### DIFF
--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -1,47 +1,61 @@
-import { Tabs } from 'flowbite-react'
+import { useState } from 'react'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 
 export default function MinutePreview({ markdown }) {
+  const [selectedTab, setSelectedTab] = useState('markdown')
+
   const sanitizedHTML = {
     __html: DOMPurify.sanitize(marked.parse(markdown, [{ gfm: true }])),
   }
 
   return (
-    <Tabs aria-label="Default tabs" variant="default" theme={customTheme}>
-      <Tabs.Item active title="Markdown">
-        <pre id="raw_markdown" className="p-4 border">
-          {markdown}
-        </pre>
-      </Tabs.Item>
-      <Tabs.Item title="Preview">
-        <div
-          id="markdown_preview"
-          className="p-4 border markdown-body"
-          dangerouslySetInnerHTML={sanitizedHTML}
-        />
-      </Tabs.Item>
-    </Tabs>
-  )
-}
+    <div>
+      <div className="mb-8">
+        <ul className="flex flex-wrap text-sm text-center border-b border-gray-300 !list-none">
+          <li className="me-2">
+            <button
+              onClick={() => setSelectedTab('markdown')}
+              className={
+                selectedTab === 'markdown'
+                  ? 'active_large_tab_item'
+                  : 'large_tab_item'
+              }
+            >
+              Markdown
+            </button>
+          </li>
+          <li className="me-2">
+            <button
+              onClick={() => setSelectedTab('preview')}
+              className={
+                selectedTab === 'preview'
+                  ? 'active_large_tab_item'
+                  : 'large_tab_item'
+              }
+            >
+              Preview
+            </button>
+          </li>
+        </ul>
+      </div>
 
-const customTheme = {
-  base: 'flex flex-col gap-2',
-  tablist: {
-    tabitem: {
-      base: 'flex items-center justify-center rounded-t-lg p-4 me-2 border border-b-0 border-gray-300 text-sm font-medium',
-      variant: {
-        default: {
-          base: 'rounded-t-lg',
-          active: {
-            on: 'bg-blue-700 text-white font-bold',
-            off: 'text-gray-500 hover:bg-blue-50',
-          },
-        },
-      },
-    },
-  },
+      <div>
+        {selectedTab === 'markdown' ? (
+          <pre id="raw_markdown" className="p-4 border border-gray-300">
+            {markdown}
+          </pre>
+        ) : (
+          <div
+            id="markdown_preview"
+            className="p-4 border border-gray-300 markdown-body"
+            dangerouslySetInnerHTML={sanitizedHTML}
+          />
+        )}
+      </div>
+    </div>
+  )
 }
 
 MinutePreview.propTypes = {

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-8">
-  <ul class="flex flex-wrap text-sm text-center border-b border-gray-200 !list-none">
+  <ul class="flex flex-wrap text-sm text-center border-b border-gray-300 !list-none">
     <% Course.all.each do |course| %>
       <li class="me-2">
         <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>


### PR DESCRIPTION
## Issue
- #219 

## 概要
議事録詳細ページのタブはflowbite-reactのコンポーネントを利用していたが、それをやめてflowbiteのタブを使うように変更した。

また、上記の変更に伴い、タブの下線の色をタブの枠線の色と同じになるように修正している。

## Screenshot
修正前
![427F49A8-4D71-4251-8602-CF4DCB364BEA](https://github.com/user-attachments/assets/3198ad35-5112-4e31-84df-ae66e889cde6)

修正後
![34B8F1D5-2C84-47F3-8794-AA2D4CA25C55](https://github.com/user-attachments/assets/6d082a69-5419-4954-846e-43c0ff74d14c)

