### PR TITLE
議事録編集ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -34,9 +34,6 @@
     .input_type_text {
         @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block max-w-full field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
-    .textarea {
-        @apply block p-2.5 min-w-[400px] field-sizing-content text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 inline-block align-middle focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
-    }
     .large_tab_item {
         @apply inline-block px-2 py-4 rounded-t-lg text-gray-500 border border-b-0 border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }

--- a/app/javascript/components/OtherForm.jsx
+++ b/app/javascript/components/OtherForm.jsx
@@ -56,11 +56,13 @@ function EditForm({ minuteId, content }) {
         placeholder="- RubyKaigiに参加するため、次回のミーティングは⚪︎月⚪︎日に行います"
         onChange={handleChange}
         id="other_field"
-        className="textarea"
+        className="block p-2.5 w-[800px] h-36 text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 "
       />
-      <button type="button" onClick={handleClick} className="button mt-2">
-        更新
-      </button>
+      <div>
+        <button type="button" onClick={handleClick} className="button mt-2">
+          更新
+        </button>
+      </div>
     </>
   )
 }

--- a/app/javascript/components/ReleaseInformationForm.jsx
+++ b/app/javascript/components/ReleaseInformationForm.jsx
@@ -29,7 +29,7 @@ export default function ReleaseInformationForm({
   return (
     <ul>
       <li>
-        <span>{label}</span>
+        <span className="block mb-2">{label}</span>
         <ul>
           {isEditing ? (
             <EditForm
@@ -97,7 +97,7 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
         placeholder={placeholder(description, course)}
         onChange={handleInput}
         id={`release_${description}_field`}
-        className="input_type_text"
+        className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block w-[500px] p-2.5 "
       />
       <button type="button" onClick={handleClick} className="button mt-2">
         更新

--- a/app/javascript/components/TopicList.jsx
+++ b/app/javascript/components/TopicList.jsx
@@ -21,7 +21,14 @@ export default function TopicList({
   return (
     <>
       {allTopics.length === 0 ? (
-        <p>話題にしたいこと・心配事はありません。</p>
+        <>
+          <p>話題にしたいこと・心配事はありません。</p>
+          <ul>
+            <li>
+              <CreateForm minuteId={minuteId} />
+            </li>
+          </ul>
+        </>
       ) : (
         <ul>
           {allTopics.map((topic) => (
@@ -33,9 +40,11 @@ export default function TopicList({
               currentDevelopmentMemberType={currentDevelopmentMemberType}
             />
           ))}
+          <li>
+            <CreateForm minuteId={minuteId} />
+          </li>
         </ul>
       )}
-      <CreateForm minuteId={minuteId} />
     </>
   )
 }
@@ -73,7 +82,7 @@ function Topic({
           setIsEditing={setIsEditing}
         />
       ) : (
-        <li>
+        <li className="mb-4">
           <span>
             {topic.content}({topic.topicable.name})
           </span>
@@ -147,7 +156,7 @@ function EditForm({ minuteId, topicId, content, setIsEditing }) {
         value={inputValue}
         onChange={handleInput}
         id="edit_topic_field"
-        className="input_type_text max-w-[800px]"
+        className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block p-2.5 w-[800px]"
       />
       <button
         type="button"
@@ -199,7 +208,7 @@ function CreateForm({ minuteId }) {
         placeholder="Good First Issueをモブプロでやったらとても勉強になりました！"
         onChange={handleInput}
         id="new_topic_field"
-        className="input_type_text"
+        className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block p-2.5 w-[800px]"
       />
       <button
         type="button"

--- a/app/views/minutes/_topic_example.html.erb
+++ b/app/views/minutes/_topic_example.html.erb
@@ -1,35 +1,36 @@
-<div class="text-sm text-green-700 p-4 mb-4 bg-green-50 border border-green-700 rounded">
-  <p class="!mb-2">例えば次のようなことを話します。ちょっとしたことでもいいので、作業を進める中で気になったことがあれば書き込んでみましょう！</p>
+<div class="text-sm text-blue-800 py-4 px-8 my-8 bg-blue-50 border border-blue-800 rounded w-[400px] md:w-[720px] mx-auto">
+  <h3 class="text-base font-bold border-b-[1px] border-blue-800 pb-2 !mt-0 !mb-4">話題にしたいこと・心配事の例</h3>
+  <p class="!mb-4">例えば次のようなことを話します。ちょっとしたことでもいいので、作業を進める中で気になったことがあれば書き込んでみましょう！</p>
   <ul class="!mb-0">
-    <li>
-      <span class="font-bold">こうしたら作業がうまく進んだ</span>
+    <li class="mb-4">
+      <span class="font-bold block mb-2">こうしたら作業がうまく進んだ</span>
       <ul>
         <li>モブプロをやってみたら自分が知らない知識を得ることができて、とても勉強になりました！</li>
         <li>⚪︎⚪︎のリファレンスとても参考になりました、おすすめです〜</li>
       </ul>
     </li>
-    <li>
-      <span class="font-bold">作業のここがうまくいかなかった</span>
+    <li class="mb-4">
+      <span class="font-bold block mb-2">作業のここがうまくいかなかった</span>
       <ul>
         <li>コードの理解に時間がかかりました。コードを読むときに気をつけていることがあれば教えて欲しいです</li>
         <li>⚪︎⚪︎について調べていたが、あまり情報を見つけることができませんでした。検索方法や対象についてアドバイスが欲しいです</li>
       </ul>
     </li>
-    <li>
-      <span class="font-bold">発生している問題</span>
+    <li class="mb-4">
+      <span class="font-bold block mb-2">発生している問題</span>
       <ul>
         <li>CIでテストが落ちてしまいます。皆さんはいかがでしょうか？</li>
       </ul>
     </li>
-    <li>
-      <span class="font-bold">チームメンバーの良かったところ・チームメンバーに対する感謝</span>
+    <li class="mb-4">
+      <span class="font-bold block mb-2">チームメンバーの良かったところ・チームメンバーに対する感謝</span>
       <ul>
         <li>⚪︎⚪︎さんのコードのここが勉強になりました！/⚪︎⚪︎さんのレビューのここが参考になりました！</li>
         <li>詰まっていた箇所を一緒にペアプロしてくださった⚪︎⚪︎さんに感謝です</li>
       </ul>
     </li>
-    <li>
-      <span class="font-bold">技術的な関心ごと・イベント</span>
+    <li class="mb-4">
+      <span class="font-bold block mb-2">技術的な関心ごと・イベント</span>
       <ul>
         <li>Railsの新バージョンについて発表がありました </li>
         <li>⚪︎⚪︎日に地域.rbイベントが開催されるみたいです！</li>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -1,6 +1,9 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の議事録編集", description: "#{@minute.title}の議事録の編集ページです。")) %>
-<div class="bg-blue-700">
-  <h1 class="page_header">議事録編集</h1>
+<div class="bg-blue-700 mb-8">
+  <div class="flex justify-between items-center md:max-w-5xl md:mx-auto">
+    <h1 class="text-white font-bold text-xl py-4 md:text-2xl">議事録編集</h1>
+    <%= link_to 'プレビュー', @minute, class: "p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
+  </div>
 </div>
 
 <div class="page_body">
@@ -47,10 +50,5 @@
 
     <h2>連絡なし</h2>
     <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id, currentMemberId: current_development_member.id, isAdmin: admin_signed_in?}.to_json do %><% end %>
-  </div>
-
-  <div class="my-8 text-center">
-    <%= link_to '議事録のプレビュー', @minute, class: "ml-4" %>
-    <%= link_to "#{@minute.course.name}の議事録一覧", course_minutes_path(@minute.course), class: "ml-4" %>
   </div>
 </div>


### PR DESCRIPTION
## Issue
- #271 

## 概要
デザインレビューで町田さんにご指摘いただいた以下の点を修正した。

- 一番上に戻るリンクを表示する
- リリースブランチ・リリースノート
  - 入力欄の幅を広くする
- その他
  - textareaをより大きくする
  - 登録ボタンを下に配置する
- 話題にしたいこと・心配事の例
  - 適度に幅を狭めて読みやすくなるようにする
  - 色を緑から青を含んだグレイなど無彩色に近いものにするか、薄いグリーンではなく薄い青にする
- 話題にしたいこと・心配事
  - 入力欄をリストの中に入れる 

## Screenshot
### 戻るリンク
![B2A79AC8-BE42-4E90-A7E4-3E0F340284E8](https://github.com/user-attachments/assets/3986bf38-f38d-4e5e-a839-dd5b55139b1f)

### リリースブランチ・リリースノート
![CA13C8D9-D28C-4901-9460-B8C4014BB4C7](https://github.com/user-attachments/assets/05d6c5cb-3dcc-46c5-adc6-5f8d082d9b32)

### その他
![235EEAE8-58F9-49CB-A50B-32215496C399](https://github.com/user-attachments/assets/d0b263a4-c761-4161-bc9a-fee73069d5c4)

### 話題にしたいこと・心配事
入力の例
![E8508168-E328-42C8-B5EF-023753239BF2](https://github.com/user-attachments/assets/cae8bda5-ae62-4128-8d05-a73f9453cc6b)


入力フォーム
![DAD2DE9A-530E-46EE-91E7-B12D6A724DAD](https://github.com/user-attachments/assets/182b485b-9356-4e41-9b72-dcf42d0e9c85)




