### PR TITLE
進捗報告記入時の注意事項を修正

### DIFF
--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -43,21 +43,16 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report, class: "block mb-2" %>
-        <%= form.text_area :progress_report, placeholder: "Issue#8000, チームメンバーのレビュー待ちの状態です。", class: 'w-[400px] md:w-[600px] h-36 border border-gray-300 rounded-lg align-middle' %>
+        <%= form.text_area :progress_report, placeholder: "#8000 チームメンバーのレビュー待ちの状態です。", class: 'w-[400px] md:w-[600px] h-36 border border-gray-300 rounded-lg align-middle' %>
         <div class="mt-2 mx-auto text-sm w-[550px] text-gray-500 text-left">
           <p class="text-center mb-2">進捗報告は以下の形式で入力をお願いします。</p>
           <ul>
-            <li>進捗報告は一つにつき一行で記入する</li>
+            <li>空行は開けず、一つの報告内容につき一行で記入してください。</li>
             <li>
-              自分にアサインされたIssueは、「Issue#番号, 進捗報告」の形式で記入する
+              「#Issue番号 進捗報告」の形式で記入してください。
               <ul>
-                <li>(例) Issue#8000, Twitter Cardの仕様を調査しました。</li>
-              </ul>
-            </li>
-            <li>
-              レビュー対応はその旨を記入する
-              <ul>
-                <li>(例) チームメンバーから依頼されたレビュー対応を行いました。</li>
+                <li>(例) #8000 Twitter Cardの仕様を調査しました。</li>
+                <li>(例) #8022 チームメンバーから依頼されたレビュー対応を行いました。</li>
               </ul>
             </li>
           </ul>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -43,21 +43,16 @@
 
       <div class="my-5 text-center absent_entry_field">
         <%= form.label :progress_report, Attendance.human_attribute_name('progress_report'), class: "block mb-2" %>
-        <%= form.text_area :progress_report, placeholder: "Issue#8000, チームメンバーのレビュー待ちの状態です。", class: 'w-[400px] md:w-[600px] h-36 border border-gray-300 rounded-lg align-middle' %>
+        <%= form.text_area :progress_report, placeholder: "#8000 チームメンバーのレビュー待ちの状態です。", class: 'w-[400px] md:w-[600px] h-36 border border-gray-300 rounded-lg align-middle' %>
         <div class="mt-2 mx-auto text-sm w-[550px] text-gray-500 text-left">
           <p class="text-center mb-2">進捗報告は以下の形式で入力をお願いします。</p>
           <ul>
-            <li>進捗報告は一つにつき一行で記入する</li>
+            <li>空行は開けず、一つの報告内容につき一行で記入してください。</li>
             <li>
-              自分にアサインされたIssueは、「Issue#番号, 進捗報告」の形式で記入する
+              「#Issue番号 進捗報告」の形式で記入してください。
               <ul>
-                <li>(例) Issue#8000, Twitter Cardの仕様を調査しました。</li>
-              </ul>
-            </li>
-            <li>
-              レビュー対応はその旨を記入する
-              <ul>
-                <li>(例) チームメンバーから依頼されたレビュー対応を行いました。</li>
+                <li>(例) #8000 Twitter Cardの仕様を調査しました。</li>
+                <li>(例) #8022 チームメンバーから依頼されたレビュー対応を行いました。</li>
               </ul>
             </li>
           </ul>

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
       status { :absent }
       time { nil }
       absence_reason { '職場のイベントに参加するため。' }
-      progress_report { "Issue#8000, チームメンバーにレビュー依頼を行いました。\r\nIssue#8102, 問題が発生している箇所の調査を行いました。\r\n依頼されたレビュー対応を行いました。" }
+      progress_report { "#8000 チームメンバーにレビュー依頼を行いました。\r\n#8102 問題が発生している箇所の調査を行いました。\r\n#8080 依頼されたレビュー対応を行いました。" }
     end
   end
 end

--- a/spec/models/markdown_builder_spec.rb
+++ b/spec/models/markdown_builder_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe MarkdownBuilder, type: :model do
         - 欠席理由
           - 職場のイベントに参加するため。
         - 進捗報告
-          - Issue#8000, チームメンバーにレビュー依頼を行いました。
-          - Issue#8102, 問題が発生している箇所の調査を行いました。
-          - 依頼されたレビュー対応を行いました。
+          - #8000 チームメンバーにレビュー依頼を行いました。
+          - #8102 問題が発生している箇所の調査を行いました。
+          - #8080 依頼されたレビュー対応を行いました。
     MARKDOWN
     expect(described_class.build(minute)).to eq expected
   end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Attendances', type: :system do
         visit new_minute_attendance_path(minute)
         choose '欠席'
         fill_in '欠席理由', with: '仕事の都合のため。'
-        fill_in '進捗報告', with: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
+        fill_in '進捗報告', with: '#1000 チームメンバーのレビュー待ちの状態です。'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -66,7 +66,7 @@ RSpec.describe 'Attendances', type: :system do
         within('#absentees') do
           expect(page).to have_selector 'li', text: member.name
           expect(page).to have_selector 'li', text: '仕事の都合のため。'
-          expect(page).to have_selector 'li', text: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
+          expect(page).to have_selector 'li', text: '#1000 チームメンバーのレビュー待ちの状態です。'
         end
       end
     end
@@ -176,7 +176,7 @@ RSpec.describe 'Attendances', type: :system do
         choose '昼の部' # チェックがついている'昼の部'を2度クリックして、チェックを外す
         choose '欠席'
         fill_in '欠席理由', with: '体調不良のため。'
-        fill_in '進捗報告', with: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
+        fill_in '進捗報告', with: '#1000 チームメンバーのレビュー待ちの状態です。'
         click_button '出席を更新'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -187,7 +187,7 @@ RSpec.describe 'Attendances', type: :system do
         within('#absentees') do
           expect(page).to have_selector 'li', text: member.name
           expect(page).to have_selector 'li', text: '体調不良のため。'
-          expect(page).to have_selector 'li', text: 'Issue#1000, チームメンバーのレビュー待ちの状態です。'
+          expect(page).to have_selector 'li', text: '#1000 チームメンバーのレビュー待ちの状態です。'
         end
       end
     end


### PR DESCRIPTION
## Issue
- #275 

## 概要
進捗報告記入時の注意事項に関して、駒形さんからご指摘のあった箇所を修正した。

- レビュー依頼の場合もIssue番号も入力してもらう
- Issueと進捗の区切り記号は空白にする
- Issueは書かずにシャープから始める

`#番号`を入力すると対応するIssue(またはPull Request)のサジェストが表示される機能は実装に時間がかかると判断し、別のPull Requestで対応を行う。

## Screenshot
修正前
![2EB175EF-1A07-4756-93DC-D3B6786F43A6_4_5005_c](https://github.com/user-attachments/assets/4390ea3c-3c41-48a6-8596-f4d3395f52f6)

修正後
![F392A878-8EF7-4F05-9532-CCDBB046D703_4_5005_c](https://github.com/user-attachments/assets/6cdad705-3b16-490f-a58f-7a6abf1a39e8)


