### PR TITLE
話題にしたいこと・心配事の編集ボタンと削除ボタンの見た目を変更した

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -28,12 +28,6 @@
     .button_cancel {
         @apply inline-block text-blue-700 hover:bg-blue-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-blue-700;
     }
-    .button_danger {
-        @apply text-white bg-red-700 hover:bg-red-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
-    }
-    .button_danger_cancel {
-        @apply inline-block text-red-700 hover:bg-red-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-red-700;
-    }
     .input_type_text {
         @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -83,14 +83,14 @@ function Topic({
               <button
                 type="button"
                 onClick={() => setIsEditing(true)}
-                className="button"
+                className="hover:bg-gray-100 font-medium border border-gray-400 rounded-lg text-sm px-2 py-1 me-2 mb-2 ml-2"
               >
                 編集
               </button>
               <button
                 type="button"
                 onClick={handleDelete}
-                className="button_danger"
+                className="text-gray-400 hover:bg-gray-100 font-medium border border-gray-400 rounded-lg text-sm px-2 py-1 me-2 mb-2 ml-2"
               >
                 削除
               </button>


### PR DESCRIPTION
## Issue
- #233 

## 概要
議事録編集ページで、自分が作成した話題にしたいこと・心配事には編集ボタンと削除ボタンが表示される。
それらのボタンの見た目が目立ちすぎていたため、目立たなくなるよう修正を行なった。

上記に関連して、TailwindのカスタムCSSで使われなくなったものを削除している。

## Screenshot
修正前
![F32F0A7E-AEB2-44A1-9119-E4F0FA8FBC72_4_5005_c](https://github.com/user-attachments/assets/8cd24902-9605-418d-8dc1-5eec19c40d99)


修正後
![9EE63FE6-ABF2-4AEF-8672-C0EBF33AD97D_4_5005_c](https://github.com/user-attachments/assets/a31b3c9d-4e43-4268-a0c1-4028cdda3073)

