### PR TITLE
落ちるようになったテストを修正

### DIFF
--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Members', type: :system do
       end
 
       scenario 'display attendances until the hibernation started if the member is hibernated', :js do
-        hibernated_member = FactoryBot.create(:member, :another_member, course: rails_course)
+        hibernated_member = FactoryBot.create(:member, :another_member, course: rails_course, created_at: Time.zone.local(2025, 1, 1))
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 15), course: rails_course)
         FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 2, 5), course: rails_course)


### PR DESCRIPTION
## Issue
なし

## 概要
`spec/system/members_spec.rb:107 `が落ちるようになっていたため、修正を行なった。

### テストが落ちる原因
該当のテストコードは以下の通り。
```ruby
      scenario 'display attendances until the hibernation started if the member is hibernated', :js do
        hibernated_member = FactoryBot.create(:member, :another_member, course: rails_course)
        FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
        FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 15), course: rails_course)
        FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 2, 5), course: rails_course)
        FactoryBot.create(:hibernation, member: hibernated_member, created_at: Time.zone.local(2025, 2, 1))

        visit member_path(hibernated_member)
        expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
        expect(page).to have_selector 'div[data-table-head="2025-01-15"]', text: '01/15'
        expect(page).not_to have_selector 'div[data-table-head="2025-02-05"]', text: '02/15'
      end
```

テスト内で、チーム開発を離脱する前の`2025/1/1`と`2025/1/15`の出席が表示されていることを確認している。
テスト失敗時のエラーメッセージによると、`2025/1/1`の出席が表示されておらずテストが失敗している。

```
     Failure/Error: expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
       expected to find css "div[data-table-head=\"2025-01-01\"]" but there were no matches
```

以下の理由でテストが落ちるようになったと推測される。
- チームメンバーの出席は、チームメンバーがアプリに登録した日(`created_at`)以降の出席を取得するようになっている
- テストが落ちるようになった日付`2025/1/2`は、テスト内で作成されているメンバー(`hibernated_member`)の`created_at`が`2025/1/2`となる
- `hibernated_member`の出席は`2025/1/2`以降の出席が取得されるため、`2025/1/1`の出席は取得されず、表示もされない

### 解決策
`hibernated_member`を作成する際、`created_at`に保存される日付が現在時刻にならないよう、日付を指定するようにした。

