### PR TITLE
テスト名がおかしい箇所を修正

### DIFF
--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance to already finished meeting' do
+    scenario 'member cannot edit attendance for the finished meeting' do
       attendance = FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date + 1.day do
         visit edit_attendance_path(attendance)


### PR DESCRIPTION
## Issue
なし

## 概要
system/attendances_spec.rb:271のテスト名がテスト内容と合っていなかったため、修正を行なった。
