### PR TITLE
出席を登録/変更した際のフラッシュメッセージの文言を変更

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -3,17 +3,17 @@
 class AttendancesController < ApplicationController
   def edit
     @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席は変更できません' if @attendance.minute.already_finished?
+    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if @attendance.minute.already_finished?
   end
 
   def update
     @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席は変更できません' if @attendance.minute.already_finished?
+    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if @attendance.minute.already_finished?
 
     remove_unnecessary_values
 
     if @attendance.update(attendance_params)
-      redirect_to edit_minute_path(@attendance.minute_id), notice: "#{Attendance.model_name.human}を更新しました"
+      redirect_to edit_minute_path(@attendance.minute_id), notice: '出席予定を更新しました'
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -14,7 +14,7 @@ class Minutes::AttendancesController < Minutes::ApplicationController
     @attendance.member_id = current_member.id
 
     if @attendance.save
-      redirect_to edit_minute_url(@minute), notice: "#{Attendance.model_name.human}を登録しました"
+      redirect_to edit_minute_url(@minute), notice: '出席予定を登録しました'
     else
       render :new, status: :unprocessable_entity
     end
@@ -35,10 +35,10 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   end
 
   def prohibit_duplicate_access
-    redirect_to edit_minute_url(@minute), alert: 'すでに出席を登録済みです' if @minute.attendances.where(member_id: current_member.id).any?
+    redirect_to edit_minute_url(@minute), alert: 'すでに出席予定を登録済みです' if @minute.attendances.where(member_id: current_member.id).any?
   end
 
   def prohibit_access_to_finished_minute
-    redirect_to edit_minute_url(@minute), alert: '終了したミーティングには出席できません' if @minute.already_finished?
+    redirect_to edit_minute_url(@minute), alert: '終了したミーティングには出席予定を登録できません' if @minute.already_finished?
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '出席を登録しました'
+        expect(page).to have_content '出席予定を登録しました'
         expect(page).not_to have_link '出席予定を登録する'
         expect(page).to have_link '出席予定を変更する'
         within('#day_attendees') do
@@ -60,7 +60,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '出席を登録しました'
+        expect(page).to have_content '出席予定を登録しました'
         expect(page).not_to have_link '出席予定を登録する'
         expect(page).to have_link '出席予定を変更する'
         within('#night_attendees') do
@@ -81,7 +81,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '出席を登録しました'
+        expect(page).to have_content '出席予定を登録しました'
         expect(page).not_to have_link '出席予定を登録する'
         expect(page).to have_link '出席予定を変更する'
         within('#absentees') do
@@ -135,7 +135,7 @@ RSpec.describe 'Attendances', type: :system do
 
         visit new_minute_attendance_path(minute)
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content 'すでに出席を登録済みです'
+        expect(page).to have_content 'すでに出席予定を登録済みです'
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe 'Attendances', type: :system do
       travel_to minute.meeting_date.days_since(1) do
         visit new_minute_attendance_path(minute)
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '終了したミーティングには出席できません'
+        expect(page).to have_content '終了したミーティングには出席予定を登録できません'
       end
     end
 
@@ -207,7 +207,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を更新'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '出席を更新しました'
+        expect(page).to have_content '出席予定を更新しました'
         within('#day_attendees', visible: false) do
           expect(page).not_to have_selector 'li', text: member.name
         end
@@ -234,7 +234,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を更新'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '出席を更新しました'
+        expect(page).to have_content '出席予定を更新しました'
         within('#absentees', visible: false) do
           expect(page).not_to have_selector 'li', text: member.name
         end
@@ -259,7 +259,7 @@ RSpec.describe 'Attendances', type: :system do
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '出席を登録しました'
+        expect(page).to have_content '出席予定を登録しました'
         within('#unexcused_absentees', visible: false) do
           expect(page).not_to have_selector 'li', text: member.name
         end
@@ -306,7 +306,7 @@ RSpec.describe 'Attendances', type: :system do
       travel_to minute.meeting_date + 1.day do
         visit edit_attendance_path(attendance)
         expect(current_path).to eq edit_minute_path(minute)
-        expect(page).to have_content '終了したミーティングの出席は変更できません'
+        expect(page).to have_content '終了したミーティングの出席予定は変更できません'
       end
     end
   end


### PR DESCRIPTION
## Issue
なし

## 概要
#273 で、出席登録/編集ページに`xxxのMTGの出席予定を登録/変更`という文言を追加した。
しかし、出席登録/編集時のフラッシュメッセージは`出席を登録/変更しました`のままだったため、文言を`出席予定を登録/変更しました`に変更している。

## Screenshot
- 出席登録時

![A361F265-709E-4A64-A8EC-E4EF68725F3A](https://github.com/user-attachments/assets/a5fb3003-d0a7-44cc-ab92-159653dfc623)

- 出席変更時

![FEF2547C-4BC5-4B45-9418-6900C3BF1D26](https://github.com/user-attachments/assets/71b4bf1f-93f1-4db5-804a-2ef1d3a0761a)

