### PR TITLE
meta descriptionsとmeta keywordsを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem 'devise-i18n'
 
 gem 'discord-notifier'
 
+gem 'meta-tags'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    meta-tags (2.22.1)
+      actionpack (>= 6.0.0, < 8.1)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
@@ -436,6 +438,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   launchy
+  meta-tags
   omniauth
   omniauth-github
   omniauth-rails_csrf_protection

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,8 @@ module ApplicationHelper
   def page_title(description)
     "#{description} | Fjord Minutes"
   end
+
+  def build_meta_tags(description)
+    { description:, keywords: 'チーム開発ミーティング, 議事録, フィヨルドブートキャンプ, FBC' }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-  def page_title(description)
-    "#{description} | Fjord Minutes"
-  end
-
-  def build_meta_tags(description)
-    { description:, keywords: 'チーム開発ミーティング, 議事録, フィヨルドブートキャンプ, FBC' }
+  def build_meta_tags(title: nil, description: nil)
+    page_title = title.nil? ? 'Fjord Minutes' : "#{title} | Fjord Minutes"
+    { title: page_title, description:, keywords: 'チーム開発ミーティング, 議事録, フィヨルドブートキャンプ, FBC' }
   end
 end

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title("#{@attendance.minute.title}の出席変更") } %>
+<% set_meta_tags(description: "#{@attendance.minute.title}の出席を変更するページです。") %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}編集" %></h1>
 

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title("#{@attendance.minute.title}の出席変更") } %>
-<% set_meta_tags(description: "#{@attendance.minute.title}の出席を変更するページです。") %>
+<% set_meta_tags(build_meta_tags("#{@attendance.minute.title}の出席を変更するページです。")) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}編集" %></h1>
 

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title("#{@attendance.minute.title}の出席変更") } %>
-<% set_meta_tags(build_meta_tags("#{@attendance.minute.title}の出席を変更するページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@attendance.minute.title}の出席変更", description: "#{@attendance.minute.title}の出席を変更するページです。")) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}編集" %></h1>
 

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title("#{@course.name}のメンバー") } %>
-<% set_meta_tags(build_meta_tags("#{@course.name}のチームメンバー一覧ページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@course.name}のメンバー一覧", description: "#{@course.name}のチームメンバー一覧ページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title("#{@course.name}のメンバー") } %>
-<% set_meta_tags(description: "#{@course.name}のチームメンバー一覧ページです。") %>
+<% set_meta_tags(build_meta_tags("#{@course.name}のチームメンバー一覧ページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title("#{@course.name}のメンバー") } %>
+<% set_meta_tags(description: "#{@course.name}のチームメンバー一覧ページです。") %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title("#{@course.name}の議事録一覧") } %>
+<% set_meta_tags(description: "#{@course.name}の議事録一覧ページです。") %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title("#{@course.name}の議事録一覧") } %>
-<% set_meta_tags(build_meta_tags("#{@course.name}の議事録一覧ページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@course.name}の議事録一覧", description: "#{@course.name}の議事録一覧ページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title("#{@course.name}の議事録一覧") } %>
-<% set_meta_tags(description: "#{@course.name}の議事録一覧ページです。") %>
+<% set_meta_tags(build_meta_tags("#{@course.name}の議事録一覧ページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title('ダッシュボード') } %>
-<% set_meta_tags(description: 'ダッシュボードページです。') %>
+<% set_meta_tags(build_meta_tags('ダッシュボードページです。')) %>
 <div class="w-full">
   <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
 

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title('ダッシュボード') } %>
-<% set_meta_tags(build_meta_tags('ダッシュボードページです。')) %>
+<% set_meta_tags(build_meta_tags(title: 'ダッシュボード', description: 'ダッシュボードページです。')) %>
 <div class="w-full">
   <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
 

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title('ダッシュボード') } %>
+<% set_meta_tags(description: 'ダッシュボードページです。') %>
 <div class="w-full">
   <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,4 @@
+<% set_meta_tags(description: 'FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。') %>
 <div>
   <h1 class="font-bold text-2xl text-center my-12">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理でより効率的に</h1>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<% set_meta_tags(description: 'FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。') %>
+<% set_meta_tags(build_meta_tag('FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。')) %>
 <div>
   <h1 class="font-bold text-2xl text-center my-12">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理でより効率的に</h1>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<% set_meta_tags(build_meta_tag('FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。')) %>
+<% set_meta_tags(build_meta_tags(description: 'FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。')) %>
 <div>
   <h1 class="font-bold text-2xl text-center my-12">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理でより効率的に</h1>
 

--- a/app/views/home/pp.html.erb
+++ b/app/views/home/pp.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title('プライバシーポリシー') } %>
-<% set_meta_tags(build_meta_tags('プライバシーポリシーのページです。')) %>
+<% set_meta_tags(build_meta_tags(title: 'プライバシーポリシー', description: 'プライバシーポリシーのページです。')) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center mb-4">プライバシーポリシー</h1>
   <p class="mb-8">「Fjord Minutes」（以下「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。</p>

--- a/app/views/home/pp.html.erb
+++ b/app/views/home/pp.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title('プライバシーポリシー') } %>
+<% set_meta_tags(description: 'プライバシーポリシーのページです。') %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center mb-4">プライバシーポリシー</h1>
   <p class="mb-8">「Fjord Minutes」（以下「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。</p>

--- a/app/views/home/pp.html.erb
+++ b/app/views/home/pp.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title('プライバシーポリシー') } %>
-<% set_meta_tags(description: 'プライバシーポリシーのページです。') %>
+<% set_meta_tags(build_meta_tags('プライバシーポリシーのページです。')) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center mb-4">プライバシーポリシー</h1>
   <p class="mb-8">「Fjord Minutes」（以下「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。</p>

--- a/app/views/home/terms_of_service.html.erb
+++ b/app/views/home/terms_of_service.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title('利用規約') } %>
-<% set_meta_tags(description: '利用規約のページです。') %>
+<% set_meta_tags(build_meta_tags('利用規約のページです。')) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center mb-4">利用規約</h1>
   <p class="mb-8">この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>

--- a/app/views/home/terms_of_service.html.erb
+++ b/app/views/home/terms_of_service.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title('利用規約') } %>
-<% set_meta_tags(build_meta_tags('利用規約のページです。')) %>
+<% set_meta_tags(build_meta_tags(title: '利用規約', description: '利用規約のページです。')) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center mb-4">利用規約</h1>
   <p class="mb-8">この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>

--- a/app/views/home/terms_of_service.html.erb
+++ b/app/views/home/terms_of_service.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title('利用規約') } %>
+<% set_meta_tags(description: '利用規約のページです。') %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center mb-4">利用規約</h1>
   <p class="mb-8">この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title><%= content_for(:title) || "Fjord Minutes" %></title>
+    <%= display_meta_tags %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Fjord Minutes" %></title>
     <%= display_meta_tags %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,10 +1,6 @@
-<% if @member == current_development_member %>
-  <% content_for(:title) { page_title("ダッシュボード") } %>
-<% else %>
-  <% content_for(:title) { page_title("#{@member.name}さんの出席一覧") } %>
-<% end %>
+<% title = @member == current_development_member ? 'ダッシュボード' : "#{@member.name}さんの出席一覧" %>
 <% description = @member == current_development_member ? 'ダッシュボードページです。' : "#{@member.name}さんの出席一覧ページです。" %>
-<% set_meta_tags(build_meta_tags(description)) %>
+<% set_meta_tags(build_meta_tags(title:, description:)) %>
 <div class="w-full">
   <h1 class="font-bold text-4xl mb-8">
     <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -3,6 +3,8 @@
 <% else %>
   <% content_for(:title) { page_title("#{@member.name}さんの出席一覧") } %>
 <% end %>
+<% description = @member == current_development_member ? 'ダッシュボードページです。' : "#{@member.name}さんの出席一覧ページです。" %>
+<% set_meta_tags(description: description) %>
 <div class="w-full">
   <h1 class="font-bold text-4xl mb-8">
     <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -4,7 +4,7 @@
   <% content_for(:title) { page_title("#{@member.name}さんの出席一覧") } %>
 <% end %>
 <% description = @member == current_development_member ? 'ダッシュボードページです。' : "#{@member.name}さんの出席一覧ページです。" %>
-<% set_meta_tags(description: description) %>
+<% set_meta_tags(build_meta_tags(description)) %>
 <div class="w-full">
   <h1 class="font-bold text-4xl mb-8">
     <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title("#{@minute.title}に出席登録") } %>
-<% set_meta_tags(description: "#{@minute.title}の出席を登録するページです。") %>
+<% set_meta_tags(build_meta_tags("#{@minute.title}の出席を登録するページです。")) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
 

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title("#{@minute.title}に出席登録") } %>
-<% set_meta_tags(build_meta_tags("#{@minute.title}の出席を登録するページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@minute.title}の出席登録", description: "#{@minute.title}の出席を登録するページです。")) %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
 

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title("#{@minute.title}に出席登録") } %>
+<% set_meta_tags(description: "#{@minute.title}の出席を登録するページです。") %>
 <div class="mx-auto w-full">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
 

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title("#{@minute.title}の議事録編集") } %>
+<% set_meta_tags(description: "#{@minute.title}の議事録の編集ページです。") %>
 <div class="mx-auto w-full">
   <div class="markdown-body">
     <h1><%= @minute.title %></h1>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title("#{@minute.title}の議事録編集") } %>
-<% set_meta_tags(description: "#{@minute.title}の議事録の編集ページです。") %>
+<% set_meta_tags(build_meta_tags("#{@minute.title}の議事録の編集ページです。")) %>
 <div class="mx-auto w-full">
   <div class="markdown-body">
     <h1><%= @minute.title %></h1>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title("#{@minute.title}の議事録編集") } %>
-<% set_meta_tags(build_meta_tags("#{@minute.title}の議事録の編集ページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録編集", description: "#{@minute.title}の議事録の編集ページです。")) %>
 <div class="mx-auto w-full">
   <div class="markdown-body">
     <h1><%= @minute.title %></h1>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) { page_title("#{@minute.title}の議事録") } %>
-<% set_meta_tags(description: "#{@minute.title}の議事録のページです。") %>
+<% set_meta_tags(build_meta_tags("#{@minute.title}の議事録のページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,5 +1,4 @@
-<% content_for(:title) { page_title("#{@minute.title}の議事録") } %>
-<% set_meta_tags(build_meta_tags("#{@minute.title}の議事録のページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録", description: "#{@minute.title}の議事録のページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title) { page_title("#{@minute.title}の議事録") } %>
+<% set_meta_tags(description: "#{@minute.title}の議事録のページです。") %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
     <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Add HTML attributes to the <title> HTML tag. Default is {}.
+  # config.title_tag_attributes = {}
+
+  # Natural separator when truncating. Default is " " (space character).
+  # Set to nil to disable natural separator.
+  # This also allows you to use a whitespace regular expression (/\s/) or
+  # a Unicode space (/\p{Space}/).
+  # config.truncate_on_natural_separator = " "
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  config.keywords_lowercase = false
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
## Issue
- #12 

## 概要
各ページにmeta descriptionsとmeta keywordsを追加した。(meta keywordsは全ページで共通)
また、titleタグの内容を`content_for`で記述していたが、meta_tags内のメソッドで記述するように変更している。

## Screenshot
- トップページ(非ログイン時)

![10D185F3-22D1-465E-824D-DF605A15270C_4_5005_c](https://github.com/user-attachments/assets/29ea70c6-5bcc-4178-a614-6acb738311e0)

- トップページ(ログイン時)

![C821687A-D177-40E9-BC6B-626EA82DBFF7_4_5005_c](https://github.com/user-attachments/assets/9f0f6fcc-9c0a-4eae-b49c-a57a669daea2)

-  プライパシーポリシー

![320C3391-4A2C-46CB-9985-07D2C519BE97_4_5005_c](https://github.com/user-attachments/assets/d5923d67-8798-4353-abc2-5594de3194f8)

- 利用規約

![8CB767D6-DB32-471D-A1FC-7DAADAA9BABE_4_5005_c](https://github.com/user-attachments/assets/37e085d9-a103-4551-ba45-9c3a5a45fcd4)

- メンバー一覧ページ

![06A08D45-E057-46E9-9A2E-CD2C159199B7_4_5005_c](https://github.com/user-attachments/assets/f8b07a68-2965-4a59-9db8-1ade7f655c0c)

- 議事録一覧ページ

![DBF98B8F-5188-4C4F-BE16-C1C7C550A75F_4_5005_c](https://github.com/user-attachments/assets/ceedc6e4-930d-411c-9030-e919df518fe8)

- メンバー詳細ページ

![CF19AF6C-C932-4958-843C-84EFD7E709F5_4_5005_c](https://github.com/user-attachments/assets/9e0a8284-a19c-46f4-91e8-4b15cc585eae)

- 議事録詳細ページ

![82FCCD17-F3B8-4EFE-B5C0-C55421039646_4_5005_c](https://github.com/user-attachments/assets/f12fb1f2-b09a-4472-90c5-4d18b088959c)

- 議事録編集ページ

![47F05713-EAFA-4F5C-8897-FA157BAF57F8_4_5005_c](https://github.com/user-attachments/assets/40492094-cd87-43ab-a2e2-2a2cb3b37b7e)

- 出席作成ページ

![5177AE4D-567C-4E95-8069-479F72C7F288_4_5005_c](https://github.com/user-attachments/assets/c3ee0eac-b5a8-4d5b-975b-b990ea54e46e)


- 出席編集ページ

![43DF7CEB-CEFB-4199-A990-2E7C987027A8_4_5005_c](https://github.com/user-attachments/assets/647bc33b-159e-4696-bc78-f854f9e4f654)
