### PR TITLE
古いバージョンのブラウザからアプリにアクセスできるように、`allow_browser versions: :modern`をコメントアウトした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,8 @@
 
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  # devツールのSafariなど、古いバージョンのブラウザからアクセスする必要があるため、一時的にコメントアウトする
+  # allow_browser versions: :modern
   devise_group :development_member, contains: %i[member admin]
   before_action :authenticate_development_member!
   before_action :prohibit_hibernated_member_access


### PR DESCRIPTION
## Issue
- #234 

## 概要
`application_controller.rb`内の`allow_browser versions: :modern`をコメントアウトし、バージョンが17.2より低いSafariからでもアプリにアクセスできるようにした。

`allow_browser versions: :modern`で指定されるブラウザのバージョンは、以下を参照。
https://api.rubyonrails.org/classes/ActionController/AllowBrowser/ClassMethods.html#method-i-allow_browser

