### PR TITLE
モデルから不必要なメソッドを削除

### DIFF
--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -16,10 +16,4 @@ class Admin < ApplicationRecord
       member.password = Devise.friendly_token[0, 20]
     end
   end
-
-  # Action CableのコネクションのIDを作成する際に呼ばれる
-  # https://github.com/rails/rails/blob/dd8f7185faeca6ee968a6e9367f6d8601a83b8db/actioncable/lib/action_cable/connection/identification.rb#L38
-  def to_gid_param
-    to_global_id.to_param
-  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -41,12 +41,6 @@ class Member < ApplicationRecord
     attendance_list(from:, to:).pop(12)
   end
 
-  # Action CableのコネクションのIDを作成する際に呼ばれる
-  # https://github.com/rails/rails/blob/dd8f7185faeca6ee968a6e9367f6d8601a83b8db/actioncable/lib/action_cable/connection/identification.rb#L38
-  def to_gid_param
-    to_global_id.to_param
-  end
-
   private
 
   def attendance_list(from: created_at, to: nil)


### PR DESCRIPTION
## Issue
- #238 

## 概要
`Admin`モデルと`Member`モデルに`to_gid_param`というメソッドを定義していたが、このメソッドは定義せずとも呼び出せることが確認できたため、削除した。

詳細についてはIssueを参照。
