### PR TITLE
GitHub ActionsでLintとテストを実行するようにワークフローを追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: 'Lint'
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Setup node environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+      - name: Cache JavaScript dependencies
+        id: cache-npm
+        uses: actions/cache@v4
+        with:
+          key: npm-${{ hashFiles('package-lock.json') }}
+          path: node_modules
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Install JavaScript dependencies
+        run: npm ci
+      - name: Run lint
+        run: bin/run_lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: "Test"
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16.4 # Herokuの本番環境とバージョンを合わせる
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_DB: rails_test
+          POSTGRES_USER: rails
+          POSTGRES_PASSWORD: password
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: "postgres://rails:password@localhost:5432/rails_test"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Ruby and gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Setup node environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+      - name: Restore JavaScript dependencies
+        id: cache-npm
+        uses: actions/cache@v4
+        with:
+          key: npm-${{ hashFiles('package-lock.json') }}
+          path: node_modules
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: Install JavaScript dependencies
+        run: npm ci
+      - name: Set up database schema
+        run: bin/rails db:schema:load
+      - name: Prepare asset
+        run: bundle exec rake assets:precompile
+      - name: Run tests
+        run: bundle exec rspec

--- a/spec/models/meeting_secretary_spec.rb
+++ b/spec/models/meeting_secretary_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe MeetingSecretary, type: :model do
 
     it 'create minute of next meeting' do
       allow(Discord::Notifier).to receive(:message).and_return(nil)
-      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
-      # ENV.fetchが複数の引数で呼ばれるため、and_call_originalも必要
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
 
       travel_to latest_minute.meeting_date + 1.day do
         expect { meeting_secretary.create_minute }.to change(rails_course.minutes, :count).by(1)
@@ -44,6 +40,9 @@ RSpec.describe MeetingSecretary, type: :model do
       allow(meeting_secretary).to receive_messages(get_latest_meeting_date_from_cloned_minutes: latest_meeting_date,
                                                    get_next_meeting_date_from_cloned_minutes: Time.zone.local(2024, 11, 20))
       allow(Discord::Notifier).to receive(:message).and_return(nil)
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
     end
 
     it 'create minute of next meeting' do
@@ -58,9 +57,6 @@ RSpec.describe MeetingSecretary, type: :model do
     end
 
     it 'does not create minute if latest meeting is not finished' do
-      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
-      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
-
       travel_to latest_meeting_date do
         expect { meeting_secretary.create_first_minute }.not_to change(rails_course.minutes, :count)
       end

--- a/spec/models/meeting_secretary_spec.rb
+++ b/spec/models/meeting_secretary_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe MeetingSecretary, type: :model do
 
     it 'create minute of next meeting' do
       allow(Discord::Notifier).to receive(:message).and_return(nil)
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      # ENV.fetchが複数の引数で呼ばれるため、and_call_originalも必要
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
 
       travel_to latest_minute.meeting_date + 1.day do
         expect { meeting_secretary.create_minute }.to change(rails_course.minutes, :count).by(1)
@@ -22,6 +26,9 @@ RSpec.describe MeetingSecretary, type: :model do
     end
 
     it 'does not create minute if latest meeting is not finished' do
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+
       travel_to latest_minute.meeting_date do
         expect { meeting_secretary.create_minute }.not_to change(rails_course.minutes, :count)
       end
@@ -51,6 +58,9 @@ RSpec.describe MeetingSecretary, type: :model do
     end
 
     it 'does not create minute if latest meeting is not finished' do
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+
       travel_to latest_meeting_date do
         expect { meeting_secretary.create_first_minute }.not_to change(rails_course.minutes, :count)
       end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -280,8 +280,6 @@ RSpec.describe 'Minutes', type: :system do
     end
 
     scenario 'admin can export minute to GitHub Wiki' do
-      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
-      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
       # GitHub Wikiリポジトリにpushされないようにする
       allow(GithubWikiManager).to receive(:export_minute).and_call_original
       allow(GithubWikiManager).to receive(:export_minute).with(minute).and_return(nil)
@@ -291,6 +289,9 @@ RSpec.describe 'Minutes', type: :system do
       visit minute_path(minute)
       expect(page).to have_button 'GitHub Wiki にエクスポート'
       expect(page).not_to have_link 'GitHub Wikiで確認'
+
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
 
       click_button 'GitHub Wiki にエクスポート'
       expect(current_path).to eq course_minutes_path(minute.course)

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -224,6 +224,9 @@ RSpec.describe 'Minutes', type: :system do
     end
 
     scenario 'display github wiki link when the minute is exported' do
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+
       exported_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), exported: true, course: rails_course)
       not_exported_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 15), course: rails_course)
 
@@ -277,6 +280,8 @@ RSpec.describe 'Minutes', type: :system do
     end
 
     scenario 'admin can export minute to GitHub Wiki' do
+      # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
       # GitHub Wikiリポジトリにpushされないようにする
       allow(GithubWikiManager).to receive(:export_minute).and_call_original
       allow(GithubWikiManager).to receive(:export_minute).with(minute).and_return(nil)


### PR DESCRIPTION
## Issue
- #6 

## 概要
CIを実行するために、コードをpushした際以下のチェックを行うようにGitHub Actionsのワークフローを追加した。

- Lint
  - rubocop
  - erb_lint
  - eslint
  - prettier
- Test
  - rspec   

## 備考
### cacheアクション
参考 : https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows

cacheアクションは、指定した`key`と厳密に一致するキャッシュを見つけた場合、`path`にキャッシュされたファイルが復元される。

`key`と一致するキャッシュが見つかった場合、**キャッシュヒット**と見做される。
→ キャッシュヒットした場合、キャッシュされたファイルが`path`ディレクトリに復元される。

見つからなかった場合**キャッシュミス**とみなされる
→ ジョブが正常に完了した後、新しいキャッシュがcacheアクションによって作成される。
→ 新しいキャッシュでは、指定した key が使用され、path で指定したファイルが含められる

#### パラメーター
- `key`(必須) : キャッシュの保存時に作成されるキーであり、キャッシュ検索時に使用されるキー
- `path`(必須) : キャッシュまたは復元した際のランナー上のパス
- `restore-keys` : 代替の復元キーを含む文字列。`key`でキャッシュを発見できなかった場合、この復元キーを元に検索される。

#### キャッシュのキーについて
ファイルのハッシュを計算する式を使用して`key`を作成することが可能。

(例)
`npm-${{ hashFiles('package-lock.json') }}`
→ `package-lock.json`ファイルを構成する依存関係が変更されると、キャッシュキーが変更され、新しいキャッシュが自動的に作成される。

#### キャッシュのアクセス制限
キャッシュを復元できるのは、以下のような制限がある。

- ワークフロー実行
  - 現在のブランチ
  - 既定のブランチ(通常は`main`)

- PRに対してワークフロー実行がトリガされた場合
  - 現在のブランチ
  - 既定のブランチ(通常は`main`)
  - ベースブランチ

#### キャッシュの結果の確認
`key`で指定したキャッシュが見つかった場合、`cache-hit`の出力が`true`になる。
これを利用して、キャッシュが見つかった場合は`if: ${{ steps.step_id.outputs.cache-hit != 'true' }}`で、キャッシュが見つからなかった場合は`if: ${{ steps.step_id.outputs.cache-hit != 'true' }}`で、ステップを実行することが可能。