### PR TITLE
出席テーブルのレイアウト崩れ問題を修正し、一部表示を変更した

### DIFF
--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -1,23 +1,22 @@
-<div class="flex">
-  <% attendances.each do |attendance| %>
-    <div class="w-16 text-center first:border [&:nth-child(n+2)]:border-t [&:nth-child(n+2)]:border-r [&:nth-child(n+2)]:border-b border-gray-400 p-2 bg-gray-200"
-         data-table-head="<%= attendance[:date].strftime('%Y-%m-%d') %>">
-      <%= attendance[:date].strftime('%m/%d') %>
-    </div>
-  <% end %>
-</div>
-<div class="flex">
-  <% attendances.each do |attendance| %>
-    <div class="w-16 text-center first:border-l border-r border-b border-gray-400 p-2" data-table-body="<%= attendance[:date].strftime('%Y-%m-%d') %>">
-      <% if attendance[:status] == 'absent' %>
-        <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
-        <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">
-          <%= attendance[:absence_reason] %>
-          <div class="tooltip-arrow" data-popper-arrow></div>
-        </div>
-      <% else %>
-        <%= attendance_status(attendance[:status], attendance[:time]) %>
-      <% end %>
-    </div>
-  <% end %>
+<div class="flex flex-col gap-x-0 gap-y-6">
+  <dl class="flex flex-wrap gap-x-0 gap-y-1">
+    <% attendances.each do |attendance| %>
+      <div class="flex flex-col justify-center items-center text-center -mr-[1px]">
+        <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]">
+          <%= attendance[:date].strftime('%m/%d') %>
+        </dt>
+        <dd class="p-1 text-sm border border-gray-400 w-12 text-center">
+          <% if attendance[:status] == 'absent' %>
+            <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
+            <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">
+              <%= attendance[:absence_reason] %>
+              <div class="tooltip-arrow" data-popper-arrow></div>
+            </div>
+          <% else %>
+            <%= attendance_status(attendance[:status], attendance[:time]) %>
+          <% end %>
+        </dd>
+      </div>
+    <% end %>
+  </dl>
 </div>

--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -2,11 +2,11 @@
   <dl class="flex flex-wrap gap-x-0 gap-y-1">
     <% attendances.each do |attendance| %>
       <div class="flex flex-col justify-center items-center text-center -mr-[1px]">
-        <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]">
+        <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]" data-attendance-on="<%= attendance[:date].strftime('%Y-%m-%d') %>">
           <%= attendance[:date].strftime('%m/%d') %>
         </dt>
         <% background_color = attendance[:status].nil? ? 'bg-gray-200' : 'bg-white' %>
-        <dd class="p-1 text-sm border border-gray-400 w-12 text-center <%= background_color %>">
+        <dd class="p-1 text-sm border border-gray-400 w-12 text-center <%= background_color %>" data-attendance-on="<%= attendance[:date].strftime('%Y-%m-%d') %>">
           <% if attendance[:status] == 'absent' %>
             <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
             <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">

--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -5,7 +5,8 @@
         <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]">
           <%= attendance[:date].strftime('%m/%d') %>
         </dt>
-        <dd class="p-1 text-sm border border-gray-400 w-12 text-center">
+        <% background_color = attendance[:status].nil? ? 'bg-gray-200' : 'bg-white' %>
+        <dd class="p-1 text-sm border border-gray-400 w-12 text-center <%= background_color %>">
           <% if attendance[:status] == 'absent' %>
             <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
             <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -40,18 +40,18 @@ RSpec.describe 'Members', type: :system do
         FactoryBot.create(:attendance, :absence, member:, minute: rails_course.minutes.third)
 
         visit member_path(member)
-        expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
-        expect(page).to have_selector 'div[data-table-body="2025-01-01"]', text: '昼'
-        expect(page).to have_selector 'div[data-table-head="2025-01-15"]', text: '01/15'
-        expect(page).to have_selector 'div[data-table-body="2025-01-15"]', text: '夜'
-        expect(page).to have_selector 'div[data-table-head="2025-02-05"]', text: '02/05'
-        expect(page).to have_selector 'div[data-table-body="2025-02-05"]', text: '欠席'
-        expect(page).to have_selector 'div[data-table-head="2025-02-19"]', text: '02/19'
-        expect(page).to have_selector 'div[data-table-body="2025-02-19"]', text: '---'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-01-01"]', text: '01/01'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-01-01"]', text: '昼'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-01-15"]', text: '01/15'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-01-15"]', text: '夜'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-02-05"]', text: '02/05'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-02-05"]', text: '欠席'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-02-19"]', text: '02/19'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-02-19"]', text: '---'
 
         attendance = Attendance.find_by(status: :absent)
         expect(page).not_to have_selector "div#absence_reason_for_attendance_#{attendance.id}", text: '体調不良のため。'
-        within('div[data-table-body="2025-02-05"]') do
+        within('dd[data-attendance-on="2025-02-05"]') do
           find("span[data-tooltip-target='absence_reason_for_attendance_#{attendance.id}']").hover
           expect(page).to have_selector "div#absence_reason_for_attendance_#{attendance.id}", text: '体調不良のため。'
         end
@@ -67,12 +67,12 @@ RSpec.describe 'Members', type: :system do
         expect(page).to have_selector 'div[data-meeting-year="2025"]'
 
         within('div[data-meeting-year="2024"]') do
-          expect(page).to have_selector 'div[data-table-head="2024-12-18"]', text: '12/18'
-          expect(page).to have_selector 'div[data-table-body="2024-12-18"]', text: '昼'
+          expect(page).to have_selector 'dt[data-attendance-on="2024-12-18"]', text: '12/18'
+          expect(page).to have_selector 'dd[data-attendance-on="2024-12-18"]', text: '昼'
         end
         within('div[data-meeting-year="2025"]') do
-          expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
-          expect(page).to have_selector 'div[data-table-body="2025-01-01"]', text: '昼'
+          expect(page).to have_selector 'dt[data-attendance-on="2025-01-01"]', text: '01/01'
+          expect(page).to have_selector 'dd[data-attendance-on="2025-01-01"]', text: '昼'
         end
       end
 
@@ -90,18 +90,18 @@ RSpec.describe 'Members', type: :system do
         expect(page).to have_selector 'div[data-attendance-table="2"]'
 
         within('div[data-attendance-table="1"]') do
-          expect(page).to have_selector 'div[data-table-head]', count: 12
-          expect(page).to have_selector 'div[data-table-body]', count: 12
-          expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
-          expect(page).to have_selector 'div[data-table-body="2025-01-01"]', text: '昼'
-          expect(page).to have_selector 'div[data-table-head="2025-06-18"]', text: '06/18'
-          expect(page).to have_selector 'div[data-table-body="2025-06-18"]', text: '昼'
+          expect(page).to have_selector 'dt[data-attendance-on]', count: 12
+          expect(page).to have_selector 'dd[data-attendance-on]', count: 12
+          expect(page).to have_selector 'dt[data-attendance-on="2025-01-01"]', text: '01/01'
+          expect(page).to have_selector 'dd[data-attendance-on="2025-01-01"]', text: '昼'
+          expect(page).to have_selector 'dt[data-attendance-on="2025-06-18"]', text: '06/18'
+          expect(page).to have_selector 'dd[data-attendance-on="2025-06-18"]', text: '昼'
         end
         within('div[data-attendance-table="2"]') do
-          expect(page).to have_selector 'div[data-table-head]', count: 1
-          expect(page).to have_selector 'div[data-table-body]', count: 1
-          expect(page).to have_selector 'div[data-table-head="2025-07-02"]', text: '07/02'
-          expect(page).to have_selector 'div[data-table-body="2025-07-02"]', text: '昼'
+          expect(page).to have_selector 'dt[data-attendance-on]', count: 1
+          expect(page).to have_selector 'dd[data-attendance-on]', count: 1
+          expect(page).to have_selector 'dt[data-attendance-on="2025-07-02"]', text: '07/02'
+          expect(page).to have_selector 'dd[data-attendance-on="2025-07-02"]', text: '昼'
         end
       end
 
@@ -113,9 +113,9 @@ RSpec.describe 'Members', type: :system do
         FactoryBot.create(:hibernation, member: hibernated_member, created_at: Time.zone.local(2025, 2, 1))
 
         visit member_path(hibernated_member)
-        expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
-        expect(page).to have_selector 'div[data-table-head="2025-01-15"]', text: '01/15'
-        expect(page).not_to have_selector 'div[data-table-head="2025-02-05"]', text: '02/15'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-01-01"]', text: '01/01'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-01-15"]', text: '01/15'
+        expect(page).not_to have_selector 'dt[data-attendance-on="2025-02-05"]', text: '02/15'
       end
 
       scenario 'does not display attendances during the hibernated period', :js do
@@ -129,12 +129,12 @@ RSpec.describe 'Members', type: :system do
         expect(page).to have_selector 'div[data-attendance-table="2"]'
 
         within('div[data-attendance-table="1"]') do
-          expect(page).to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
-          expect(page).not_to have_selector 'div[data-table-head="2025-01-15"]', text: '01/15'
+          expect(page).to have_selector 'dt[data-attendance-on="2025-01-01"]', text: '01/01'
+          expect(page).not_to have_selector 'dt[data-attendance-on="2025-01-15"]', text: '01/15'
         end
         within('div[data-attendance-table="2"]') do
-          expect(page).to have_selector 'div[data-table-head="2025-02-05"]', text: '02/05'
-          expect(page).not_to have_selector 'div[data-table-head="2025-01-15"]', text: '01/15'
+          expect(page).to have_selector 'dt[data-attendance-on="2025-02-05"]', text: '02/05'
+          expect(page).not_to have_selector 'dt[data-attendance-on="2025-01-15"]', text: '01/15'
         end
       end
 
@@ -192,22 +192,22 @@ RSpec.describe 'Members', type: :system do
       login_as member
       visit course_members_path(rails_course)
       within("li[data-member='#{member.id}']") do
-        expect(page).to have_selector 'div[data-table-head]', count: 12
-        expect(page).to have_selector 'div[data-table-body]', count: 12
-        expect(page).not_to have_selector 'div[data-table-head="2025-01-01"]', text: '01/01'
-        expect(page).to have_selector 'div[data-table-head="2025-01-15"]', text: '01/15'
-        expect(page).to have_selector 'div[data-table-body="2025-01-15"]', text: '昼'
-        expect(page).to have_selector 'div[data-table-head="2025-07-02"]', text: '07/02'
-        expect(page).to have_selector 'div[data-table-body="2025-07-02"]', text: '昼'
+        expect(page).to have_selector 'dt[data-attendance-on]', count: 12
+        expect(page).to have_selector 'dd[data-attendance-on]', count: 12
+        expect(page).not_to have_selector 'dt[data-attendance-on="2025-01-01"]', text: '01/01'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-01-15"]', text: '01/15'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-01-15"]', text: '昼'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-07-02"]', text: '07/02'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-07-02"]', text: '昼'
       end
       within("li[data-member='#{another_member.id}']") do
-        expect(page).to have_selector 'div[data-table-head]', count: 7
-        expect(page).to have_selector 'div[data-table-body]', count: 7
-        expect(page).not_to have_selector 'div[data-table-head="2025-03-19"]', text: '03/19'
-        expect(page).to have_selector 'div[data-table-head="2025-04-02"]', text: '04/02'
-        expect(page).to have_selector 'div[data-table-body="2025-04-02"]', text: '夜'
-        expect(page).to have_selector 'div[data-table-head="2025-07-02"]', text: '07/02'
-        expect(page).to have_selector 'div[data-table-body="2025-07-02"]', text: '夜'
+        expect(page).to have_selector 'dt[data-attendance-on]', count: 7
+        expect(page).to have_selector 'dd[data-attendance-on]', count: 7
+        expect(page).not_to have_selector 'dt[data-attendance-on="2025-03-19"]', text: '03/19'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-04-02"]', text: '04/02'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-04-02"]', text: '夜'
+        expect(page).to have_selector 'dt[data-attendance-on="2025-07-02"]', text: '07/02'
+        expect(page).to have_selector 'dd[data-attendance-on="2025-07-02"]', text: '夜'
       end
     end
 


### PR DESCRIPTION
## Issue
- #271 

## 概要
デザインレビューの対応で、以下のことを行った。

- 画面幅が狭い場合に出席テーブルの表示が崩れてしまう問題を修正
- 無断欠席であることがわかりやすくなるように、無断欠席の場合は背景色にグレーを追加

## Screenshot
### 画面幅が狭い時の表示
- 修正前

![ADB79832-0C43-43C2-8856-B2D1FAA5D420](https://github.com/user-attachments/assets/5ec5503b-fe73-4deb-97b3-ab834c5a1eb6)

- 修正後
  - 画面幅が狭い場合はテーブルが折り返すようになっている

![9BEAF494-3708-41F6-A6A7-78C3BD4F1AB1](https://github.com/user-attachments/assets/4e4e9d78-482a-470e-9407-4ffbe99fd2b4)

### 無断欠席の表示
- 修正前

![97A47B99-ACB4-4C79-A7AA-47B2D563F8EF](https://github.com/user-attachments/assets/69b2b5bc-0a4b-4033-bdd8-2f1d6a572243)

- 修正後

![7893BD0A-E63A-4DCB-B26B-0F4C49940CB7_4_5005_c](https://github.com/user-attachments/assets/c88cb32a-727b-46ac-b54f-99ad6faee951)

