### PR TITLE
本番環境で発生しているSprockets::Rails::Helper::AssetNotFoundを修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
         title: page_title,
         description:,
         site_name: 'Fjord Minutes',
-        image: image_url('ogp_image')
+        image: image_url('ogp_image.png')
       },
       twitter: {
         card: 'summary',


### PR DESCRIPTION
## Issue
- #231 

## 概要
本番環境で発生しているSprockets::Rails::Helper::AssetNotFoundを解消するために、エラーが発生している`image_url`に渡していた画像ファイル名に拡張子を追加した。

どうやら、`image_url('filename')`のように拡張子をつけないでコードを実行すると、本番環境ではクラッシュするが開発環境ではクラッシュせず動作する模様。

https://github.com/rails/rails/issues/42784



