### PR TITLE
h1が存在しないページにh1を追加

### DIFF
--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -3,7 +3,7 @@
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
 
-    <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h2>
+    <h1 class="mb-8 text-4xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h1>
 
     <% if admin_signed_in? %>
       <% active_tab = params[:status] ? params[:status] : 'active' %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -3,7 +3,7 @@
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
 
-    <h2 class="mb-8 text-2xl font-bold text-center"><%= "#{@course.name}の議事録" %></h2>
+    <h1 class="mb-8 text-4xl font-bold text-center"><%= "#{@course.name}の議事録" %></h1>
 
     <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>
     <%= render 'years_tab', course: @course, active_tab: active_tab %>


### PR DESCRIPTION
## Issue
- #233 

## 概要
以下のページはh1が存在しなかったため、h2を削除してh1を追加した。

- `/courses/:course_id/members`
- `/courses/:course_id/minutes`


