### PR TITLE
Action Cableのコネクション作成時、IDを付与するようにした

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -2,5 +2,30 @@
 
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :current_development_member
+
+    def connect
+      development_member = find_development_member
+      reject_unauthorized_connection unless development_member
+
+      self.current_development_member = development_member
+      Rails.logger.info("Action Cable connection from #{development_member.class}(id: #{development_member.id}) is established.")
+    end
+
+    def disconnect
+      Rails.logger.info("Action Cable connection from #{current_development_member.class}(id: #{current_development_member.id}) is closed.")
+    end
+
+    private
+
+    def find_development_member
+      if cookies.signed[:remember_admin_token]
+        Admin.serialize_from_cookie(*cookies.signed[:remember_admin_token])
+      elsif cookies.signed[:remember_member_token]
+        Member.serialize_from_cookie(*cookies.signed[:remember_member_token])
+      else
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -16,4 +16,10 @@ class Admin < ApplicationRecord
       member.password = Devise.friendly_token[0, 20]
     end
   end
+
+  # Action CableのコネクションのIDを作成する際に呼ばれる
+  # https://github.com/rails/rails/blob/dd8f7185faeca6ee968a6e9367f6d8601a83b8db/actioncable/lib/action_cable/connection/identification.rb#L38
+  def to_gid_param
+    to_global_id.to_param
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -41,6 +41,12 @@ class Member < ApplicationRecord
     attendance_list(from:, to:).pop(12)
   end
 
+  # Action CableのコネクションのIDを作成する際に呼ばれる
+  # https://github.com/rails/rails/blob/dd8f7185faeca6ee968a6e9367f6d8601a83b8db/actioncable/lib/action_cable/connection/identification.rb#L38
+  def to_gid_param
+    to_global_id.to_param
+  end
+
   private
 
   def attendance_list(from: created_at, to: nil)

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationCable::Connection, type: :channel do
+  let(:admin) { FactoryBot.create(:admin) }
+  let(:member) { FactoryBot.create(:member) }
+
+  it 'successfully connect when admin has valid remember cookie' do
+    # ユーザーのログインを記憶する処理を簡易的に実行する
+    # https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/controllers/rememberable.rb#L22
+    admin.remember_me!
+    cookies.signed[:remember_admin_token] = Admin.serialize_into_cookie(admin)
+
+    connect
+    expect(connection.current_development_member.id).to eq admin.id
+  end
+
+  it 'successfully connect when member has valid remember cookie' do
+    member.remember_me!
+    cookies.signed[:remember_member_token] = Member.serialize_into_cookie(member)
+
+    connect
+    expect(connection.current_development_member.id).to eq member.id
+  end
+
+  it 'does not connect without remember cookie' do
+    member.remember_me!
+
+    expect { connect }.to have_rejected_connection
+  end
+
+  it 'does not connect when resource is not found from cookie' do
+    member.remember_me!
+    cookies.signed[:remember_member_token] = Member.serialize_into_cookie(member)
+
+    allow(Member).to receive(:serialize_from_cookie).and_return(nil)
+    expect { connect }.to have_rejected_connection
+  end
+end


### PR DESCRIPTION
## Issue
- #222 

## 概要
Action Cableのコネクションが作成された際、そのコネクションにIDを追加するようにした。

## Screenshot
### IDを付与しない場合

![CC55C1AB-3616-4801-AD6A-E0EEA0282308](https://github.com/user-attachments/assets/24caab13-6a01-4afa-992f-e26d2982eb0d)



### IDを付与した場合

![7309C834-D1B7-47F4-8203-0F35752F77F8](https://github.com/user-attachments/assets/d02a34fa-16fb-49de-bd1a-24b0684c42d1)


## 備考
以下参考文献と関連するコード。

### コネクションのテストに関して
- [ActionCable::Connection::TestCase](https://railsguides.jp/testing.html#%E3%82%B3%E3%83%8D%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E3%83%86%E3%82%B9%E3%83%88%E3%82%B1%E3%83%BC%E3%82%B9)
- [rspec\.info/features/7\-1/rspec\-rails/channel\-specs/channel\-spec/](https://rspec.info/features/7-1/rspec-rails/channel-specs/channel-spec/)


### コネクションのIDに関して
- [rails/actioncable/lib/action\_cable/connection/identification\.rb at dd8f7185faeca6ee968a6e9367f6d8601a83b8db · rails/rails](https://github.com/rails/rails/blob/dd8f7185faeca6ee968a6e9367f6d8601a83b8db/actioncable/lib/action_cable/connection/identification.rb)
- `to_gid_param`の実装例
  - https://github.com/rails/rails/commit/952887a8bd1fc1e197a482b01c6b1b1ccbcdba2d
  - [globalid](https://github.com/rails/globalid/tree/e9548a3531a89abfaf036f88d4dac732355a5b80)というgemが使われている 


### ユーザーのログイン状態を記憶する処理に関して
- コントローラーから呼び出すメソッド
  - https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/controllers/rememberable.rb#L22 
- モデルから呼び出すメソッド
  - https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/models/rememberable.rb#L50
