### PR TITLE
開発用のログインボタンの位置を修正

### DIFF
--- a/app/views/home/_developer_login_button.html.erb
+++ b/app/views/home/_developer_login_button.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center mt-12">
+<div class="flex justify-center my-8">
   <% Course.all.each do |course| %>
     <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
       <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mx-10"><%= course.name %>でログイン(開発環境用)</button>


### PR DESCRIPTION
## Issue
なし

## 概要
開発環境で表示している開発用のログインボタンの位置がフッターと近づきすぎていたため、距離を開けて表示するように修正を行なった。

## Screenshot
修正前
![39D2D2C8-A650-4B4A-A3E7-DCC3AFA95332](https://github.com/user-attachments/assets/d5bcba8e-d495-44b6-85dc-0b1321ffab71)

修正後
![C8FA446E-82EF-47B1-AC12-0C6B0BCE539F](https://github.com/user-attachments/assets/922f318c-3376-4eef-a9f6-2b60dd5f2329)



