### PR TITLE
編集フォームのエラーを解決するため、議事録のカラムにデフォルト値を追加

### DIFF
--- a/db/migrate/20250111062114_add_default_to_release_branch_and_release_note_in_minutes.rb
+++ b/db/migrate/20250111062114_add_default_to_release_branch_and_release_note_in_minutes.rb
@@ -1,0 +1,6 @@
+class AddDefaultToReleaseBranchAndReleaseNoteInMinutes < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default(:minutes, :release_branch, '')
+    change_column_default(:minutes, :release_note, '')
+  end
+end

--- a/db/migrate/20250111063340_add_default_to_other_in_minutes.rb
+++ b/db/migrate/20250111063340_add_default_to_other_in_minutes.rb
@@ -1,0 +1,5 @@
+class AddDefaultToOtherInMinutes < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default(:minutes, :other, '')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_062114) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_063340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,7 +74,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_062114) do
   create_table "minutes", force: :cascade do |t|
     t.string "release_branch", default: ""
     t.string "release_note", default: ""
-    t.text "other"
+    t.text "other", default: ""
     t.date "meeting_date"
     t.date "next_meeting_date"
     t.datetime "notified_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_03_220952) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_11_062114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,8 +72,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_03_220952) do
   end
 
   create_table "minutes", force: :cascade do |t|
-    t.string "release_branch"
-    t.string "release_note"
+    t.string "release_branch", default: ""
+    t.string "release_note", default: ""
     t.text "other"
     t.date "meeting_date"
     t.date "next_meeting_date"


### PR DESCRIPTION
## Issue
- #255 

## 概要
議事録編集フォームでリリースブランチ・リリースノート編集ボタンを押すと、``value` prop on `input` should not be null.`というエラーが発生する問題を解消するため、リリースブランチとリリースノートの値はデフォルト値で空文字列となるようにDBを変更した。

また、その他編集フォームに対してもコンポーネントに渡される値が`null`となってしまうのを防ぐため、デフォルト値を設定している。

## 備考
### textareaのvalue
ドキュメントによると、`<textarea />`の`value`に`null`を渡してはいけないとあるため、その他編集フォームにもデフォルト値を設定した。

> 制御されたコンポーネントは常に文字列の value を受け取るべきであり、null や undefined であってはいけません。

> あなたの value が API や state 変数から来ている場合、それが null や undefined に初期化されているかもしれません。その場合、まず空の文字列（''）にセットするか、value が文字列であることを保証するために value={someValue ?? ''} を渡すようにしてください。

https://ja.react.dev/reference/react-dom/components/textarea#im-getting-an-error-a-component-is-changing-an-uncontrolled-input-to-be-controlled

