### PR TITLE
各ページの見出しにデザインを追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -50,9 +50,9 @@
         @apply inline-block px-4 py-2 text-white bg-blue-700 border border-gray-300 rounded-3xl hover:no-underline;
     }
     .flash_notice {
-        @apply py-2.5 px-4 text-green-500 bg-green-100 mb-5 font-medium rounded-lg inline-block;
+        @apply py-2.5 px-4 my-5 text-green-500 bg-green-100 font-medium rounded-lg inline-block;
     }
     .flash_alert {
-        @apply py-2.5 px-4 text-red-500 bg-red-100 mb-5 font-medium rounded-lg inline-block;
+        @apply py-2.5 px-4 my-5 text-red-500 bg-red-100 font-medium rounded-lg inline-block;
     }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -22,6 +22,9 @@
     .field_with_errors {
         display: inline;
     }
+    .page_header {
+        @apply text-white font-bold text-xl py-4 mb-8 md:text-2xl md:max-w-5xl md:mx-auto;
+    }
     .page_body {
         @apply max-w-5xl mx-auto;
     }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -22,6 +22,9 @@
     .field_with_errors {
         display: inline;
     }
+    .page_body {
+        @apply max-w-5xl mx-auto;
+    }
     .button {
         @apply text-white bg-blue-700 hover:bg-blue-800 font-medium rounded-lg text-sm px-4 py-2 me-2 mb-2 ml-2;
     }

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,5 +1,5 @@
 <% set_meta_tags(build_meta_tags(title: "#{@attendance.minute.title}の出席変更", description: "#{@attendance.minute.title}の出席を変更するページです。")) %>
-<div class="mx-auto w-full">
+<div class="page_body">
   <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}編集" %></h1>
 
   <div>

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,8 +1,12 @@
 <% set_meta_tags(build_meta_tags(title: "#{@attendance.minute.title}の出席変更", description: "#{@attendance.minute.title}の出席を変更するページです。")) %>
-<div class="page_body">
-  <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}編集" %></h1>
+<div class="bg-blue-700">
+  <h1 class="page_header"><%= "#{Attendance.model_name.human}編集" %></h1>
+</div>
 
+<div class="page_body">
   <div>
+    <p class="text-lg text-center"><%= @attendance.minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を編集</p>
+
     <%= form_with(model: @attendance, id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-4">
   <% if course.members.any? %>
-    <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
+    <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <li class="me-2">
         <%= link_to '現役', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'small_tab_item' %>
       </li>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,7 +1,9 @@
 <% set_meta_tags(build_meta_tags(title: "#{@course.name}のメンバー一覧", description: "#{@course.name}のチームメンバー一覧ページです。")) %>
 <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
 
-<h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}のメンバー" %></h1>
+<div class="bg-blue-700">
+  <h1 class="page_header"><%= "#{@course.name}のメンバー" %></h1>
+</div>
 
 <div class="page_body">
   <% if admin_signed_in? %>

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -1,40 +1,38 @@
 <% set_meta_tags(build_meta_tags(title: "#{@course.name}のメンバー一覧", description: "#{@course.name}のチームメンバー一覧ページです。")) %>
-<div class="mx-auto w-full">
-  <div class="mx-auto">
-    <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
+<%= render 'courses/tabs/course_tab', active_tab: @course, resource: Member %>
 
-    <h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}のメンバー" %></h1>
+<h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}のメンバー" %></h1>
 
-    <% if admin_signed_in? %>
-      <% active_tab = params[:status] ? params[:status] : 'active' %>
-      <%= render 'status_tab', course: @course, active_tab: active_tab %>
-    <% end %>
+<div class="page_body">
+  <% if admin_signed_in? %>
+    <% active_tab = params[:status] ? params[:status] : 'active' %>
+    <%= render 'status_tab', course: @course, active_tab: active_tab %>
+  <% end %>
 
-    <div>
-      <ul class="list-disc list-inside">
-        <% @members.each do |member| %>
-          <li class="mb-6" data-member="<%= member.id %>">
-            <%= image_tag member.avatar_url, alt: "#{member.name}の画像", class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
-            <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
-            <% if member.hibernated? %>
-              <span class="text-sm text-gray-500">離脱中</span>
-            <% end %>
-            <% if admin_signed_in? && !member.hibernated? %>
-              <div class="mt-2">
-                <%= link_to 'チームメンバーから外す', member_hibernations_path(member), data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんをチームメンバーから外します、よろしいですか？" },
-                                                                                    class: "text-sm text-gray-400" %>
-              </div>
-            <% end %>
-            <% if member.recent_attendances.empty? %>
-              <p class="mt-2"><%= member.name %>さんはまだミーティングに出席していません</p>
-            <% else %>
-              <div class="my-2">
-                <%= render 'shared/attendance_table', attendances: member.recent_attendances %>
-              </div>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+  <div>
+    <ul class="list-disc list-inside pl-0">
+      <% @members.each do |member| %>
+        <li class="mb-6" data-member="<%= member.id %>">
+          <%= image_tag member.avatar_url, alt: "#{member.name}の画像", class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
+          <%= link_to "#{member.name}", member, class: "py-3 inline-block" %>
+          <% if member.hibernated? %>
+            <span class="text-sm text-gray-500">離脱中</span>
+          <% end %>
+          <% if admin_signed_in? && !member.hibernated? %>
+            <div class="mt-2">
+              <%= link_to 'チームメンバーから外す', member_hibernations_path(member), data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんをチームメンバーから外します、よろしいですか？" },
+                                                                                  class: "text-sm text-gray-400" %>
+            </div>
+          <% end %>
+          <% if member.recent_attendances.empty? %>
+            <p class="mt-2"><%= member.name %>さんはまだミーティングに出席していません</p>
+          <% else %>
+            <div class="my-2">
+              <%= render 'shared/attendance_table', attendances: member.recent_attendances %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -1,6 +1,6 @@
 <div class="mb-4">
   <% if course.minutes.any? %>
-    <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 !list-none">
+    <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <% course.meeting_years.sort.each do |year| %>
         <li class="me-2">
           <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab_item' : 'small_tab_item' %>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,30 +1,28 @@
 <% set_meta_tags(build_meta_tags(title: "#{@course.name}の議事録一覧", description: "#{@course.name}の議事録一覧ページです。")) %>
-<div class="mx-auto w-full">
-  <div class="mx-auto">
-    <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
+<%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
 
-    <h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}の議事録" %></h1>
+<h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}の議事録" %></h1>
 
-    <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>
-    <%= render 'years_tab', course: @course, active_tab: active_tab %>
+<div class="page_body">
+  <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>
+  <%= render 'years_tab', course: @course, active_tab: active_tab %>
 
-    <div>
-      <% if @minutes.none? %>
-        <p><%= "#{@course.name}の議事録はまだ作成されていません。" %></p>
-      <% else %>
-        <ul class="list-disc list-inside">
-          <% @minutes.each do |minute| %>
-            <li class="mb-4">
-              <%= link_to "#{minute.title}", minute, class: "py-3 inline-block text-sm md:text-base" %>
-              <% if minute.exported? %>
-                <span class="ml-2">
-                  <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>
-                </span>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
-    </div>
+  <div>
+    <% if @minutes.none? %>
+      <p><%= "#{@course.name}の議事録はまだ作成されていません。" %></p>
+    <% else %>
+      <ul class="list-disc list-inside pl-0">
+        <% @minutes.each do |minute| %>
+          <li class="mb-4">
+            <%= link_to "#{minute.title}", minute, class: "py-3 inline-block text-sm md:text-base" %>
+            <% if minute.exported? %>
+              <span class="ml-2">
+                <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>
+              </span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </div>

--- a/app/views/courses/minutes/index.html.erb
+++ b/app/views/courses/minutes/index.html.erb
@@ -1,7 +1,9 @@
 <% set_meta_tags(build_meta_tags(title: "#{@course.name}の議事録一覧", description: "#{@course.name}の議事録一覧ページです。")) %>
 <%= render 'courses/tabs/course_tab', active_tab: @course, resource: Minute %>
 
-<h1 class="mb-8 text-xl font-bold text-center md:text-4xl"><%= "#{@course.name}の議事録" %></h1>
+<div class="bg-blue-700">
+  <h1 class="page_header"><%= "#{@course.name}の議事録" %></h1>
+</div>
 
 <div class="page_body">
   <% active_tab = params[:year] ? params[:year].to_i : @course.meeting_years.max %>

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -1,5 +1,5 @@
-<div class="mb-8">
-  <ul class="flex flex-wrap text-center border-b border-gray-300 !list-none pl-4 md:pl-8">
+<div class="pt-4 mb-8">
+  <ul class="flex flex-wrap text-center border-b border-gray-300 !list-none pl-4 md:pl-52">
     <% Course.all.each do |course| %>
       <li class="me-2">
         <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -1,9 +1,13 @@
 <div class="pt-4 mb-8">
-  <ul class="flex flex-wrap text-center border-b border-gray-300 !list-none pl-4 md:pl-52">
-    <% Course.all.each do |course| %>
-      <li class="me-2">
-        <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>
-      </li>
-    <% end %>
-  </ul>
+  <div class="border-b border-gray-300">
+    <div class="md:max-w-5xl md:mx-auto">
+      <ul class="flex flex-wrap text-center pl-0 !list-none">
+        <% Course.all.each do |course| %>
+          <li class="me-2">
+            <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
 </div>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: 'ダッシュボード', description: 'ダッシュボードページです。')) %>
-<div class="w-full">
-  <h1 class="font-bold text-xl text-center mb-8 md:text-4xl">管理ページ</h1>
+<h1 class="font-bold text-xl text-center mb-8 md:text-4xl">管理ページ</h1>
 
+<div class="page_body">
   <% @courses.each do |course| %>
     <div class="mb-10" data-course="<%= course.id %>">
       <h2 class="text-lg font-bold mb-4 md:text-2xl"><%= course.name %></h2>

--- a/app/views/home/admin_dashboard.html.erb
+++ b/app/views/home/admin_dashboard.html.erb
@@ -1,5 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: 'ダッシュボード', description: 'ダッシュボードページです。')) %>
-<h1 class="font-bold text-xl text-center mb-8 md:text-4xl">管理ページ</h1>
+<div class="bg-blue-700">
+  <h1 class="page_header">管理ページ</h1>
+</div>
 
 <div class="page_body">
   <% @courses.each do |course| %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(build_meta_tags(description: 'FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。')) %>
-<div>
-  <h1 class="font-bold text-xl text-center my-12 md:text-2xl">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理で<br class="md:hidden">より効率的に</h1>
+<h1 class="font-bold text-xl text-center my-12 md:text-2xl">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理で<br class="md:hidden">より効率的に</h1>
 
+<div class="page_body">
   <div class="flex justify-around mb-12">
     <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
       <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">

--- a/app/views/home/pp.html.erb
+++ b/app/views/home/pp.html.erb
@@ -1,6 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: 'プライバシーポリシー', description: 'プライバシーポリシーのページです。')) %>
-<div class="mx-auto w-full">
-  <h1 class="font-bold text-4xl text-center mb-4">プライバシーポリシー</h1>
+<h1 class="font-bold text-4xl text-center mb-4">プライバシーポリシー</h1>
+
+<div class="page_body">
   <p class="mb-8">「Fjord Minutes」（以下「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。</p>
 
   <h2 class="text-2xl font-bold mb-4">第1条（個人情報）</h2>

--- a/app/views/home/pp.html.erb
+++ b/app/views/home/pp.html.erb
@@ -1,7 +1,11 @@
 <% set_meta_tags(build_meta_tags(title: 'プライバシーポリシー', description: 'プライバシーポリシーのページです。')) %>
-<h1 class="font-bold text-4xl text-center mb-4">プライバシーポリシー</h1>
+<div class="bg-blue-700">
+  <h1 class="page_header">プライバシーポリシー</h1>
+</div>
 
 <div class="page_body">
+  <h2 class="text-3xl font-bold mb-4 text-center">プライバシーポリシー</h2>
+
   <p class="mb-8">「Fjord Minutes」（以下「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。</p>
 
   <h2 class="text-2xl font-bold mb-4">第1条（個人情報）</h2>

--- a/app/views/home/terms_of_service.html.erb
+++ b/app/views/home/terms_of_service.html.erb
@@ -1,7 +1,11 @@
 <% set_meta_tags(build_meta_tags(title: '利用規約', description: '利用規約のページです。')) %>
-<h1 class="font-bold text-4xl text-center mb-4">利用規約</h1>
+<div class="bg-blue-700">
+  <h1 class="page_header">利用規約</h1>
+</div>
 
 <div class="page_body">
+  <h2 class="text-3xl font-bold mb-4 text-center">利用規約</h2>
+
   <p class="mb-8">この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>
 
   <h2 class="text-2xl font-bold mb-4">第1条（適用）</h2>

--- a/app/views/home/terms_of_service.html.erb
+++ b/app/views/home/terms_of_service.html.erb
@@ -1,6 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: '利用規約', description: '利用規約のページです。')) %>
-<div class="mx-auto w-full">
-  <h1 class="font-bold text-4xl text-center mb-4">利用規約</h1>
+<h1 class="font-bold text-4xl text-center mb-4">利用規約</h1>
+
+<div class="page_body">
   <p class="mb-8">この利用規約（以下，「本規約」といいます。）は，このウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下，「ユーザー」といいます。）には，本規約に従って，本サービスをご利用いただきます。</p>
 
   <h2 class="text-2xl font-bold mb-4">第1条（適用）</h2>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <nav id="header" class="border-b-2 border-gray-200">
-  <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto px-4 py-2">
+  <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto py-2">
     <a href="/" class="flex items-center">
       <%= image_tag('logo.png', alt: 'Fjord Minutesのロゴ画像', class: "h-8 md:h-12") %>
     </a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 
   <body class="flex flex-col h-screen">
     <%= render 'layouts/header' %>
-    <main class="glow container mx-auto mt-5 px-5 max-w-5xl">
+    <main>
       <%= render 'layouts/flash' %>
       <%= yield %>
     </main>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -2,18 +2,21 @@
 <% description = @member == current_development_member ? 'ダッシュボードページです。' : "#{@member.name}さんの出席一覧ページです。" %>
 <% set_meta_tags(build_meta_tags(title:, description:)) %>
 
-<h1 class="font-bold text-xl mb-8 md:text-4xl">
-  <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>
-</h1>
+<div class="bg-blue-700">
+  <h1 class="page_header">
+    <%= "#{@member.name}さん" %>
+  </h1>
+</div>
 
 <div class="page_body">
+  <h2 class="font-bold text-lg text-blue-700 bg-gray-200 py-2 pl-2 border-l-8 border-blue-700 mb-8">出席状況</h2>
   <div class="mb-8">
     <% if @member.all_attendances.empty? %>
       <p><%= @member.name %>さんはまだミーティングに出席していません</p>
     <% else %>
       <% @member.all_attendances.each do |year, attendances_by_year| %>
         <div class="mb-8" data-meeting-year="<%= year %>">
-          <p class="mb-2 text-xl"><%= year %>年</p>
+          <p class="mb-4 font-bold border-b-[1px] border-gray-200"><%= year %>年</p>
           <% attendances_by_year.each.with_index do |attendances, i| %>
             <div class="mb-2" data-attendance-table="<%= i + 1 %>">
               <%= render 'shared/attendance_table', attendances: attendances %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,11 +1,12 @@
 <% title = @member == current_development_member ? 'ダッシュボード' : "#{@member.name}さんの出席一覧" %>
 <% description = @member == current_development_member ? 'ダッシュボードページです。' : "#{@member.name}さんの出席一覧ページです。" %>
 <% set_meta_tags(build_meta_tags(title:, description:)) %>
-<div class="w-full">
-  <h1 class="font-bold text-xl mb-8 md:text-4xl">
-    <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>
-  </h1>
 
+<h1 class="font-bold text-xl mb-8 md:text-4xl">
+  <%= "#{@member.name}さんの出席一覧(#{@member.course.name})" %>
+</h1>
+
+<div class="page_body">
   <div class="mb-8">
     <% if @member.all_attendances.empty? %>
       <p><%= @member.name %>さんはまだミーティングに出席していません</p>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -9,6 +9,21 @@
 </div>
 
 <div class="page_body">
+  <div class="flex mb-8">
+    <div>
+      <%= image_tag @member.avatar_url, alt: "#{@member.name}の画像", class: 'w-20 h-20 rounded-full border border-gray-300' %>
+    </div>
+    <div class="pt-2 ml-2">
+      <p class="text-lg pl-2">
+        <%= @member.name %>
+        <% if @member.hibernated? %>
+          <span class="text-sm text-gray-500 pl-2">離脱中</span>
+        <% end %>
+      </p>
+      <p class="text-gray-500 pl-2"><%= @member.course.name %></p>
+    </div>
+  </div>
+
   <h2 class="font-bold text-lg text-blue-700 bg-gray-200 py-2 pl-2 border-l-8 border-blue-700 mb-8">出席状況</h2>
   <div class="mb-8">
     <% if @member.all_attendances.empty? %>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,7 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の出席登録", description: "#{@minute.title}の出席を登録するページです。")) %>
-<div class="mx-auto w-full">
-  <h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
+<h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
 
+<div class="page_body">
   <div>
     <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance.errors.any? %>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,8 +1,12 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の出席登録", description: "#{@minute.title}の出席を登録するページです。")) %>
-<h1 class="font-bold text-4xl text-center"><%= "#{Attendance.model_name.human}登録" %></h1>
+<div class="bg-blue-700">
+  <h1 class="page_header"><%= "#{Attendance.model_name.human}登録" %></h1>
+</div>
 
 <div class="page_body">
   <div>
+    <p class="text-lg text-center"><%= @minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を登録</p>
+
     <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,5 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録編集", description: "#{@minute.title}の議事録の編集ページです。")) %>
-<h1 class="mb-8 text-xl font-bold text-center md:text-4xl">議事録編集</h1>
+<div class="bg-blue-700">
+  <h1 class="page_header">議事録編集</h1>
+</div>
 
 <div class="page_body">
   <div class="markdown-body">

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,5 +1,7 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録編集", description: "#{@minute.title}の議事録の編集ページです。")) %>
-<div class="mx-auto w-full">
+<h1 class="mb-8 text-xl font-bold text-center md:text-4xl">議事録編集</h1>
+
+<div class="page_body">
   <div class="markdown-body">
     <h1><%= @minute.title %></h1>
 

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,23 +1,23 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録", description: "#{@minute.title}の議事録のページです。")) %>
-<div class="mx-auto w-full">
-  <div class="mx-auto">
-    <h1 class="mb-8 text-xl font-bold md:text-4xl"><%= @minute.title %></h1>
+<h1 class="mb-8 text-xl font-bold text-center md:text-4xl">議事録</h1>
 
-    <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
+<div class="page_body">
+  <h2 class="mb-8 text-xl font-bold md:text-4xl"><%= @minute.title %></h2>
 
-    <% if admin_signed_in? %>
-      <%= button_to 'GitHub Wiki にエクスポート', minute_exports_path(@minute), form: { class: 'text-center' },  class: 'button m-auto' %>
-    <% end %>
+  <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 
-    <% if @minute.exported? %>
-      <div class="text-center my-2">
-        <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow" %>
-      </div>
-    <% end %>
+  <% if admin_signed_in? %>
+    <%= button_to 'GitHub Wiki にエクスポート', minute_exports_path(@minute), form: { class: 'text-center' },  class: 'button m-auto' %>
+  <% end %>
 
-    <div class="my-8 text-center">
-      <%= link_to '議事録を編集する', edit_minute_path(@minute), class: "ml-4" %>
-      <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4" %>
+  <% if @minute.exported? %>
+    <div class="text-center my-2">
+      <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow" %>
     </div>
+  <% end %>
+
+  <div class="my-8 text-center">
+    <%= link_to '議事録を編集する', edit_minute_path(@minute), class: "ml-4" %>
+    <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4" %>
   </div>
 </div>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,8 +1,10 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録", description: "#{@minute.title}の議事録のページです。")) %>
-<h1 class="mb-8 text-xl font-bold text-center md:text-4xl">議事録</h1>
+<div class="bg-blue-700">
+  <h1 class="page_header">議事録</h1>
+</div>
 
 <div class="page_body">
-  <h2 class="mb-8 text-xl font-bold md:text-4xl"><%= @minute.title %></h2>
+  <h2 class="mb-8 text-xl font-bold md:text-2xl"><%= @minute.title %></h2>
 
   <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe 'Members', type: :system do
 
       login_as member
       visit member_path(member)
-      expect(page).to have_selector 'h1', text: 'aliceさんの出席一覧(Railsエンジニアコース)'
+      expect(page).to have_selector 'h1', text: 'aliceさん'
       expect(page).to have_button 'チーム開発を抜ける'
 
       visit member_path(another_member)
-      expect(page).to have_selector 'h1', text: 'bobさんの出席一覧(フロントエンドエンジニアコース)'
+      expect(page).to have_selector 'h1', text: 'bobさん'
       expect(page).not_to have_button 'チーム開発を抜ける'
     end
 

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       click_button 'Railsエンジニアコースで登録'
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
-      expect(page).to have_selector 'h1', text: 'aliceさんの出席一覧(Railsエンジニアコース)'
+      expect(page).to have_selector 'h1', text: 'aliceさん'
     end
 
     scenario 'user can log in as member of the front end course' do
@@ -30,7 +30,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
       click_button 'フロントエンドエンジニアコースで登録'
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
-      expect(page).to have_selector 'h1', text: 'aliceさんの出席一覧(フロントエンドエンジニアコース)'
+      expect(page).to have_selector 'h1', text: 'aliceさん'
     end
   end
 


### PR DESCRIPTION
## Issue
- #271 

## 概要
デザインレビューをもとに、各ページのh1タグにデザインを追加した。
このデザイン追加を行うために、HTMLのマークアップ構造を変更している。
これに関連して、以下のページは表示する内容を追加している。

- メンバー詳細ページで、メンバー情報の表示を追加した

## Screenshot
### 管理者のマイページ
![04A6BF4E-3348-488E-BAFB-F3AA16006A2A](https://github.com/user-attachments/assets/e26b792b-f9be-4187-bde8-2db2275a9f5f)

### 議事録一覧ページ
![74DCB4A6-5EB3-4EC4-B613-A5A7E3A359AE](https://github.com/user-attachments/assets/762411de-0a2f-4a3e-93e9-9faaf1e29cac)

### 議事録詳細ページ
![81494676-315C-4B96-B177-1EA63222EDA3](https://github.com/user-attachments/assets/26a7773a-2387-4e7e-80d7-c313744fe04d)

### 議事録編集ページ
![3827BF6D-7BDE-4E47-8063-43BA1572B6E2](https://github.com/user-attachments/assets/04ac0b9d-e1e5-4a38-948f-9413c0cf20d8)

### メンバー一覧
![52CDC5F9-E9CF-4453-8493-DDF6574142B3](https://github.com/user-attachments/assets/5a2223f1-1ae1-45bb-acf1-38e64c5f9320)

### メンバー詳細
- デザインレビューで、見出しを`xxさんの出席一覧`とするのは不適切であると指摘があり、`xxさん`のページであることを示すため`xxさん`という見出しに変更している
- ユーザー情報と出席状況をそれぞれ表示

![8F15DD01-294A-457F-926E-0D4C19C9EDEA](https://github.com/user-attachments/assets/418c1a26-fa9b-43a6-bc17-5e2019ad547f)

### 出席登録ページ
- どのミーティングに対しての出席なのかが情報としてほしいとアドバイスがあったため、ミーティングの日付を追加した
- 文言が違和感がないように`出席予定`に変更

![CEC4FEC4-7864-4958-8E60-B01294EB004E](https://github.com/user-attachments/assets/a26efa55-eabb-4e09-ae40-42a53e6f27ee)

### 出席編集ページ
![B8198F34-274E-465F-9C0E-A1584E7C8EFC](https://github.com/user-attachments/assets/15701b1e-317e-4eff-9cb9-4f4c88063c4d)


### 利用規約
![0F2E36C7-CE9C-4506-B16E-B6F3EADFF743](https://github.com/user-attachments/assets/fa8b9a75-e667-40b9-9206-58299efd0112)

### プライバシーポリシー
![EA3F5899-FE5D-4085-9DE4-B4CCFC1343E1](https://github.com/user-attachments/assets/7b581942-ead8-4c12-b293-42d9e790172b)
