### PR TITLE
スマホで表示した際のデザイン崩れを修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -29,7 +29,7 @@
         @apply inline-block text-blue-700 hover:bg-blue-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-blue-700;
     }
     .input_type_text {
-        @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] max-w-full field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
+        @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block max-w-full field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
     .textarea {
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -29,7 +29,7 @@
         @apply inline-block text-blue-700 hover:bg-blue-100 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-8 focus:outline-none border border-blue-700;
     }
     .input_type_text {
-        @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
+        @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block min-w-[400px] max-w-full field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
     .textarea {
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -35,10 +35,10 @@
         @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
     .large_tab_item {
-        @apply inline-block p-4 rounded-t-lg text-gray-500 border border-b-0 border-gray-300 hover:bg-blue-50 hover:no-underline;
+        @apply inline-block px-2 py-4 rounded-t-lg text-gray-500 border border-b-0 border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }
     .active_large_tab_item {
-        @apply inline-block p-4 rounded-t-lg text-white font-bold bg-blue-700 border border-b-0 border-gray-300 hover:no-underline;
+        @apply inline-block px-2 py-4 rounded-t-lg text-white font-bold bg-blue-700 border border-b-0 border-gray-300 hover:no-underline text-xs md:px-4 md:text-base;
     }
     .small_tab_item {
         @apply inline-block px-4 py-2 text-gray-600 border border-gray-300 rounded-3xl hover:bg-blue-50 hover:no-underline;

--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -43,7 +43,10 @@ export default function MinutePreview({ markdown }) {
 
       <div>
         {selectedTab === 'markdown' ? (
-          <pre id="raw_markdown" className="p-4 border border-gray-300">
+          <pre
+            id="raw_markdown"
+            className="p-4 border border-gray-300 whitespace-pre-wrap break-all"
+          >
             {markdown}
           </pre>
         ) : (

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -58,7 +58,7 @@ function EditForm({ minuteId, content }) {
         id="other_field"
         className="textarea"
       />
-      <button type="button" onClick={handleClick} className="button">
+      <button type="button" onClick={handleClick} className="button mt-2">
         更新
       </button>
     </>

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -99,7 +99,7 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
         id={`release_${description}_field`}
         className="input_type_text"
       />
-      <button type="button" onClick={handleClick} className="button">
+      <button type="button" onClick={handleClick} className="button mt-2">
         更新
       </button>
     </li>

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -153,7 +153,7 @@ function EditForm({ minuteId, topicId, content, setIsEditing }) {
         type="button"
         onClick={handleClick}
         disabled={isEmpty}
-        className="button disabled:bg-slate-50 disabled:text-slate-500 disabled:border disabled:border-gray-300 disabled:hover:cursor-not-allowed"
+        className="button mt-2 disabled:bg-slate-50 disabled:text-slate-500 disabled:border disabled:border-gray-300 disabled:hover:cursor-not-allowed"
       >
         更新
       </button>
@@ -205,7 +205,7 @@ function CreateForm({ minuteId }) {
         type="button"
         onClick={handleClick}
         disabled={isEmpty}
-        className="button disabled:bg-slate-50 disabled:text-slate-500 disabled:border disabled:border-gray-300 disabled:hover:cursor-not-allowed"
+        className="button mt-2 disabled:bg-slate-50 disabled:text-slate-500 disabled:border disabled:border-gray-300 disabled:hover:cursor-not-allowed"
       >
         作成
       </button>

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -34,12 +34,12 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :absence_reason %>
-        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため' ,class: 'input_type_text' %>
+        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため' ,class: 'input_type_text min-w-[400px]' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report %>
-        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text' %>
+        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text min-w-[400px]' %>
       </div>
 
       <div class="text-center">

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -3,7 +3,7 @@
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
 
-    <h1 class="mb-8 text-4xl font-bold text-center"><%= "#{@course.name}のメンバー" %></h1>
+    <h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}のメンバー" %></h1>
 
     <% if admin_signed_in? %>
       <% active_tab = params[:status] ? params[:status] : 'active' %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -3,7 +3,7 @@
   <div class="mx-auto">
     <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
 
-    <h1 class="mb-8 text-4xl font-bold text-center"><%= "#{@course.name}の議事録" %></h1>
+    <h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}の議事録" %></h1>
 
     <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>
     <%= render 'years_tab', course: @course, active_tab: active_tab %>
@@ -15,7 +15,7 @@
         <ul class="list-disc list-inside">
           <% @minutes.each do |minute| %>
             <li class="mb-4">
-              <%= link_to "#{minute.title}", minute, class: "py-3 inline-block" %>
+              <%= link_to "#{minute.title}", minute, class: "py-3 inline-block text-sm md:text-base" %>
               <% if minute.exported? %>
                 <span class="ml-2">
                   <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -1,5 +1,5 @@
 <div class="mb-8">
-  <ul class="flex flex-wrap text-sm text-center border-b border-gray-300 !list-none">
+  <ul class="flex flex-wrap text-center border-b border-gray-300 !list-none pl-4 md:pl-8">
     <% Course.all.each do |course| %>
       <li class="me-2">
         <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>

--- a/app/views/home/_developer_login_button.html.erb
+++ b/app/views/home/_developer_login_button.html.erb
@@ -1,7 +1,7 @@
-<div class="flex justify-center my-8">
+<div class="my-8 text-center md:flex md:justify-center">
   <% Course.all.each do |course| %>
     <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-      <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mx-10"><%= course.name %>でログイン(開発環境用)</button>
+      <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mb-4 mx-10 w-[300px]"><%= course.name %>でログイン(開発環境用)</button>
     <% end %>
   <% end %>
 </div>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,10 +1,10 @@
 <% set_meta_tags(build_meta_tags(title: 'ダッシュボード', description: 'ダッシュボードページです。')) %>
 <div class="w-full">
-  <h1 class="font-bold text-4xl text-center mb-8">管理ページ</h1>
+  <h1 class="font-bold text-xl text-center mb-8 md:text-4xl">管理ページ</h1>
 
   <% @courses.each do |course| %>
     <div class="mb-10" data-course="<%= course.id %>">
-      <h2 class="text-2xl font-bold mb-4"><%= course.name %></h2>
+      <h2 class="text-lg font-bold mb-4 md:text-2xl"><%= course.name %></h2>
       <ul>
         <li class="mb-2"><%= link_to "議事録一覧", course_minutes_path(course) %></li>
         <li class="mb-2"><%= link_to "所属メンバー一覧", course_members_path(course) %></li>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,32 +1,32 @@
 <% set_meta_tags(build_meta_tags(description: 'FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。')) %>
 <div>
-  <h1 class="font-bold text-2xl text-center my-12">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理でより効率的に</h1>
+  <h1 class="font-bold text-xl text-center my-12 md:text-2xl">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理で<br class="md:hidden">より効率的に</h1>
 
-  <div class="flex justify-evenly mb-12">
-    <div class="py-4 border border-gray-400 rounded-md w-64 flex flex-col items-center">
-      <svg class="w-20 h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <div class="flex justify-around mb-12">
+    <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
+      <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 5V4a1 1 0 0 0-1-1H8.914a1 1 0 0 0-.707.293L4.293 7.207A1 1 0 0 0 4 7.914V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-5M9 3v4a1 1 0 0 1-1 1H4m11.383.772 2.745 2.746m1.215-3.906a2.089 2.089 0 0 1 0 2.953l-6.65 6.646L9 17.95l.739-3.692 6.646-6.646a2.087 2.087 0 0 1 2.958 0Z" />
       </svg>
-      <p class="mt-2">議事録を自動で作成</p>
+      <p class="text-xs text-center mt-2 md:text-base">議事録を自動で作成</p>
     </div>
-    <div class="py-4 border border-gray-400 rounded-md w-64 flex flex-col items-center">
-      <svg class="w-20 h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
+      <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 10V4a1 1 0 0 0-1-1H9.914a1 1 0 0 0-.707.293L5.293 7.207A1 1 0 0 0 5 7.914V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2M10 3v4a1 1 0 0 1-1 1H5m5 6h9m0 0-2-2m2 2-2 2" />
       </svg>
-      <p class="text-center mt-2">議事録の内容からMarkdownを<br>作成し、GitHub Wikiに出力</p>
+      <p class="text-xs text-center mt-2 md:text-base">議事録の内容からMarkdownを<br>作成し、GitHub Wikiに出力</p>
     </div>
-    <div class="py-4 border border-gray-400 rounded-md w-64 flex flex-col items-center">
-      <svg class="w-20 h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+    <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
+      <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z" />
       </svg>
-      <p class="text-center mt-2">チームメンバーのミーティング<br>出席状況を一括表示</p>
+      <p class="text-xs text-center mt-2 md:text-base">チームメンバーのミーティング<br>出席状況を一括表示</p>
     </div>
   </div>
 
-  <div class="flex justify-center mb-2">
+  <div class="text-center md:flex md:justify-center">
     <% Course.all.order(id: :asc).each do |course| %>
       <%= form_tag("/auth/github?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-        <button type='submit' class="text-white bg-blue-600 hover:bg-blue-700 font-medium rounded-lg text-sm px-6 py-4 mx-10">
+        <button type='submit' class="text-white bg-blue-600 hover:bg-blue-700 font-medium rounded-lg text-sm px-6 py-4 mb-4 w-[300px] md:mx-10">
           <%= "#{course.name}で登録" %>
         </button>
       <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,12 +1,12 @@
 <nav id="header" class="border-b-2 border-gray-200">
   <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto px-4 py-2">
     <a href="/" class="flex items-center">
-      <%= image_tag('logo.png', alt: 'Fjord Minutesのロゴ画像', class: "h-12") %>
+      <%= image_tag('logo.png', alt: 'Fjord Minutesのロゴ画像', class: "h-8 md:h-12") %>
     </a>
 
     <% if development_member_signed_in? %>
       <div class="block w-auto">
-        <ul class="font-medium flex items-center flex-row p-0 rounded-lg space-x-8 !list-none">
+        <ul class="font-medium flex items-center flex-row p-0 rounded-lg space-x-2 !list-none md:space-x-8">
           <li class="block">
             <%= link_to '議事録', member_signed_in? ? course_minutes_path(current_member.course) : course_minutes_path(Course.first) %>
           </li>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -2,7 +2,7 @@
 <% description = @member == current_development_member ? 'ダッシュボードページです。' : "#{@member.name}さんの出席一覧ページです。" %>
 <% set_meta_tags(build_meta_tags(title:, description:)) %>
 <div class="w-full">
-  <h1 class="font-bold text-4xl mb-8">
+  <h1 class="font-bold text-xl mb-8 md:text-4xl">
     <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>
   </h1>
 

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -34,12 +34,12 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :absence_reason, Attendance.human_attribute_name('absence_reason') %>
-        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため', class: 'input_type_text' %>
+        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため', class: 'input_type_text min-w-[400px]' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report, Attendance.human_attribute_name('progress_report') %>
-        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text' %>
+        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text min-w-[400px]' %>
       </div>
 
       <div class="text-center">

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録", description: "#{@minute.title}の議事録のページです。")) %>
 <div class="mx-auto w-full">
   <div class="mx-auto">
-    <h1 class="mb-8 text-4xl font-bold"><%= @minute.title %></h1>
+    <h1 class="mb-8 text-xl font-bold md:text-4xl"><%= @minute.title %></h1>
 
     <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Homes', type: :system do
     FactoryBot.create(:front_end_course)
 
     visit root_path
-    expect(page).to have_selector 'h1', text: "フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを\n議事録の自動作成と出席管理でより効率的に"
+    expect(page).to have_selector 'h1', text: "フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを\n議事録の自動作成と出席管理で\nより効率的に"
     expect(page).to have_button 'Railsエンジニアコースで登録'
     expect(page).to have_button 'フロントエンドエンジニアコースで登録'
   end


### PR DESCRIPTION
## Issue
- #233 

## 概要
以下のページは画面の幅をスマホの幅で表示するとデザインが崩れてしまっていたため、修正を行なった。

- Home#index
- ヘッダー
- 管理者のマイページ
- メンバーのマイページ(メンバーshow)
- 議事録show
- 議事録edit
- コースに紐づくメンバーindex
- コースに紐づく議事録index

画面幅が狭い場合、メンバー一覧ページとメンバー詳細ページで表示される出席テーブルの表示が崩れる問題が発生している。
この問題に関しては、デザインレビュー時に町田さんから修正のアドバイスをしていただくこととなったため、当PRでは修正を行なっていない。

## Screenshot
- Home#index

![D57B5B87-B652-4365-9705-2C941A5E36EC](https://github.com/user-attachments/assets/1d125787-406b-4e5a-a102-3d713cb15720)

- ヘッダー

![D020DDEC-1FA7-4E4C-A7FD-7AB493BD0E6C_4_5005_c](https://github.com/user-attachments/assets/00256eaa-d1e5-45c6-8b5e-09f4a21bdb82)

- 管理者のマイページ

![DA364DE8-E8DB-41B7-B13C-BD345A057BB6](https://github.com/user-attachments/assets/662e5176-462f-41de-8e71-9313444d5e86)


- メンバーのマイページ(メンバーshow)

![BCA30AE1-FD78-464B-9715-A437F92C8CBD](https://github.com/user-attachments/assets/ac738a52-03da-4052-8d21-3e148efe39da)

- 議事録show

[![Image from Gyazo](https://i.gyazo.com/4491626cc2e99bba6f512c889a772b63.gif)](https://gyazo.com/4491626cc2e99bba6f512c889a772b63)

- 議事録edit

[![Image from Gyazo](https://i.gyazo.com/dcf050a41190b779ee0752a6a94a364b.gif)](https://gyazo.com/dcf050a41190b779ee0752a6a94a364b)

- コースに紐づくメンバーindex

![3F2308D8-2018-43CF-BAD0-71310CD08374](https://github.com/user-attachments/assets/6425c91c-8d99-42bc-90b0-ba4115289101)

- コースに紐づく議事録index

![B2936C08-C809-4773-B63B-24FED862FF54](https://github.com/user-attachments/assets/eba56d6b-857e-4ff2-9819-c6f38a600ec7)
