### PR TITLE
アプリのセットアップコードを整備

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ require:
 AllCops:
   NewCops: enable
 
+Layout/LineLength:
+  Max: 200
+
 RSpec/StringAsInstanceDoubleConstant:
   Enabled: true
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -48,8 +48,8 @@ class Member < ApplicationRecord
           .where(course_id:)
           .where(meeting_date: from..to)
           .order(:meeting_date)
-          .pluck(:id, :meeting_date, attendances: %i[status time absence_reason])
-          .map { |data| { minute_id: data[0], date: data[1], status: data[2], time: data[3], absence_reason: data[4] } }
+          .pluck(:id, :meeting_date, attendances: %i[id status time absence_reason])
+          .map { |data| { minute_id: data[0], date: data[1], attendance_id: data[2], status: data[3], time: data[4], absence_reason: data[5] } }
   end
 
   def split_for_display(attendances)

--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -10,8 +10,8 @@
   <% attendances.each do |attendance| %>
     <div class="w-16 text-center first:border-l border-r border-b border-gray-400 p-2" data-table-body="<%= attendance[:date].strftime('%Y-%m-%d') %>">
       <% if attendance[:status] == 'absent' %>
-        <span data-tooltip-target="tooltip_absence_reason">欠席</span>
-        <div id="tooltip_absence_reason" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">
+        <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
+        <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">
           <%= attendance[:absence_reason] %>
           <div class="tooltip-arrow" data-popper-arrow></div>
         </div>

--- a/bin/setup
+++ b/bin/setup
@@ -18,7 +18,7 @@ FileUtils.chdir APP_ROOT do
   system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies
-  system("yarn install --check-files")
+  system!("npm ci")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,6 +55,11 @@ members = members_data.map do |member_data|
   end
 end
 
+# Memberのcreated_atにシード実行の日時が保存されると期待した通りに出席を取得できない可能性があるため、created_atの日付を固定しておく
+members.each do |member|
+  member.update!(created_at: Time.zone.local(2025, 1, 1))
+end
+
 rookie_member = Member.find_by(email: 'rookie_member@example.com')
 rookie_member.update!(created_at: Time.zone.local(2026, 1, 10))
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,10 +4,163 @@
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
-Course.find_or_create_by!(name: 'Railsエンジニアコース') do |course|
-  course.meeting_week = :odd
+# add course data
+courses_data = [{ name: 'Railsエンジニアコース', meeting_week: :odd }, { name: 'フロントエンドエンジニアコース', meeting_week: :even }]
+courses = courses_data.map do |course_data|
+  Course.find_or_create_by!(name: course_data[:name]) do |course|
+    course.meeting_week = course_data[:meeting_week]
+  end
 end
 
-Course.find_or_create_by!(name: 'フロントエンドエンジニアコース') do |course|
-  course.meeting_week = :even
+# add member data
+members_data = [
+  {
+    email: 'day_attendee@example.com',
+    name: 'day_attendee'
+  },
+  {
+    email: 'night_attendee@example.com',
+    name: 'night_attendee'
+  },
+  {
+    email: 'absentee@example.com',
+    name: 'absentee'
+  },
+  {
+    email: 'unexcused_absentee@example.com',
+    name: 'unexcused_absentee'
+  },
+  {
+    email: 'hibernated_member@example.com',
+    name: 'hibernated_member'
+  },
+  {
+    email: 'returned_member@example.com',
+    name: 'returned_member'
+  },
+  {
+    email: 'rookie_member@example.com',
+    name: 'rookie_member'
+  }
+]
+
+members = members_data.map do |member_data|
+  Member.find_or_create_by!(email: member_data[:email]) do |member|
+    member.password = 'password'
+    member.provider = 'developer'    # developer認証でログインできるように、providerはdeveloperにしておく
+    member.uid = member_data[:email] # developer認証でログインできるように、uidにはemailの値にしておく
+    member.name = member_data[:name]
+    member.avatar_url = 'https://i.gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3.png'
+    member.course = courses.first
+  end
+end
+
+rookie_member = Member.find_by(email: 'rookie_member@example.com')
+rookie_member.update!(created_at: Time.zone.local(2026, 1, 10))
+
+# add admin data
+admins_data = [
+  {
+    email: 'komagata@example.com',
+    uid: 211_111,
+    name: 'komagata'
+  }
+]
+
+admins = admins_data.map do |admin_data|
+  Admin.find_or_create_by!(email: admin_data[:email]) do |admin|
+    admin.password = 'password'
+    admin.provider = 'github'
+    admin.uid = admin_data[:uid]
+    admin.name = admin_data[:name]
+    admin.avatar_url = 'https://i.gyazo.com/40600d4c2f36e6ec49ec17af0ef610d3.png'
+  end
+end
+
+# add member hibernation data
+hibernated_member = Member.find_by(email: 'hibernated_member@example.com')
+hibernated_member_hibernation = hibernated_member.hibernations.create!
+hibernated_member_hibernation.update!(created_at: Time.zone.local(2025, 6, 30))
+
+returned_member = Member.find_by(email: 'returned_member@example.com')
+returned_member_hibernation = returned_member.hibernations.create!
+returned_member_hibernation.update!(created_at: Time.zone.local(2025, 6, 30), finished_at: Time.zone.local(2025, 8, 15))
+
+# add minute data
+meeting_dates = [
+  { meeting_date: Time.zone.local(2025, 1, 15), next_meeting_date: Time.zone.local(2025, 2, 5) },
+  { meeting_date: Time.zone.local(2025, 2, 5), next_meeting_date: Time.zone.local(2025, 2, 19) },
+  { meeting_date: Time.zone.local(2025, 2, 19), next_meeting_date: Time.zone.local(2025, 3, 5) },
+  { meeting_date: Time.zone.local(2025, 3, 5), next_meeting_date: Time.zone.local(2025, 3, 19) },
+  { meeting_date: Time.zone.local(2025, 3, 19), next_meeting_date: Time.zone.local(2025, 4, 2) },
+  { meeting_date: Time.zone.local(2025, 4, 2), next_meeting_date: Time.zone.local(2025, 4, 16) },
+  { meeting_date: Time.zone.local(2025, 4, 16), next_meeting_date: Time.zone.local(2025, 5, 7) },
+  { meeting_date: Time.zone.local(2025, 5, 7), next_meeting_date: Time.zone.local(2025, 5, 21) },
+  { meeting_date: Time.zone.local(2025, 5, 21), next_meeting_date: Time.zone.local(2025, 6, 4) },
+  { meeting_date: Time.zone.local(2025, 6, 4), next_meeting_date: Time.zone.local(2025, 6, 18) },
+  { meeting_date: Time.zone.local(2025, 6, 18), next_meeting_date: Time.zone.local(2025, 7, 2) },
+  { meeting_date: Time.zone.local(2025, 7, 2), next_meeting_date: Time.zone.local(2025, 7, 16) },
+  { meeting_date: Time.zone.local(2025, 7, 16), next_meeting_date: Time.zone.local(2025, 8, 6) },
+  { meeting_date: Time.zone.local(2025, 8, 6), next_meeting_date: Time.zone.local(2025, 8, 20) },
+  { meeting_date: Time.zone.local(2025, 8, 20), next_meeting_date: Time.zone.local(2025, 9, 3) },
+  { meeting_date: Time.zone.local(2025, 9, 3), next_meeting_date: Time.zone.local(2025, 9, 17) },
+  { meeting_date: Time.zone.local(2025, 9, 17), next_meeting_date: Time.zone.local(2025, 10, 1) },
+  { meeting_date: Time.zone.local(2025, 10, 1), next_meeting_date: Time.zone.local(2025, 10, 15) },
+  { meeting_date: Time.zone.local(2025, 10, 15), next_meeting_date: Time.zone.local(2025, 11, 5) },
+  { meeting_date: Time.zone.local(2025, 11, 5), next_meeting_date: Time.zone.local(2025, 11, 19) },
+  { meeting_date: Time.zone.local(2025, 11, 19), next_meeting_date: Time.zone.local(2025, 12, 3) },
+  { meeting_date: Time.zone.local(2025, 12, 3), next_meeting_date: Time.zone.local(2025, 12, 17) },
+  { meeting_date: Time.zone.local(2025, 12, 17), next_meeting_date: Time.zone.local(2026, 1, 7) },
+  { meeting_date: Time.zone.local(2026, 1, 7), next_meeting_date: Time.zone.local(2026, 1, 21) }
+]
+
+minutes = meeting_dates.map do |date|
+  Minute.find_or_create_by(meeting_date: date[:meeting_date]) do |minute|
+    minute.release_branch = ''
+    minute.release_note = ''
+    minute.other = ''
+    minute.meeting_date = date[:meeting_date]
+    minute.next_meeting_date = date[:next_meeting_date]
+    minute.course = courses.first
+  end
+end
+
+# add topic data
+Topic.find_or_create_by!(minute: minutes.last, topicable: members.first) { |topic| topic.content = 'CI上でテストが落ちてしまいます' }
+Topic.find_or_create_by!(minute: minutes.last, topicable: members.second) { |topic| topic.content = '動作確認のお手伝いをしてくださる方を募集中です' }
+Topic.find_or_create_by!(minute: minutes.last, topicable: admins.first) { |topic| topic.content = '合同企業説明会がありますので是非ご参加ください' }
+
+# add attendance data
+day_attendee = Member.find_by(email: 'day_attendee@example.com')
+night_attendee = Member.find_by(email: 'night_attendee@example.com')
+absentee = Member.find_by(email: 'absentee@example.com')
+
+minutes.each do |minute|
+  Attendance.find_or_create_by!(minute:, member: day_attendee) do |attendance|
+    attendance.status = :present
+    attendance.time = :day
+  end
+  Attendance.find_or_create_by!(minute:, member: night_attendee) do |attendance|
+    attendance.status = :present
+    attendance.time = :night
+  end
+  Attendance.find_or_create_by!(minute:, member: absentee) do |attendance|
+    attendance.status = :absent
+    attendance.absence_reason = '仕事の都合のため'
+    attendance.progress_report = '今週の進捗はありません、仕事が忙しく時間が取れずにいます。'
+  end
+end
+
+Minute.where(meeting_date: ..hibernated_member_hibernation.created_at).find_each do |minute|
+  Attendance.find_or_create_by!(minute:, member: hibernated_member) do |attendance|
+    attendance.status = :present
+    attendance.time = :day
+  end
+end
+
+Minute.where.not(meeting_date: returned_member_hibernation.created_at..returned_member_hibernation.finished_at).find_each do |minute|
+  Attendance.find_or_create_by!(minute:, member: returned_member) do |attendance|
+    attendance.status = :present
+    attendance.time = :night
+  end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -35,34 +35,34 @@ RSpec.describe Member, type: :model do
 
     it 'returns all attendances since the member sign up' do
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 9, 18), course: rails_course)
-      expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), status: 'present', time: 'day', absence_reason: nil },
-                              { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), status: 'absent', time: nil, absence_reason: '体調不良のため。' },
-                              { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), status: nil, time: nil, absence_reason: nil }]
+      expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil },
+                              { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', time: nil, absence_reason: '体調不良のため。' },
+                              { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [expected_attendances] })
     end
 
     it 'returns attendances until the hibernation started if the member is hibernated' do
       FactoryBot.create(:hibernation, member:, created_at: Time.zone.local(2024, 11, 1))
 
-      attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), status: 'present', time: 'day', absence_reason: nil },
-                                       { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), status: 'absent', time: nil, absence_reason: '体調不良のため。' }]
+      attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil },
+                                       { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', time: nil, absence_reason: '体調不良のため。' }]
       expect(member.all_attendances).to eq({ 2024 => [attendances_until_hibernation] })
     end
 
     it 'does not include attendances during hibernated period' do
       FactoryBot.create(:hibernation, finished_at: Time.zone.local(2024, 10, 31), member:, created_at: Time.zone.local(2024, 10, 3))
 
-      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), status: 'present', time: 'day', absence_reason: nil }]
-      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), status: nil, time: nil, absence_reason: nil }]
+      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil }]
+      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [attendances_before_hibernation, attendances_after_hibernation] })
     end
 
     it 'divides attendances by year' do
       latest_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
-      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), status: 'present', time: 'day', absence_reason: nil },
-                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), status: 'absent', time: nil, absence_reason: '体調不良のため。' },
-                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), status: nil, time: nil, absence_reason: nil }]
-      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), status: nil, time: nil, absence_reason: nil }]
+      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil },
+                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', time: nil, absence_reason: '体調不良のため。' },
+                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
+      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [first_year_attendances], 2025 => [second_year_attendances] })
     end
 
@@ -98,9 +98,9 @@ RSpec.describe Member, type: :model do
     end
 
     it 'returns recent attendances up to twelve' do
-      first_attendance = { minute_id: rails_course.minutes.first.id, date: Date.new(2025, 12, 18), status: nil, time: nil, absence_reason: nil }
-      second_attendance = { minute_id: rails_course.minutes.second.id, date: Date.new(2025, 1, 1), status: nil, time: nil, absence_reason: nil }
-      last_attendance = { minute_id: rails_course.minutes.last.id, date: Date.new(2025, 6, 18), status: nil, time: nil, absence_reason: nil }
+      first_attendance = { minute_id: rails_course.minutes.first.id, date: Date.new(2025, 12, 18), attendance_id: nil, status: nil, time: nil, absence_reason: nil }
+      second_attendance = { minute_id: rails_course.minutes.second.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, time: nil, absence_reason: nil }
+      last_attendance = { minute_id: rails_course.minutes.last.id, date: Date.new(2025, 6, 18), attendance_id: nil, status: nil, time: nil, absence_reason: nil }
 
       expect(member.recent_attendances.length).to eq 12
       expect(member.recent_attendances).not_to include(first_attendance)

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -49,10 +49,11 @@ RSpec.describe 'Members', type: :system do
         expect(page).to have_selector 'div[data-table-head="2025-02-19"]', text: '02/19'
         expect(page).to have_selector 'div[data-table-body="2025-02-19"]', text: '---'
 
-        expect(page).not_to have_selector 'div#tooltip_absence_reason', text: '体調不良のため。'
+        attendance = Attendance.find_by(status: :absent)
+        expect(page).not_to have_selector "div#absence_reason_for_attendance_#{attendance.id}", text: '体調不良のため。'
         within('div[data-table-body="2025-02-05"]') do
-          find('span[data-tooltip-target="tooltip_absence_reason"]').hover
-          expect(page).to have_selector 'div#tooltip_absence_reason', text: '体調不良のため。'
+          find("span[data-tooltip-target='absence_reason_for_attendance_#{attendance.id}']").hover
+          expect(page).to have_selector "div#absence_reason_for_attendance_#{attendance.id}", text: '体調不良のため。'
         end
       end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
## Issue
- #229 

## 概要
アプリ生成時に追加された`bin/setup`ファイルに、以下を追加した。

- JavaScriptの依存関係をインストールするコードを追加
- テストデータを追加するようにseeds.rbに追記

また、以下の問題が発覚したため修正を行なった。
- 出席表示で複数欠席が表示される場合、一番最後の欠席しか欠席理由のツールチップが表示されない問題を修正

### ツールチップ問題の修正
以下の原因により欠席理由のツールチップが一つしか表示されない状態だった問題を修正した。

修正前のコード
```
    <div class="w-16 text-center first:border-l border-r border-b border-gray-400 p-2" data-table-body="<%= attendance[:date].strftime('%Y-%m-%d') %>">
      <% if attendance[:status] == 'absent' %>
        <span data-tooltip-target="tooltip_absence_reason">欠席</span>
        <div id="tooltip_absence_reason" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">
          <%= attendance[:absence_reason] %>
          <div class="tooltip-arrow" data-popper-arrow></div>
        </div>
      <% else %>
        <%= attendance_status(attendance[:status], attendance[:time]) %>
      <% end %>
    </div>
```

`data-tooltip-target`の値とツールチップの中身を格納するdivのidに`tooltip_absence_reason`という値を格納している。
flowbiteでツールチップの使い方を確認してみると、異なるツールチップには異なるidの値を指定する必要があることがわかった。

[tooltip_absence_reason](https://flowbite.com/docs/components/tooltips/#tooltip-styles)

そのため、idの値は`absence_reason_for_attendance_#{出席のID}`とするように変更を行った。
これに関連し、出席データの中に出席のIDを含むように、出席データの構造を変更している。
