### PR TITLE
アプリを携帯端末で見た場合の、スタイルシートが読み込まれる前の背景色とステータスバーの色を設定

### DIFF
--- a/app/views/pwa/manifest.json.erb
+++ b/app/views/pwa/manifest.json.erb
@@ -17,6 +17,6 @@
   "display": "standalone",
   "scope": "/",
   "description": "FjordMinutes.",
-  "theme_color": "red",
-  "background_color": "red"
+  "theme_color": "#1D4ED8",
+  "background_color": "white"
 }


### PR DESCRIPTION
## Issue
- #258 

## 概要
アプリをスマホで見た際、ステータスバーが赤色となって違和感があったため、アプリ内で使っている青色となるよう設定を変更した。

## 備考
### ウェブアプリマニフェストについて
PWAはアプリをネイティブアプリのように見せることが可能だが、そのために必要な情報をJSONで渡す必要がある。
このファイルのことをウェブアプリマニフェストと呼ぶ。

Rails7では以下のようにウェブアプリマニフェストが読み込まれている。

- `<head>`タグ内で`<link rel="manifest" href="/manifest.json">`が読み込まれている
- 該当のファイルは`app/views/pwa/manifest.json.erb`に存在する

今回はウェブアプリマニフェストの設定で、以下の項目を変更した。

- `background_color`
  - アプリを起動してからスタイルシートが読み込まれる前に表示される、アプリケーションページの背景色を定義する
- `theme_color`
  - アプリケーションのテーマカラーを定義
  - 端末やOSによって使われ方が異なる
    - 携帯端末ではステータスバーに適用される
    - デスクトップOSでは、PWAをローカルにインストールして起動する際に、以下の図のようにタイトルバーの色となる
  
![0660BEA0-BC3B-440A-B9AA-13C4717F0022](https://github.com/user-attachments/assets/162a94b7-e9a1-4e2c-9831-1023aad0f4a5)




参考
- https://developer.mozilla.org/ja/docs/Web/Manifest
- https://developer.mozilla.org/ja/docs/Web/Manifest
