### PR TITLE
管理者のダッシュボードの見た目を修正

### DIFF
--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -5,24 +5,22 @@
   <% @courses.each do |course| %>
     <div class="mb-10" data-course="<%= course.id %>">
       <h2 class="text-2xl font-bold mb-4"><%= course.name %></h2>
-      <p class="mb-2">議事録</p>
-      <p class="mb-2 pl-4"><%= link_to "議事録一覧", course_minutes_path(course) %></p>
-
-      <p class="mb-2">メンバー</p>
-      <p class="mb-2 pl-4"><%= link_to "所属メンバー一覧", course_members_path(course) %></p>
-
-      <p class="mb-2">ミーティング</p>
-      <p class="mb-2 pl-4">
-        ミーティング開催週 :
-        <span class="font-bold"><%= Course.human_attribute_name("meeting_week.#{course.meeting_week}") %></span>
-      </p>
-      <p class="mb-2 pl-4">次回ミーティングの議事録 :
-        <% if course.minutes.none? %>
-          まだ議事録は作成されていません
-        <% else %>
-          <%= link_to "#{course.minutes.order(:meeting_date).last.title}", edit_minute_path(course.minutes.order(:meeting_date).last) %>
-        <% end %>
-      </p>
+      <ul>
+        <li class="mb-2"><%= link_to "議事録一覧", course_minutes_path(course) %></li>
+        <li class="mb-2"><%= link_to "所属メンバー一覧", course_members_path(course) %></li>
+        <li class="mb-2">
+          <span class="after:content-['\00a0:']">ミーティング開催週</span>
+          <span class="font-bold"><%= Course.human_attribute_name("meeting_week.#{course.meeting_week}") %></span>
+        </li>
+        <li class="mb-2">
+          <span class="after:content-['\00a0:']">最新の議事録</span>
+          <% if course.minutes.none? %>
+            まだ議事録は作成されていません
+          <% else %>
+            <%= link_to "#{course.minutes.order(:meeting_date).last.title}", edit_minute_path(course.minutes.order(:meeting_date).last) %>
+          <% end %>
+        </li>
+      </ul>
     </div>
   <% end %>
 </div>

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -64,13 +64,13 @@ RSpec.describe 'Homes', type: :system do
     within("div[data-course='#{rails_course.id}']") do
       expect(page).to have_link '議事録一覧', href: course_minutes_path(rails_course)
       expect(page).to have_link 'メンバー一覧', href: course_members_path(rails_course)
-      expect(page).to have_content 'ミーティング開催週 : 奇数週 (第一・第三週)'
+      expect(page).to have_content '奇数週 (第一・第三週)'
       expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月16日', href: edit_minute_path(rails_course_latest_minute)
     end
     within("div[data-course='#{front_end_course.id}']") do
       expect(page).to have_link '議事録一覧', href: course_minutes_path(front_end_course)
       expect(page).to have_link 'メンバー一覧', href: course_members_path(front_end_course)
-      expect(page).to have_content 'ミーティング開催週 : 偶数週 (第二・第四週)'
+      expect(page).to have_content '偶数週 (第二・第四週)'
       expect(page).to have_link 'ふりかえり・計画ミーティング2024年10月23日', href: edit_minute_path(front_end_course_latest_minute)
     end
   end


### PR DESCRIPTION
## Issue
なし

## 概要
管理者のダッシュボードには各コースの情報を表示しているが、その見た目がリスト表示になるように修正した。

## Screenshot
修正前
![272909C1-FCF6-414A-8B0F-7D1F776A9161](https://github.com/user-attachments/assets/a337fbf1-3abc-4f05-92a0-46057c9d8521)

修正後
![5458C541-B1FF-441C-9B93-C726A6FD8E6C](https://github.com/user-attachments/assets/2844c95c-a216-465b-b98e-02eab303e9c3)

## 備考
擬似要素の中に空白を含める方法については[こちら](https://stackoverflow.com/questions/5467605/add-a-space-after-an-element-using-after)を参照した。
