### PR TITLE
欠席時の進捗報告を複数行入力できるようにした

### DIFF
--- a/app/javascript/components/AbsenteesList.jsx
+++ b/app/javascript/components/AbsenteesList.jsx
@@ -38,8 +38,20 @@ function Absentee({ absentee, currentMemberId, isAdmin }) {
         </a>
       )}
       <ul className="!mt-2">
-        <li>欠席理由: {absentee.absence_reason}</li>
-        <li>今週の進捗: {absentee.progress_report}</li>
+        <li>
+          欠席理由
+          <ul>
+            <li>{absentee.absence_reason}</li>
+          </ul>
+        </li>
+        <li>
+          今週の進捗
+          <ul>
+            {absentee.progress_report.split('\r\n').map((report, index) => (
+              <li key={index}>{report}</li>
+            ))}
+          </ul>
+        </li>
       </ul>
     </li>
   )

--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -68,7 +68,11 @@ class MarkdownBuilder
            .includes(:member)
            .order(:member_id)
            .pluck(:absence_reason, :progress_report, :name)
-           .map { |absence_reason, progress_report, name| "- #{name}\n  - 欠席理由 : #{absence_reason}\n  - 進捗報告 : #{progress_report}" }
+           .map { |absence_reason, progress_report, name| "- #{name}\n  - 欠席理由\n    - #{absence_reason}\n  - 進捗報告\n#{progress_reports(progress_report)}" }
            .join("\n")
+  end
+
+  def progress_reports(progress_report)
+    progress_report.split("\r\n").map { |report| "    - #{report}" }.join("\n")
   end
 end

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -37,8 +37,8 @@
       </div>
 
       <div class="my-5 text-center absent_entry_field">
-        <%= form.label :absence_reason %>
-        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため' ,class: 'input_type_text min-w-[400px]' %>
+        <%= form.label :absence_reason, class: "block mb-2" %>
+        <%= form.text_field :absence_reason, placeholder: '職場のイベントに参加するため' ,class: 'input_type_text w-[400px] md:w-[600px]' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -42,8 +42,26 @@
       </div>
 
       <div class="my-5 text-center absent_entry_field">
-        <%= form.label :progress_report %>
-        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text min-w-[400px]' %>
+        <%= form.label :progress_report, class: "block mb-2" %>
+        <%= form.text_area :progress_report, placeholder: "Issue#8000, チームメンバーのレビュー待ちの状態です。", class: 'w-[400px] md:w-[600px] h-36 border border-gray-300 rounded-lg align-middle' %>
+        <div class="mt-2 mx-auto text-sm w-[550px] text-gray-500 text-left">
+          <p class="text-center mb-2">進捗報告は以下の形式で入力をお願いします。</p>
+          <ul>
+            <li>進捗報告は一つにつき一行で記入する</li>
+            <li>
+              自分にアサインされたIssueは、「Issue#番号, 進捗報告」の形式で記入する
+              <ul>
+                <li>(例) Issue#8000, Twitter Cardの仕様を調査しました。</li>
+              </ul>
+            </li>
+            <li>
+              レビュー対応はその旨を記入する
+              <ul>
+                <li>(例) チームメンバーから依頼されたレビュー対応を行いました。</li>
+              </ul>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <div class="text-center">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -37,8 +37,8 @@
       </div>
 
       <div class="my-5 text-center absent_entry_field">
-        <%= form.label :absence_reason, Attendance.human_attribute_name('absence_reason') %>
-        <%= form.text_field :absence_reason, placeholder: '家庭の都合のため', class: 'input_type_text min-w-[400px]' %>
+        <%= form.label :absence_reason, Attendance.human_attribute_name('absence_reason'), class: "block mb-2" %>
+        <%= form.text_field :absence_reason, placeholder: '職場のイベントに参加するため', class: 'input_type_text w-[400px] md:w-[600px]' %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -42,8 +42,26 @@
       </div>
 
       <div class="my-5 text-center absent_entry_field">
-        <%= form.label :progress_report, Attendance.human_attribute_name('progress_report') %>
-        <%= form.text_field :progress_report, placeholder: '#8000はチームメンバーのレビュー待ちの状態です', class: 'input_type_text min-w-[400px]' %>
+        <%= form.label :progress_report, Attendance.human_attribute_name('progress_report'), class: "block mb-2" %>
+        <%= form.text_area :progress_report, placeholder: "Issue#8000, チームメンバーのレビュー待ちの状態です。", class: 'w-[400px] md:w-[600px] h-36 border border-gray-300 rounded-lg align-middle' %>
+        <div class="mt-2 mx-auto text-sm w-[550px] text-gray-500 text-left">
+          <p class="text-center mb-2">進捗報告は以下の形式で入力をお願いします。</p>
+          <ul>
+            <li>進捗報告は一つにつき一行で記入する</li>
+            <li>
+              自分にアサインされたIssueは、「Issue#番号, 進捗報告」の形式で記入する
+              <ul>
+                <li>(例) Issue#8000, Twitter Cardの仕様を調査しました。</li>
+              </ul>
+            </li>
+            <li>
+              レビュー対応はその旨を記入する
+              <ul>
+                <li>(例) チームメンバーから依頼されたレビュー対応を行いました。</li>
+              </ul>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <div class="text-center">

--- a/db/migrate/20250125233751_change_data_type_progress_report_of_attendances.rb
+++ b/db/migrate/20250125233751_change_data_type_progress_report_of_attendances.rb
@@ -1,0 +1,5 @@
+class ChangeDataTypeProgressReportOfAttendances < ActiveRecord::Migration[7.2]
+  def change
+    change_column :attendances, :progress_report, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_11_063340) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_25_233751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,7 +31,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_11_063340) do
     t.integer "status", null: false
     t.integer "time"
     t.string "absence_reason"
-    t.string "progress_report"
+    t.text "progress_report"
     t.bigint "minute_id", null: false
     t.bigint "member_id", null: false
     t.datetime "created_at", null: false

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -19,5 +19,12 @@ FactoryBot.define do
       absence_reason { '体調不良のため。' }
       progress_report { 'PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。' }
     end
+
+    trait :absence_with_multiple_progress_reports do
+      status { :absent }
+      time { nil }
+      absence_reason { '職場のイベントに参加するため。' }
+      progress_report { "Issue#8000, チームメンバーにレビュー依頼を行いました。\r\nIssue#8102, 問題が発生している箇所の調査を行いました。\r\n依頼されたレビュー対応を行いました。" }
+    end
   end
 end

--- a/spec/models/markdown_builder_spec.rb
+++ b/spec/models/markdown_builder_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MarkdownBuilder, type: :model do
   it 'returns markdown of minute' do
     FactoryBot.create(:attendance, member: alice, minute:)
     FactoryBot.create(:attendance, :night, member: bob, minute:)
-    FactoryBot.create(:attendance, :absence, member: absentee, minute:)
+    FactoryBot.create(:attendance, :absence_with_multiple_progress_reports, member: absentee, minute:)
     FactoryBot.create(:topic, :by_member, minute:, topicable: alice)
 
     expected = <<~MARKDOWN
@@ -68,8 +68,12 @@ RSpec.describe MarkdownBuilder, type: :model do
       # 欠席者
 
       - absentee
-        - 欠席理由 : 体調不良のため。
-        - 進捗報告 : PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。
+        - 欠席理由
+          - 職場のイベントに参加するため。
+        - 進捗報告
+          - Issue#8000, チームメンバーにレビュー依頼を行いました。
+          - Issue#8102, 問題が発生している箇所の調査を行いました。
+          - 依頼されたレビュー対応を行いました。
     MARKDOWN
     expect(described_class.build(minute)).to eq expected
   end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Attendances', type: :system do
         visit new_minute_attendance_path(minute)
         choose '欠席'
         fill_in '欠席理由', with: '仕事の都合のため。'
-        fill_in '進捗報告', with: '今週は依頼されたIssueを進めていました。来週にはPRを提出できそうです。'
+        fill_in '進捗報告', with: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -65,8 +65,8 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_link '出席編集'
         within('#absentees') do
           expect(page).to have_selector 'li', text: member.name
-          expect(page).to have_selector 'li', text: '欠席理由: 仕事の都合のため。'
-          expect(page).to have_selector 'li', text: '今週は依頼されたIssueを進めていました。来週にはPRを提出できそうです。'
+          expect(page).to have_selector 'li', text: '仕事の都合のため。'
+          expect(page).to have_selector 'li', text: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
         end
       end
     end
@@ -176,7 +176,7 @@ RSpec.describe 'Attendances', type: :system do
         choose '昼の部' # チェックがついている'昼の部'を2度クリックして、チェックを外す
         choose '欠席'
         fill_in '欠席理由', with: '体調不良のため。'
-        fill_in '進捗報告', with: 'PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。'
+        fill_in '進捗報告', with: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
         click_button '出席を更新'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -186,8 +186,8 @@ RSpec.describe 'Attendances', type: :system do
         end
         within('#absentees') do
           expect(page).to have_selector 'li', text: member.name
-          expect(page).to have_selector 'li', text: '欠席理由: 体調不良のため。'
-          expect(page).to have_selector 'li', text: 'PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。'
+          expect(page).to have_selector 'li', text: '体調不良のため。'
+          expect(page).to have_selector 'li', text: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
         end
       end
     end


### PR DESCRIPTION
## Issue
- #275 

## 概要
欠席時の進捗報告入力欄をtextareaに変更し、複数行入力できるようにした。
議事録上では入力した行ごとにリストで表示されるようになっている。

また、上記に関連して議事録の欠席者の表示を変更している。

## Screenshot
### 出席登録ページ
- 変更前

![4CF13C85-7E50-47F4-A545-6F077B839B65](https://github.com/user-attachments/assets/ac339d8a-0e07-4273-bbc7-2a773517a4be)


- 変更後

![0F5A22A4-CE5E-47D9-B5F7-F7AE1284B6D1](https://github.com/user-attachments/assets/d84ede66-2661-4df3-bce7-9b662fae178d)

### 出席編集ページ
- 変更前

![BC63A48E-B07A-4D3C-AB81-DCDBDA3237FF](https://github.com/user-attachments/assets/8fc75245-d6aa-4418-886b-2b02f3778296)

- 変更後

![069CBDD8-64DB-4E30-BBCD-39A90C69FA61](https://github.com/user-attachments/assets/309415c6-47d9-43cb-8bbb-a5e378de6422)


### 欠席者の表示(Markdown)
- 変更前

![945AD5FC-3913-4D1E-B0B3-488408512435](https://github.com/user-attachments/assets/2870eee6-c91c-43dd-9e78-b625c6bc5c6c)

- 変更後
  - 欠席理由と進捗報告はネストして表示する
  - 進捗報告は入力された行ごとにリストで表示される

![E15155FF-118F-4EC9-A1C7-073341FFE971](https://github.com/user-attachments/assets/4c7a5b1b-9b70-44cd-b528-e8712b5cd876)

### 欠席者の表示(議事録編集ページ)
- 変更前

![D880E705-438E-4661-9D63-821655A9016B](https://github.com/user-attachments/assets/ea69e86f-2383-4345-9eda-aea0cbf1b646)


- 変更後
  - 欠席理由と進捗報告はネストして表示する
  - 進捗報告は入力された行ごとにリストで表示される

![E363874A-58EE-47EE-A959-C69F5EB87519](https://github.com/user-attachments/assets/d4af8e76-97b6-4f38-a100-f1794a20fa07)

