### PR TITLE
imageタグにaltを追加、修正を行なった

### DIFF
--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -14,7 +14,7 @@
       <ul class="list-disc list-inside">
         <% @members.each do |member| %>
           <li class="mb-6" data-member="<%= member.id %>">
-            <%= image_tag member.avatar_url, class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
+            <%= image_tag member.avatar_url, alt: "#{member.name}の画像", class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
             <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
             <% if member.hibernated? %>
               <span class="text-sm text-gray-500">離脱中</span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,7 +15,7 @@
           </li>
           <li class="block">
             <a href="/" class="navbar_item">
-              <%= image_tag(current_development_member.avatar_url, alt: 'ログインしているユーザーの画像', class: "w-8 h-8 rounded-full") %>
+              <%= image_tag(current_development_member.avatar_url, alt: "ダッシュボード", class: "w-8 h-8 rounded-full") %>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Issue
- #233 

## 概要
imageタグの`alt`属性に関して、以下の修正を行なった。

- メンバー一覧ページ(`/courses/:course_id/members`)で表示されるメンバーの画像に`alt`属性が付与されていなかったため、追加した
- ヘッダーで表示される画像リンクに関して、その画像の`alt`属性がリンクとして使われる旨を表すように修正した
  - 参考 : https://developer.mozilla.org/ja/docs/Web/API/HTMLImageElement/alt#%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%A8%E3%81%97%E3%81%A6%E4%BD%BF%E3%82%8F%E3%82%8C%E3%82%8B%E7%94%BB%E5%83%8F 

## Screenshot
### メンバー一覧ページ
修正前
![308CFE40-186F-4367-BF70-C9602DAD94C0_4_5005_c](https://github.com/user-attachments/assets/835f68fc-fd2b-4809-a427-d7378297b29a)

修正後
![A857CC72-8D58-4AAD-B932-C345D9ACC87A_4_5005_c](https://github.com/user-attachments/assets/9ba8139c-b4c9-4979-82d6-c47334b018a9)

### ヘッダー
修正前
![D3A4CD5F-D5E0-4587-9CE3-98ABD27D96DA_4_5005_c](https://github.com/user-attachments/assets/e2503661-8e5c-430b-9381-4af00ab8acd2)


修正後
![49DFA969-D7A4-4551-803B-3983C6FAF2E4_4_5005_c](https://github.com/user-attachments/assets/dba412e5-44da-44e4-bfe3-c1193da7852d)


