### PR TITLE
`<meta name="apple-mobile-web-app-capable" content="yes">`を削除

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <%= display_meta_tags %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
## Issue
- #228 

## 概要
`<meta name="apple-mobile-web-app-capable" content="yes">`を削除した。

## screenshot
ローカル環境でコンソールの警告がなくなっていることを確認。
![75ED8DFE-2F2A-4B62-B4A3-4708EABB852B_4_5005_c](https://github.com/user-attachments/assets/2bb9cae4-284e-45e6-990a-a798aeb60c4e)

## 備考
### apple-mobile-web-app-capableについて

`<meta name="apple-mobile-web-app-capable" content="yes">`を含むWebアプリは、フルスクリーンで単体のアプリのように立ち上げることができる。

> iPhone では、ユーザーはウェブアプリをホーム画面にインストールして、ウェブアプリを全画面表示のウェブアプリとして起動できます。

https://web.dev/articles/fullscreen?hl=ja#ios

現在このアプリは全画面表示には対応していないため、このタグを削除することにした。

> サイトまたはアプリケーションがウェブアプリに対応している場合、つまり、[戻る] ボタンがないなど、最小限の UI でサイトを単独で構築できる場合は、メタタグを使用してブラウザに次の内容を伝えることもできます。

> アプリが実際にそのアプリに対応している場合にのみ含めてください。

https://web.dev/learn/html/metadata?hl=ja#other_useful_meta_information


### mobile-web-app-capableについて
ちなみに、エラーメッセージで代替として`<meta name="mobile-web-app-capable" content="yes">`が挙げられているが、これを含むWebアプリはChrome for Androidでフルスクリーンでアプリを立ち上げることができる。

> Chrome チームは最近、ユーザーがホーム画面に追加した場合に、全画面表示のページを起動するようブラウザに指示する機能を実装しました。この機能は、iOS Safari モデルの機能と類似しています。

https://web.dev/articles/fullscreen?hl=ja#chrome_for_android


 
