### PR TITLE
READMEに議事録編集時のリアルタイム反映機能についての記述を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ $ bin/dev
 
 http://localhost:3000/ にアクセスすると、アプリのトップページが表示されます。
 
+### リアルタイム反映機能
+議事録編集ページでは、議事録を変更するとそれが他のブラウザ上でもリアルタイムで反映されるようになっています。
+
+この機能を利用するためにはRedisが必要となります。
+
+Redisのインストールと起動方法については、以下のページを参考にしてください。
+
+[Install Redis \| Docs](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
+
 ## Lint
 以下のコマンドでLinterを実行することができます。
 ```


### PR DESCRIPTION
## Issue
- #267 

## 概要
議事録編集ページのリアルタイム編集機能を利用するためにはRedisが起動している必要があるため、この機能とRedisの利用方法についてREADMEに追加した。


