### PR TITLE
Action Cableのテストを追加

### DIFF
--- a/spec/channels/minute_channel_spec.rb
+++ b/spec/channels/minute_channel_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MinuteChannel, type: :channel do
+  it 'successfully subscribes with minute id' do
+    minute = FactoryBot.create(:minute)
+    subscribe id: minute.id
+
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_for(minute)
+  end
+
+  it 'does not subscribe without minute id' do
+    expect { subscribe }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     trait :by_member do
       content { 'gitのブランチ履歴がおかしくなってしまったので、どなたかペアプロをお願いしたいです' }
       association :minute, factory: :minute
-      association :topicable, factory: :admin
+      association :topicable, factory: :member
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,4 +69,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include RequestSpecHelper, type: :request
 end

--- a/spec/requests/minutes/topics_apis_spec.rb
+++ b/spec/requests/minutes/topics_apis_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Minutes::Topics API', type: :request do
 
   context 'when create topic' do
     it 'broadcast to subscriber when topic is created' do
+      # post api_minute_topics_path(minute) で新しく作成されるデータを期待値に含めることができないので、ブロードキャストで配信されるデータまではテストしない
       expect do
         post api_minute_topics_path(minute), params: { minute_id: minute.id, topic: { content: 'CIでテストが落ちています！' } }
       end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
@@ -21,17 +22,20 @@ RSpec.describe 'Minutes::Topics API', type: :request do
 
   context 'when update topic' do
     it 'broadcast to subscriber when topic is updated' do
+      broadcasted_data = [{ id: topic.id, content: '話題にしたいこと・心配事を更新しました', topicable_id: topic.topicable.id, topicable_type: 'Member',
+                            topicable: { name: topic.topicable.name } }.as_json]
       expect do
         patch api_minute_topic_path(minute, topic), params: { topic: { content: '話題にしたいこと・心配事を更新しました' } }
-      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel).with(body: { topics: broadcasted_data })
     end
   end
 
   context 'when destroy topic' do
     it 'broadcast to subscriber when topic is destroyed' do
+      broadcasted_data = []
       expect do
         delete api_minute_topic_path(minute, topic)
-      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel).with(body: { topics: broadcasted_data })
     end
   end
 end

--- a/spec/requests/minutes/topics_apis_spec.rb
+++ b/spec/requests/minutes/topics_apis_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe 'Minutes::Topics API', type: :request do
   let(:member) { FactoryBot.create(:member) }
   let(:topic) { FactoryBot.create(:topic, :by_member, minute:, topicable: member) }
 
+  before do
+    sign_in member
+  end
+
   context 'when create topic' do
     it 'broadcast to subscriber when topic is created' do
-      sign_in member
       expect do
         post api_minute_topics_path(minute), params: { minute_id: minute.id, topic: { content: 'CIでテストが落ちています！' } }
       end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
@@ -18,7 +21,6 @@ RSpec.describe 'Minutes::Topics API', type: :request do
 
   context 'when update topic' do
     it 'broadcast to subscriber when topic is updated' do
-      sign_in member
       expect do
         patch api_minute_topic_path(minute, topic), params: { topic: { content: '話題にしたいこと・心配事を更新しました' } }
       end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
@@ -27,7 +29,6 @@ RSpec.describe 'Minutes::Topics API', type: :request do
 
   context 'when destroy topic' do
     it 'broadcast to subscriber when topic is destroyed' do
-      sign_in member
       expect do
         delete api_minute_topic_path(minute, topic)
       end.to have_broadcasted_to(minute).from_channel(MinuteChannel)

--- a/spec/requests/minutes/topics_apis_spec.rb
+++ b/spec/requests/minutes/topics_apis_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Minutes::Topics API', type: :request do
+  let!(:minute) { FactoryBot.create(:minute) }
+  let(:member) { FactoryBot.create(:member) }
+  let(:topic) { FactoryBot.create(:topic, :by_member, minute:, topicable: member) }
+
+  context 'when create topic' do
+    it 'broadcast to subscriber when topic is created' do
+      sign_in member
+      expect do
+        post api_minute_topics_path(minute), params: { minute_id: minute.id, topic: { content: 'CIでテストが落ちています！' } }
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+    end
+  end
+
+  context 'when update topic' do
+    it 'broadcast to subscriber when topic is updated' do
+      sign_in member
+      expect do
+        patch api_minute_topic_path(minute, topic), params: { topic: { content: '話題にしたいこと・心配事を更新しました' } }
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+    end
+  end
+
+  context 'when destroy topic' do
+    it 'broadcast to subscriber when topic is destroyed' do
+      sign_in member
+      expect do
+        delete api_minute_topic_path(minute, topic)
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+    end
+  end
+end

--- a/spec/requests/minutes_apis_spec.rb
+++ b/spec/requests/minutes_apis_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Minutes API', type: :request do
+  let!(:minute) { FactoryBot.create(:minute) }
+  let(:admin) { FactoryBot.create(:admin) }
+
+  context 'when update minute' do
+    it 'broadcast to subscriber when minute is updated' do
+      sign_in admin
+      expect do
+        patch api_minute_path(minute), params: { id: minute.id, minute: { release_branch: 'http://example.com/pull/1234' } }
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+    end
+  end
+end

--- a/spec/requests/minutes_apis_spec.rb
+++ b/spec/requests/minutes_apis_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe 'Minutes API', type: :request do
 
   context 'when update minute' do
     it 'broadcast to subscriber when minute is updated' do
+      broadcasted_data = { release_branch: 'https://example.com/pull/1234', release_note: 'https://example.com/announcements/100', other: '連絡事項は特にありません',
+                           next_meeting_date: '2024-10-16' }.as_json
       sign_in admin
       expect do
-        patch api_minute_path(minute), params: { id: minute.id, minute: { release_branch: 'http://example.com/pull/1234' } }
-      end.to have_broadcasted_to(minute).from_channel(MinuteChannel)
+        patch api_minute_path(minute), params: { id: minute.id, minute: { release_branch: 'https://example.com/pull/1234' } }
+      end.to have_broadcasted_to(minute).from_channel(MinuteChannel).with(body: { minute: broadcasted_data })
     end
   end
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module RequestSpecHelper
+  include Warden::Test::Helpers
+
+  def self.included(base)
+    base.before { Warden.test_mode! }
+    base.after { Warden.test_reset! }
+  end
+
+  def sign_in(resource)
+    login_as(resource, scope: warden_scope(resource))
+  end
+
+  def sign_out(resource)
+    logout(warden_scope(resource))
+  end
+
+  private
+
+  def warden_scope(resource)
+    resource.class.name.underscore.to_sym
+  end
+end


### PR DESCRIPTION
## Issue
- #100 

## 概要
Action Cableに関する以下のテストを追加した。

- チャネルのテスト
- ブロードキャストのテスト
  - `API::MinutesController`のテスト
  - `API::Minutes::TopicsController`のテスト   

コネクションのテストに関しては #223  で追加済み。

## Screenshot
追加したテストの実行画面。
![81B128E2-BE25-43C4-A6AC-FD411884A121](https://github.com/user-attachments/assets/b6deb557-d7eb-4d49-8ab2-2bfe55dc9df0)

## 備考
### ログインのヘルパーメソッド
request spec内でログインする際に利用しているヘルパーメソッドは、Everyday Railsと以下のページを参考にした。
- https://github.com/heartcombo/devise/wiki/How-To:-sign-in-and-out-a-user-in-Request-type-specs-(specs-tagged-with-type:-:request)#2-a-more-complicated-example
