### PR TITLE
議事録や話題にしたいこと・心配事が0である時、その旨を表示するようにした

### DIFF
--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -2,6 +2,8 @@
 
 class Courses::MinutesController < Courses::ApplicationController
   def index
+    return @minutes = [] if @course.minutes.none?
+
     year = params[:year] ? params[:year].to_i : @course.meeting_years.max
     @minutes = @course.minutes.where(meeting_date: Time.zone.local(year, 1, 1, 0, 0, 0)..Time.zone.local(year, 12, 31, 23, 59, 59)).order(:created_at)
   end

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -20,17 +20,21 @@ export default function TopicList({
 
   return (
     <>
-      <ul>
-        {allTopics.map((topic) => (
-          <Topic
-            key={topic.id}
-            minuteId={minuteId}
-            topic={topic}
-            currentDevelopmentMemberId={currentDevelopmentMemberId}
-            currentDevelopmentMemberType={currentDevelopmentMemberType}
-          />
-        ))}
-      </ul>
+      {allTopics.length === 0 ? (
+        <p>話題にしたいこと・心配事はありません。</p>
+      ) : (
+        <ul>
+          {allTopics.map((topic) => (
+            <Topic
+              key={topic.id}
+              minuteId={minuteId}
+              topic={topic}
+              currentDevelopmentMemberId={currentDevelopmentMemberId}
+              currentDevelopmentMemberType={currentDevelopmentMemberType}
+            />
+          ))}
+        </ul>
+      )}
       <CreateForm minuteId={minuteId} />
     </>
   )

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -9,18 +9,22 @@
     <%= render 'years_tab', course: @course, active_tab: active_tab %>
 
     <div>
-      <ul class="list-disc list-inside">
-        <% @minutes.each do |minute| %>
-          <li class="mb-4">
-            <%= link_to "#{minute.title}", minute, class: "py-3 inline-block" %>
-            <% if minute.exported? %>
-              <span class="ml-2">
-                <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>
-              </span>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
+      <% if @minutes.none? %>
+        <p><%= "#{@course.name}の議事録はまだ作成されていません。" %></p>
+      <% else %>
+        <ul class="list-disc list-inside">
+          <% @minutes.each do |minute| %>
+            <li class="mb-4">
+              <%= link_to "#{minute.title}", minute, class: "py-3 inline-block" %>
+              <% if minute.exported? %>
+                <span class="ml-2">
+                  <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>
+                </span>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -59,9 +59,12 @@ RSpec.describe 'Minutes', type: :system do
 
       scenario 'can create, edit and delete topic', :js do
         within('#topics') do
+          expect(page).to have_content '話題にしたいこと・心配事はありません。'
+
           expect(find('button', text: '作成')).to be_disabled
           fill_in 'new_topic_field', with: '今週ミートアップがありますのでぜひご参加を！'
           click_button '作成'
+          expect(page).not_to have_content '話題にしたいこと・心配事はありません。'
           expect(page).to have_selector 'li', text: '今週ミートアップがありますのでぜひご参加を！(admin)'
           expect(page).to have_selector 'button', text: '編集'
           expect(page).to have_selector 'button', text: '削除'

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -188,10 +188,14 @@ RSpec.describe 'Minutes', type: :system do
     end
 
     scenario 'display minutes by course' do
+      visit course_minutes_path(rails_course)
+      expect(page).to have_content 'Railsエンジニアコースの議事録はまだ作成されていません。'
+
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 2), course: rails_course)
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 10, 9), course: front_end_course)
 
       visit course_minutes_path(rails_course)
+      expect(page).not_to have_content 'Railsエンジニアコースの議事録はまだ作成されていません。'
       expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月02日'
       expect(page).not_to have_link 'ふりかえり・計画ミーティング2024年10月09日'
 


### PR DESCRIPTION
## Issue
- #233 

## 概要
以下のページに、何も作成されていない場合の表示を追加した。

- 議事録編集ページ
  - 話題にしたいこと・心配事が0の時の表示
- 議事録一覧ページ
  - 議事録が0の時の表示
  

## Screenshot
### 議事録編集ページ
![53742A2B-F265-40A4-87B7-949DEF2989C2_4_5005_c](https://github.com/user-attachments/assets/5b53beca-8bb6-4101-bfc1-253bf63a24ce)


### 議事録一覧ページ

![E72F4083-47DD-49F1-9363-2D28687F530C](https://github.com/user-attachments/assets/82da9679-3992-469f-9b25-4c775299e5a2)


## 備考
### メンバー一覧ページ
メンバー一覧ページにメンバーが0の時の表示を追加するか検討を行ったが、開発メンバーが0人となる場合はあまり考えられないと判断し、実装する必要はないと考えた。

### 議事録一覧ページ
議事録一覧ページは、ローカル環境で発生した以下のエラーの対応に関連して、議事録が0の場合の表示を追加している。


エラー内容
ローカルで`bin/setup`を実行したのち、アプリを起動してフロントエンドエンジニアコースの議事録一覧ページにアクセスすると、次のエラーが表示される。

![4EC0875A-57FC-4D6C-AD54-3C9173548A31](https://github.com/user-attachments/assets/7ccd34ae-5ad0-4d6b-8a1d-f7dfa9a8947e)

シードデータではフロントエンドエンジニアコースのデータを追加していない。
そのため、`@course.meeting_years.max`が`nil`を返し、`Time.zone.local(nil, 1, 1, 0, 0, 0)`という呼び出しが行われ、エラーが発生してしまった。

エラーの解決策として、議事録が作成されていない場合にコントローラー内で早期リターンを行うようにしている。

