### PR TITLE
出席登録ページと編集ページで、クリックできる要素に`cursor: pointer;`を追加

### DIFF
--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -18,18 +18,18 @@
 
       <div class="my-5 text-center">
         <p><%= Attendance.human_attribute_name('status') %></p>
-        <%= form.radio_button :status, "present" %>
-        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10" %>
-        <%= form.radio_button :status, "absent" %>
-        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent') %>
+        <%= form.radio_button :status, "present", class: "cursor-pointer" %>
+        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10 cursor-pointer" %>
+        <%= form.radio_button :status, "absent", class: "cursor-pointer" %>
+        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent'), class: "cursor-pointer" %>
       </div>
 
       <div class="my-5 text-center present_entry_field">
         <p><%= Attendance.human_attribute_name('time') %></p>
-        <%= form.radio_button :time, "day" %>
-        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10" %>
-        <%= form.radio_button :time, "night" %>
-        <%= form.label :time_night, Attendance.human_attribute_name('time.night') %>
+        <%= form.radio_button :time, "day", class: "cursor-pointer" %>
+        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10 cursor-pointer" %>
+        <%= form.radio_button :time, "night", class: "cursor-pointer" %>
+        <%= form.label :time_night, Attendance.human_attribute_name('time.night'), class: "cursor-pointer" %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
@@ -43,7 +43,7 @@
       </div>
 
       <div class="text-center">
-        <%= form.submit "#{Attendance.model_name.human}を更新", class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+        <%= form.submit "#{Attendance.model_name.human}を更新", class: "button cursor-pointer" %>
       </div>
     <% end %>
   </div>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -18,18 +18,18 @@
 
       <div class="my-5 text-center">
         <p><%= Attendance.human_attribute_name('status') %></p>
-        <%= form.radio_button :status, "present" %>
-        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10" %>
-        <%= form.radio_button :status, "absent" %>
-        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent') %>
+        <%= form.radio_button :status, "present", class: "cursor-pointer" %>
+        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10 cursor-pointer" %>
+        <%= form.radio_button :status, "absent", class: "cursor-pointer" %>
+        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent'), class: "cursor-pointer" %>
       </div>
 
       <div class="my-5 text-center present_entry_field">
         <p><%= Attendance.human_attribute_name('time') %></p>
-        <%= form.radio_button :time, "day" %>
-        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10" %>
-        <%= form.radio_button :time, "night" %>
-        <%= form.label :time_night, Attendance.human_attribute_name('time.night') %>
+        <%= form.radio_button :time, "day", class: "cursor-pointer" %>
+        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10 cursor-pointer" %>
+        <%= form.radio_button :time, "night", class: "cursor-pointer" %>
+        <%= form.label :time_night, Attendance.human_attribute_name('time.night'), class: "cursor-pointer" %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
@@ -43,7 +43,7 @@
       </div>
 
       <div class="text-center">
-        <%= form.submit "#{Attendance.model_name.human}を登録", class: "button" %>
+        <%= form.submit "#{Attendance.model_name.human}を登録", class: "button cursor-pointer" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## Issue
- #233 

## 概要
出席登録ページ(`/minutes/:minute_id/attendances/new`)と出席編集ページ(`/attendances/:id/edit`)で、以下の要素に`cursor: pointer;`を追加した。

- 各ラジオボタン
- 送信ボタン

## Screenshot
変更前
[![Image from Gyazo](https://i.gyazo.com/1aa8088dd006b3b2273e69158170a5c0.gif)](https://gyazo.com/1aa8088dd006b3b2273e69158170a5c0)

変更後
[![Image from Gyazo](https://i.gyazo.com/a03560187562d1878a952a283c257a7a.gif)](https://gyazo.com/a03560187562d1878a952a283c257a7a)

