### PR TITLE
入力欄にプレースホルダを追加

### DIFF
--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -53,6 +53,7 @@ function EditForm({ minuteId, content }) {
     <>
       <textarea
         value={inputValue}
+        placeholder="- RubyKaigiに参加するため、次回のミーティングは⚪︎月⚪︎日に行います"
         onChange={handleChange}
         id="other_field"
         className="textarea"

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -8,6 +8,7 @@ export default function ReleaseInformationForm({
   description,
   content,
   isAdmin,
+  course,
 }) {
   const [informationContent, setInformationContent] = useState(content)
   const [isEditing, setIsEditing] = useState(false)
@@ -35,6 +36,7 @@ export default function ReleaseInformationForm({
               minuteId={minuteId}
               description={description}
               content={informationContent}
+              course={course}
               setIsEditing={setIsEditing}
             />
           ) : (
@@ -50,7 +52,7 @@ export default function ReleaseInformationForm({
   )
 }
 
-function EditForm({ minuteId, description, content, setIsEditing }) {
+function EditForm({ minuteId, description, content, course, setIsEditing }) {
   const [inputValue, setInputValue] = useState(content)
   const handleInput = function (e) {
     setInputValue(e.target.value)
@@ -77,11 +79,22 @@ function EditForm({ minuteId, description, content, setIsEditing }) {
     }
   }
 
+  const placeholder = (description, course) => {
+    if (description === 'note') {
+      return 'https://bootcamp.fjord.jp/announcements/1000'
+    } else {
+      return course === 'Railsエンジニアコース'
+        ? 'https://github.com/fjordllc/bootcamp/pull/8000'
+        : 'https://github.com/fjordllc/agent/pull/40'
+    }
+  }
+
   return (
     <li>
       <input
         type="text"
         value={inputValue}
+        placeholder={placeholder(description, course)}
         onChange={handleInput}
         id={`release_${description}_field`}
         className="input_type_text"
@@ -115,12 +128,14 @@ ReleaseInformationForm.propTypes = {
   description: PropTypes.string,
   content: PropTypes.string,
   isAdmin: PropTypes.bool,
+  course: PropTypes.string,
 }
 
 EditForm.propTypes = {
   minuteId: PropTypes.number,
   description: PropTypes.string,
   content: PropTypes.string,
+  course: PropTypes.string,
   setIsEditing: PropTypes.func,
 }
 

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -192,6 +192,7 @@ function CreateForm({ minuteId }) {
       <input
         type="text"
         value={inputValue}
+        placeholder="Good First Issueをモブプロでやったらとても勉強になりました！"
         onChange={handleInput}
         id="new_topic_field"
         className="input_type_text"

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -34,12 +34,12 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :absence_reason %>
-        <%= form.text_field :absence_reason, class: 'input_type_text' %>
+        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため' ,class: 'input_type_text' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report %>
-        <%= form.text_field :progress_report, class: 'input_type_text' %>
+        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text' %>
       </div>
 
       <div class="text-center">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -34,12 +34,12 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :absence_reason, Attendance.human_attribute_name('absence_reason') %>
-        <%= form.text_field :absence_reason, class: 'input_type_text' %>
+        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため', class: 'input_type_text' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report, Attendance.human_attribute_name('progress_report') %>
-        <%= form.text_field :progress_report, class: 'input_type_text' %>
+        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text' %>
       </div>
 
       <div class="text-center">

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -15,8 +15,8 @@
 
     <h2>今週のリリースの確認</h2>
     <p>木曜日の15時頃リリースします。</p>
-    <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: admin_signed_in?}.to_json do %><% end %>
-    <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: admin_signed_in?}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
 
     <h2>話題にしたいこと・心配事</h2>
     <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>


### PR DESCRIPTION
## Issue
- #233 

## 概要
以下の入力欄にプレースホルダを追加した。
- 議事録編集ページ
  - リリースブランチ入力欄
  - リリースノート入力欄
  - 話題にしたいこと・心配事入力欄
  - その他入力欄   
- 出席作成ページ
  - 欠席理由入力欄
  - 進捗報告入力欄 
- 出席編集ページ
  - 欠席理由入力欄
  - 進捗報告入力欄 

## Screenshot
### 議事録編集ページ
- リリースブランチ入力欄
- リリースノート入力欄

![B5E8F711-3BAD-44BC-B847-C6DBA7737E94](https://github.com/user-attachments/assets/e2484181-e5b5-458d-84f9-8024b3ea20e4)

リリースブランチに関して、フロントエンドエンジニアコースの議事録ではagentのリポジトリのURLが表示される。
![6437A038-DA22-407B-B54F-9470F2241862_4_5005_c](https://github.com/user-attachments/assets/d1ed69fa-fdf2-45d9-a1ae-7a5c75cad9f3)

- 話題にしたいこと・心配事入力欄

![1E637B5E-A044-488C-9F1C-D3A5E45777C7_4_5005_c](https://github.com/user-attachments/assets/6583fce9-3556-43fb-90d2-ac4b73c6c2d9)

- その他入力欄  

![698E3F22-F1FA-4F19-854F-DF32AEB4397F_4_5005_c](https://github.com/user-attachments/assets/3361f3aa-2748-4ca6-a5fb-a745bed5043c)


### 出席作成ページ

![D345E019-BBEB-436B-835C-8466ADCCC16B](https://github.com/user-attachments/assets/8a6d9983-3ac2-4de1-98fe-00304ccd8a35)

### 出席編集ページ

![2E752EB7-0503-4862-83E0-6D2CCAE0276C](https://github.com/user-attachments/assets/44173238-663a-41b7-8b3c-81108db126e9)

