### PR TITLE
進捗報告内に記述されているIssueの番号をリンクに変換するようにした

### DIFF
--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -54,7 +54,12 @@ class MarkdownBuilder
   end
 
   def split_line_to_list(progress_report)
-    progress_report.split("\r\n").map { |report| "    - #{report}" }.join("\n")
+    progress_report.split("\r\n").map { |report| "    - #{rewrite_issue_number_as_link(report)}" }.join("\n")
+  end
+
+  def rewrite_issue_number_as_link(progress_report)
+    repository_url = @minute.course.name == 'Railsエンジニアコース' ? 'https://github.com/fjordllc/bootcamp' : 'https://github.com/fjordllc/agent'
+    progress_report.gsub(/#(\d+)/, "[#\\1](#{repository_url}/issues/\\1)")
   end
 
   def member_link(name)

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -20,7 +20,7 @@
     <%= content_tag :div, id: 'attendees_list', data: {minuteId: @minute.id}.to_json do %><% end %>
 
     <h2>欠席者</h2>
-    <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id}.to_json do %><% end %>
+    <%= content_tag :div, id: 'absentees_list', data: {minuteId: @minute.id, course_name: @minute.course.name}.to_json do %><% end %>
 
     <h3>連絡なし</h3>
     <%= content_tag :div, id: 'unexcused_absentees_list', data: {minuteId: @minute.id}.to_json do %><% end %>

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
       status { :absent }
       time { nil }
       absence_reason { '職場のイベントに参加するため。' }
-      progress_report { "#8000 チームメンバーにレビュー依頼を行いました。\r\n#8102 問題が発生している箇所の調査を行いました。\r\n#8080 依頼されたレビュー対応を行いました。" }
+      progress_report { "#8000 チームメンバーにレビュー依頼を行いました。\r\n#8102 問題が発生している箇所の調査を行いました(関連Issue#8100)。\r\n#8080 依頼されたレビュー対応を行いました。" }
     end
   end
 end

--- a/spec/models/markdown_builder_spec.rb
+++ b/spec/models/markdown_builder_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe MarkdownBuilder, type: :model do
         - 欠席理由
           - 職場のイベントに参加するため。
         - 進捗報告
-          - #8000 チームメンバーにレビュー依頼を行いました。
-          - #8102 問題が発生している箇所の調査を行いました。
-          - #8080 依頼されたレビュー対応を行いました。
+          - [#8000](https://github.com/fjordllc/bootcamp/issues/8000) チームメンバーにレビュー依頼を行いました。
+          - [#8102](https://github.com/fjordllc/bootcamp/issues/8102) 問題が発生している箇所の調査を行いました(関連Issue[#8100](https://github.com/fjordllc/bootcamp/issues/8100))。
+          - [#8080](https://github.com/fjordllc/bootcamp/issues/8080) 依頼されたレビュー対応を行いました。
 
       ## デモ
 

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe 'Attendances', type: :system do
           expect(page).to have_selector 'li', text: member.name
           expect(page).to have_selector 'li', text: '仕事の都合のため。'
           expect(page).to have_selector 'li', text: '#1000 チームメンバーのレビュー待ちの状態です。'
+          expect(page).to have_link '#1000', href: 'https://github.com/fjordllc/bootcamp/issues/1000'
         end
       end
     end


### PR DESCRIPTION
## Issue
- #275 

## 概要
進捗報告内に`#Issue番号`と記述すると、以下のページではリンクとして表示されるようにした。

- 議事録詳細ページ(議事録のMarkdown)
- 議事録編集ページ

## Screenshot
次のような進捗報告が保存されている場合の表示。
![1DCEFB6F-6026-4734-991E-9AEB1834118C](https://github.com/user-attachments/assets/da1568d0-fa8c-482e-bdaa-edd66946869f)


- 議事録詳細ページ

![11C5D728-E7C4-4E28-A8F7-FB23021BD705](https://github.com/user-attachments/assets/83c19ae2-f71a-43d5-b6ff-b4466f5f42da)


- 議事録編集ページ

![391C7F8A-E31B-4C89-98C6-CCCDDF61BF2B](https://github.com/user-attachments/assets/381c66e4-33f0-4dd0-8404-faafa7eb7195)

