### PR TITLE
議事録詳細ページ内のリンクの位置を修正

### DIFF
--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -1,6 +1,10 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録", description: "#{@minute.title}の議事録のページです。")) %>
-<div class="bg-blue-700">
-  <h1 class="page_header">議事録</h1>
+<div class="bg-blue-700 mb-8">
+  <div class="flex justify-between items-center md:max-w-5xl md:mx-auto">
+    <h1 class="text-white font-bold text-xl py-4 md:text-2xl">議事録</h1>
+    <%= link_to '議事録一覧', course_minutes_path(@minute.course),
+                class: "p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
+  </div>
 </div>
 
 <div class="page_body">
@@ -20,6 +24,5 @@
 
   <div class="my-8 text-center">
     <%= link_to '議事録を編集する', edit_minute_path(@minute), class: "ml-4" %>
-    <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4" %>
   </div>
 </div>

--- a/app/views/minutes/show.html.erb
+++ b/app/views/minutes/show.html.erb
@@ -12,17 +12,19 @@
 
   <%= content_tag :div, id: 'minute_preview', data: {markdown: MarkdownBuilder.build(@minute)}.to_json, class: 'mb-4' do %><% end %>
 
-  <% if admin_signed_in? %>
-    <%= button_to 'GitHub Wiki にエクスポート', minute_exports_path(@minute), form: { class: 'text-center' },  class: 'button m-auto' %>
-  <% end %>
+  <div class="my-8 flex justify-center items-center gap-x-4">
+    <%= link_to '編集する', edit_minute_path(@minute),
+                class: "block w-52 h-14 border border-blue-700 rounded-lg text-center leading-[54px] hover:no-underline hover:bg-blue-100" %>
+    <% if admin_signed_in? %>
+      <%= button_to minute_exports_path(@minute), form: { class: 'text-center h-14' },  class: 'button m-auto w-52' do %>
+        GitHub Wiki に<br>エクスポート
+      <% end %>
+    <% end %>
+  </div>
 
   <% if @minute.exported? %>
     <div class="text-center my-2">
       <%= link_to 'GitHub Wikiで確認', github_wiki_url(@minute), target: "_blank", rel: "nofollow" %>
     </div>
   <% end %>
-
-  <div class="my-8 text-center">
-    <%= link_to '議事録を編集する', edit_minute_path(@minute), class: "ml-4" %>
-  </div>
 </div>


### PR DESCRIPTION
## Issue
- #271 

## 概要
議事録詳細ページの以下のリンクの位置を修正した。

- 議事録一覧ページのリンクを、ページトップの見出しの横に移動
- 議事録編集ページのリンクを、`GitHub Wikiにエクスポート`ボタンと横並びの位置に移動
- `GitHub Wiki で確認`リンクはページの一番下に移動

## Screenshot
- 議事録一覧ページのリンク

![6A7B6A49-54FF-4AAF-B9D2-D76546D11FB3](https://github.com/user-attachments/assets/c5e23e2d-c148-4436-b992-8b0589446c24)

- 議事録編集ページのリンク(管理者でログイン時)
- `GitHub Wiki で確認`リンク

![0636BE90-CE1E-44BC-94A2-E05E1A671936](https://github.com/user-attachments/assets/fe0ec9e7-fab6-495b-800a-52974f43828c)

- 議事録編集ページのリンク(チームメンバーでログイン時)

![C6EDACF0-BCC6-470C-B375-48136AE61EA2](https://github.com/user-attachments/assets/68a349e4-09e2-4a1f-813b-bf77730fde33)

