### PR TITLE
出席登録/編集ページの上部に、議事録編集ページに戻るリンクを追加

### DIFF
--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,6 +1,9 @@
 <% set_meta_tags(build_meta_tags(title: "#{@attendance.minute.title}の出席変更", description: "#{@attendance.minute.title}の出席を変更するページです。")) %>
-<div class="bg-blue-700">
-  <h1 class="page_header"><%= "#{Attendance.model_name.human}編集" %></h1>
+<div class="bg-blue-700 mb-8">
+  <div class="flex justify-between items-center md:max-w-5xl md:mx-auto">
+    <h1 class="text-white font-bold text-xl py-4 md:text-2xl">出席編集</h1>
+    <%= link_to '戻る', edit_minute_path(@attendance.minute), class: "block w-28 text-center p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
+  </div>
 </div>
 
 <div class="page_body">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -1,6 +1,9 @@
 <% set_meta_tags(build_meta_tags(title: "#{@minute.title}の出席登録", description: "#{@minute.title}の出席を登録するページです。")) %>
-<div class="bg-blue-700">
-  <h1 class="page_header"><%= "#{Attendance.model_name.human}登録" %></h1>
+<div class="bg-blue-700 mb-8">
+  <div class="flex justify-between items-center md:max-w-5xl md:mx-auto">
+    <h1 class="text-white font-bold text-xl py-4 md:text-2xl">出席登録</h1>
+    <%= link_to '戻る', edit_minute_path(@minute), class: "block w-28 text-center p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
+  </div>
 </div>
 
 <div class="page_body">


### PR DESCRIPTION
## Issue
- #271 

## 概要
出席登録ページと出席編集ページの最上部に、議事録編集ページに戻るリンクを追加した。

## Screenshot
- 出席登録ページ

![4AB501FE-4AB8-4B4F-9731-7D006EA0F5F5](https://github.com/user-attachments/assets/00e47c9f-ee32-4278-8792-c5cd3c9a4103)

- 出席編集ページ

![4779E58A-CC4C-45F1-B4CB-928D856F99C0](https://github.com/user-attachments/assets/5b43dd7b-2868-462a-91e6-228f798c084f)


