### PR TITLE
出席登録/編集ページの選択肢を簡潔にした

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -2,18 +2,19 @@
 
 class AttendancesController < ApplicationController
   def edit
-    @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if @attendance.minute.already_finished?
+    attendance = current_member.attendances.find(params[:id])
+    redirect_to edit_minute_url(attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if attendance.minute.already_finished?
+
+    @attendance_form = AttendanceForm.new(model: attendance)
   end
 
   def update
-    @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if @attendance.minute.already_finished?
+    attendance = current_member.attendances.find(params[:id])
+    redirect_to edit_minute_url(attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if attendance.minute.already_finished?
 
-    remove_unnecessary_values
-
-    if @attendance.update(attendance_params)
-      redirect_to edit_minute_path(@attendance.minute_id), notice: '出席予定を更新しました'
+    @attendance_form = AttendanceForm.new(model: attendance, **attendance_form_params)
+    if @attendance_form.save
+      redirect_to edit_minute_path(attendance.minute), notice: '出席予定を更新しました'
     else
       render :edit, status: :unprocessable_entity
     end
@@ -21,16 +22,7 @@ class AttendancesController < ApplicationController
 
   private
 
-  def attendance_params
-    params.require(:attendance).permit(:status, :session, :absence_reason, :progress_report)
-  end
-
-  def remove_unnecessary_values
-    if attendance_params['status'] == 'present'
-      @attendance.absence_reason = nil
-      @attendance.progress_report = nil
-    elsif attendance_params['status'] == 'absent'
-      @attendance.session = nil
-    end
+  def attendance_form_params
+    params.require(:attendance_form).permit(:status, :absence_reason, :progress_report)
   end
 end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -6,14 +6,13 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   before_action :prohibit_access_to_finished_minute, only: %i[new create]
 
   def new
-    @attendance = Attendance.new
+    @attendance_form = AttendanceForm.new(model: Attendance.new, minute: @minute, member: current_member)
   end
 
   def create
-    @attendance = @minute.attendances.new(attendance_params)
-    @attendance.member_id = current_member.id
+    @attendance_form = AttendanceForm.new(model: Attendance.new, minute: @minute, member: current_member, **attendance_form_params)
 
-    if @attendance.save
+    if @attendance_form.save
       redirect_to edit_minute_url(@minute), notice: '出席予定を登録しました'
     else
       render :new, status: :unprocessable_entity
@@ -22,8 +21,8 @@ class Minutes::AttendancesController < Minutes::ApplicationController
 
   private
 
-  def attendance_params
-    params.require(:attendance).permit(:status, :session, :absence_reason, :progress_report)
+  def attendance_form_params
+    params.require(:attendance_form).permit(:status, :absence_reason, :progress_report)
   end
 
   def already_registered_attendance

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class AttendanceForm
+  include ActiveModel::API
+  include ActiveModel::Attributes
+
+  attribute :status, :string
+  attribute :absence_reason, :string
+  attribute :progress_report, :string
+
+  validates :status, presence: true
+  validates :absence_reason, presence: true, if: -> { status == 'absent' }
+  validates :progress_report, presence: true, if: -> { status == 'absent' }
+
+  attr_accessor :attendance
+
+  def initialize(model: nil, minute: nil, member: nil, **attrs)
+    attrs.symbolize_keys!
+    if model
+      @attendance = model
+      @minute = @attendance.minute || minute
+      @member = @attendance.member || member
+      attrs = transfer_attributes_from_model.merge(attrs)
+    end
+    super(**attrs)
+  end
+
+  def save(...)
+    return false unless valid?
+
+    transfer_attributes_to_model
+    attendance.save(...)
+  end
+
+  private
+
+  def transfer_attributes_from_model
+    if attendance.present?
+      { status: attendance.session }
+    else
+      { status: 'absent', absence_reason: attendance.absence_reason, progress_report: attendance.progress_report }
+    end
+  end
+
+  def transfer_attributes_to_model
+    attendance.minute = @minute
+    attendance.member = @member
+
+    if status == 'absent'
+      attendance.present = false
+      attendance.session = nil
+      attendance.absence_reason = absence_reason
+      attendance.progress_report = progress_report
+    else
+      attendance.present = true
+      attendance.session = status
+      attendance.absence_reason = nil
+      attendance.progress_report = nil
+    end
+  end
+end

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -32,9 +32,19 @@ class AttendanceForm
     attendance.save(...)
   end
 
+  def form_with_options
+    if attendance.persisted?
+      { url: Rails.application.routes.url_helpers.attendance_path(attendance), method: :patch }
+    else
+      { url: Rails.application.routes.url_helpers.minute_attendances_path(@minute), method: :post }
+    end
+  end
+
   private
 
   def transfer_attributes_from_model
+    return {} if attendance.present.nil? # model: Attendance.new が渡された場合は空のハッシュを返しておく
+
     if attendance.present?
       { status: attendance.session }
     else

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -8,7 +8,7 @@ class AttendanceForm
   attribute :absence_reason, :string
   attribute :progress_report, :string
 
-  validates :status, presence: true
+  validates :status, presence: { message: "#{AttendanceForm.human_attribute_name('status')}を選択してください" }
   validates :absence_reason, presence: true, if: -> { status == 'absent' }
   validates :progress_report, presence: true, if: -> { status == 'absent' }
 

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -6,9 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 出欠のラジオボタンでフォームの表示を切り替える処理
   const statusRadioButtons = document.querySelectorAll(
-    '[name="attendance[status]"]'
+    '[name="attendance_form[status]"]'
   )
-  const presentFields = document.querySelectorAll('.present_entry_field')
   const absentFields = document.querySelectorAll('.absent_entry_field')
 
   const handleChange = function () {
@@ -16,26 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const toggleForm = function () {
-    const checkedStatus = attendanceForm.elements['attendance[status]'].value
-    if (checkedStatus === 'present') {
-      showPresentField()
-      hideAbsentField()
-    } else if (checkedStatus === 'absent') {
-      hidePresentField()
+    const checkedStatus =
+      attendanceForm.elements['attendance_form[status]'].value
+    if (checkedStatus === 'absent') {
       showAbsentField()
+    } else {
+      hideAbsentField()
     }
-  }
-
-  const showPresentField = function () {
-    presentFields.forEach((field) => {
-      field.style.display = 'block'
-    })
-  }
-
-  const hidePresentField = function () {
-    presentFields.forEach((field) => {
-      field.style.display = 'none'
-    })
   }
 
   const showAbsentField = function () {
@@ -55,29 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   const isStatusChecked =
-    attendanceForm.elements['attendance[status]'].value !== ''
+    attendanceForm.elements['attendance_form[status]'].value !== ''
   if (isStatusChecked) {
     toggleForm()
   } else {
-    // 出欠が未選択の場合、まず出欠を入力してもらうために他の入力欄を隠しておく
-    hidePresentField()
     hideAbsentField()
   }
-
-  // 出席時間帯のラジオボタンを2度クリックするとチェックを消せるようにする処理
-  const sessionRadioButtons = document.querySelectorAll(
-    '[name="attendance[session]"]'
-  )
-  let lastCheckedTimeRadioButton = null
-
-  sessionRadioButtons.forEach((button) => {
-    button.addEventListener('click', function () {
-      if (lastCheckedTimeRadioButton === this) {
-        this.checked = false
-        lastCheckedTimeRadioButton = null
-      } else {
-        lastCheckedTimeRadioButton = this
-      }
-    })
-  })
 })

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,42 +1,41 @@
-<% set_meta_tags(build_meta_tags(title: "#{@attendance.minute.title}の出席変更", description: "#{@attendance.minute.title}の出席を変更するページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@attendance_form.attendance.minute.title}の出席変更", description: "#{@attendance_form.attendance.minute.title}の出席を変更するページです。")) %>
 <div class="bg-blue-700 mb-8">
   <div class="flex justify-between items-center md:max-w-5xl md:mx-auto">
     <h1 class="text-white font-bold text-xl py-4 md:text-2xl">出席編集</h1>
-    <%= link_to '戻る', edit_minute_path(@attendance.minute), class: "block w-28 text-center p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
+    <%= link_to '戻る', edit_minute_path(@attendance_form.attendance.minute), class: "block w-28 text-center p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
   </div>
 </div>
 
 <div class="page_body">
   <div>
-    <p class="text-lg text-center"><%= @attendance.minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を編集</p>
+    <p class="text-lg text-center"><%= @attendance_form.attendance.minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を編集</p>
 
-    <%= form_with(model: @attendance, id: "attendance_form", class: "contents") do |form| %>
-      <% if @attendance.errors.any? %>
+    <%= form_with(model: @attendance_form, **@attendance_form.form_with_options, id: "attendance_form", class: "contents") do |form| %>
+      <% if @attendance_form.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
           <h2>以下の項目で入力内容に誤りがあります:</h2>
 
           <ul>
-            <% @attendance.errors.each do |error| %>
+            <% @attendance_form.errors.each do |error| %>
               <li><%= error.full_message %></li>
             <% end %>
           </ul>
         </div>
       <% end %>
 
-      <div class="my-5 text-center">
-        <p><%= Attendance.human_attribute_name('status') %></p>
-        <%= form.radio_button :status, "present", class: "cursor-pointer" %>
-        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :status, "absent", class: "cursor-pointer" %>
-        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent'), class: "cursor-pointer" %>
-      </div>
-
-      <div class="my-5 text-center present_entry_field">
-        <p><%= Attendance.human_attribute_name('session') %></p>
-        <%= form.radio_button :session, "afternoon", class: "cursor-pointer" %>
-        <%= form.label :session_afternoon, Attendance.human_attribute_name('session.afternoon'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :session, "night", class: "cursor-pointer" %>
-        <%= form.label :session_night, Attendance.human_attribute_name('session.night'), class: "cursor-pointer" %>
+      <div class="mt-8 mb-12 flex gap-x-6 w-[550px] mx-auto">
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "afternoon", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_afternoon, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "night", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_night, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "absent", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_absent, AttendanceForm.human_attribute_name('status.absent'), class: "cursor-pointer text-blue-700 align-middle font-bold ml-4" %>
+        </div>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -10,33 +10,32 @@
   <div>
     <p class="text-lg text-center"><%= @minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を登録</p>
 
-    <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
-      <% if @attendance.errors.any? %>
+    <%= form_with(model: [ @minute, @attendance_form ], **@attendance_form.form_with_options, id: "attendance_form", class: "contents") do |form| %>
+      <% if @attendance_form.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
           <h2>以下の項目で入力内容に誤りがあります:</h2>
 
           <ul>
-            <% @attendance.errors.each do |error| %>
+            <% @attendance_form.errors.each do |error| %>
               <li><%= error.full_message %></li>
             <% end %>
           </ul>
         </div>
       <% end %>
 
-      <div class="my-5 text-center">
-        <p><%= Attendance.human_attribute_name('status') %></p>
-        <%= form.radio_button :status, "present", class: "cursor-pointer" %>
-        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :status, "absent", class: "cursor-pointer" %>
-        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent'), class: "cursor-pointer" %>
-      </div>
-
-      <div class="my-5 text-center present_entry_field">
-        <p><%= Attendance.human_attribute_name('session') %></p>
-        <%= form.radio_button :session, "afternoon", class: "cursor-pointer" %>
-        <%= form.label :session_afternoon, Attendance.human_attribute_name('session.afternoon'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :session, "night", class: "cursor-pointer" %>
-        <%= form.label :session_night, Attendance.human_attribute_name('session.night'), class: "cursor-pointer" %>
+      <div class="mt-8 mb-12 flex gap-x-6 w-[550px] mx-auto">
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "afternoon", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_afternoon, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "night", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_night, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "absent", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_absent, AttendanceForm.human_attribute_name('status.absent'), class: "cursor-pointer text-blue-700 align-middle font-bold ml-4" %>
+        </div>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,10 @@ ja:
         status: 出欠
         absence_reason: 欠席理由
         progress_report: 進捗報告
+      attendance_form/status:
+        afternoon: 昼の部
+        night: 夜の部
+        absent: 欠席
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,11 @@
 ---
 ja:
+  activemodel:
+    attributes:
+      attendance_form:
+        status: 出欠
+        absence_reason: 欠席理由
+        progress_report: 進捗報告
   activerecord:
     errors:
       messages:

--- a/spec/forms/attendance_form_spec.rb
+++ b/spec/forms/attendance_form_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AttendanceForm, type: :model do
+  describe 'when create attendance' do
+    let(:minute) { FactoryBot.create(:minute) }
+    let(:member) { FactoryBot.create(:member, course: minute.course) }
+
+    it 'can create an attendance to afternoon session' do
+      attributes_when_attend_afternoon_session = { status: 'afternoon' }
+      expect do
+        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_afternoon_session).save
+      end.to change(Attendance, :count).by(1)
+    end
+
+    it 'can create an attendance to night session' do
+      attributes_when_attend_night_session = { status: 'night' }
+      expect do
+        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_night_session).save
+      end.to change(Attendance, :count).by(1)
+    end
+
+    it 'can create an attendance as absence' do
+      attributes_when_absent_from_meeting = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+      expect do
+        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_absent_from_meeting).save
+      end.to change(Attendance, :count).by(1)
+    end
+
+    it 'cannot create an attendance with invalid attributes' do
+      attributes_without_status = { status: nil }
+      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_status)
+      expect do
+        attendance_form.save
+      end.not_to change(Attendance, :count)
+
+      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+      expect do
+        attendance_form.save
+      end.not_to change(Attendance, :count)
+    end
+  end
+
+  describe 'when update attendance' do
+    let(:minute) { FactoryBot.create(:minute) }
+    let(:member) { FactoryBot.create(:member, course: minute.course) }
+    let(:attendance) { FactoryBot.create(:attendance, minute:, member:) }
+
+    it 'can update an attendance with valid attributes' do
+      expect(attendance.present).to be true
+      expect(attendance.session).to eq 'afternoon'
+      expect(attendance.absence_reason).to be_nil
+      expect(attendance.progress_report).to be_nil
+
+      valid_attributes = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+      attendance_form = described_class.new(model: attendance, minute:, member:, **valid_attributes)
+      attendance_form.save
+      expect(attendance.present).to be false
+      expect(attendance.session).to be_nil
+      expect(attendance.absence_reason).to eq '職場のイベントに参加するため'
+      expect(attendance.progress_report).to eq '#1200 PRを作成しレビュー依頼中です。'
+    end
+
+    it 'cannot update an attendance with invalid attributes' do
+      expect(attendance.present).to be true
+
+      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+      attendance_form = described_class.new(model: attendance, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+      attendance_form.save
+      expect(attendance.present).to be true
+    end
+  end
+end

--- a/spec/forms/attendance_form_spec.rb
+++ b/spec/forms/attendance_form_spec.rb
@@ -3,73 +3,91 @@
 require 'rails_helper'
 
 RSpec.describe AttendanceForm, type: :model do
-  describe 'when create attendance' do
+  describe '#form_with_options' do
     let(:minute) { FactoryBot.create(:minute) }
     let(:member) { FactoryBot.create(:member, course: minute.course) }
 
-    it 'can create an attendance to afternoon session' do
-      attributes_when_attend_afternoon_session = { status: 'afternoon' }
-      expect do
-        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_afternoon_session).save
-      end.to change(Attendance, :count).by(1)
+    it 'returns path and method for create an attendance when attendance is not saved' do
+      attendance_form = described_class.new(model: Attendance.new, minute:, member:, status: 'night')
+      expect(attendance_form.form_with_options).to eq({ url: "/minutes/#{minute.id}/attendances", method: :post })
     end
 
-    it 'can create an attendance to night session' do
-      attributes_when_attend_night_session = { status: 'night' }
-      expect do
-        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_night_session).save
-      end.to change(Attendance, :count).by(1)
-    end
-
-    it 'can create an attendance as absence' do
-      attributes_when_absent_from_meeting = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
-      expect do
-        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_absent_from_meeting).save
-      end.to change(Attendance, :count).by(1)
-    end
-
-    it 'cannot create an attendance with invalid attributes' do
-      attributes_without_status = { status: nil }
-      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_status)
-      expect do
-        attendance_form.save
-      end.not_to change(Attendance, :count)
-
-      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
-      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_absence_reason_and_progress_report)
-      expect do
-        attendance_form.save
-      end.not_to change(Attendance, :count)
+    it 'returns path and method for update an attendance when attendance is already saved' do
+      attendance = FactoryBot.create(:attendance, minute:, member:)
+      attendance_form = described_class.new(model: attendance, minute:, member:, status: 'night')
+      expect(attendance_form.form_with_options).to eq({ url: "/attendances/#{attendance.id}", method: :patch })
     end
   end
 
-  describe 'when update attendance' do
-    let(:minute) { FactoryBot.create(:minute) }
-    let(:member) { FactoryBot.create(:member, course: minute.course) }
-    let(:attendance) { FactoryBot.create(:attendance, minute:, member:) }
+  describe '#save' do
+    describe 'when create attendance' do
+      let(:minute) { FactoryBot.create(:minute) }
+      let(:member) { FactoryBot.create(:member, course: minute.course) }
 
-    it 'can update an attendance with valid attributes' do
-      expect(attendance.present).to be true
-      expect(attendance.session).to eq 'afternoon'
-      expect(attendance.absence_reason).to be_nil
-      expect(attendance.progress_report).to be_nil
+      it 'can create an attendance to afternoon session' do
+        attributes_when_attend_afternoon_session = { status: 'afternoon' }
+        expect do
+          described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_afternoon_session).save
+        end.to change(Attendance, :count).by(1)
+      end
 
-      valid_attributes = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
-      attendance_form = described_class.new(model: attendance, minute:, member:, **valid_attributes)
-      attendance_form.save
-      expect(attendance.present).to be false
-      expect(attendance.session).to be_nil
-      expect(attendance.absence_reason).to eq '職場のイベントに参加するため'
-      expect(attendance.progress_report).to eq '#1200 PRを作成しレビュー依頼中です。'
+      it 'can create an attendance to night session' do
+        attributes_when_attend_night_session = { status: 'night' }
+        expect do
+          described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_night_session).save
+        end.to change(Attendance, :count).by(1)
+      end
+
+      it 'can create an attendance as absence' do
+        attributes_when_absent_from_meeting = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+        expect do
+          described_class.new(model: Attendance.new, minute:, member:, **attributes_when_absent_from_meeting).save
+        end.to change(Attendance, :count).by(1)
+      end
+
+      it 'cannot create an attendance with invalid attributes' do
+        attributes_without_status = { status: nil }
+        attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_status)
+        expect do
+          attendance_form.save
+        end.not_to change(Attendance, :count)
+
+        attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+        attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+        expect do
+          attendance_form.save
+        end.not_to change(Attendance, :count)
+      end
     end
 
-    it 'cannot update an attendance with invalid attributes' do
-      expect(attendance.present).to be true
+    describe 'when update attendance' do
+      let(:minute) { FactoryBot.create(:minute) }
+      let(:member) { FactoryBot.create(:member, course: minute.course) }
+      let(:attendance) { FactoryBot.create(:attendance, minute:, member:) }
 
-      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
-      attendance_form = described_class.new(model: attendance, minute:, member:, **attributes_without_absence_reason_and_progress_report)
-      attendance_form.save
-      expect(attendance.present).to be true
+      it 'can update an attendance with valid attributes' do
+        expect(attendance.present).to be true
+        expect(attendance.session).to eq 'afternoon'
+        expect(attendance.absence_reason).to be_nil
+        expect(attendance.progress_report).to be_nil
+
+        valid_attributes = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+        attendance_form = described_class.new(model: attendance, minute:, member:, **valid_attributes)
+        attendance_form.save
+        expect(attendance.present).to be false
+        expect(attendance.session).to be_nil
+        expect(attendance.absence_reason).to eq '職場のイベントに参加するため'
+        expect(attendance.progress_report).to eq '#1200 PRを作成しレビュー依頼中です。'
+      end
+
+      it 'cannot update an attendance with invalid attributes' do
+        expect(attendance.present).to be true
+
+        attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+        attendance_form = described_class.new(model: attendance, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+        attendance_form.save
+        expect(attendance.present).to be true
+      end
     end
   end
 end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -28,15 +28,14 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can create afternoon attendance', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can create afternoon attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
         click_link '出席予定を登録する'
 
         expect(current_path).to eq new_minute_attendance_path(minute)
-        choose '出席'
-        choose '昼の部'
+        choose '昼の部に出席'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -49,14 +48,13 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can create night attendance', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can create night attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
         click_link '出席予定を登録する'
 
-        choose '出席'
-        choose '夜の部'
+        choose '夜の部に出席'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -69,7 +67,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can create absence', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can create absence', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
@@ -127,11 +125,10 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance twice', { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member cannot create attendance twice' do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
-        choose '出席'
-        choose '昼の部'
+        choose '昼の部に出席'
         click_button '出席を登録'
 
         visit new_minute_attendance_path(minute)
@@ -155,7 +152,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance with invalid input', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member cannot create attendance with invalid input', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
 
@@ -163,21 +160,7 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '出欠を選択してください'
 
         choose '欠席'
-        fill_in '欠席理由', with: '仕事の都合。'
-        fill_in '進捗報告', with: '今週の進捗は特にありません。'
-        choose '出席'
         click_button '出席を登録'
-        expect(page).to have_content '出席時間帯を入力してください'
-        expect(page).to have_content '欠席理由は入力しないでください'
-        expect(page).to have_content '進捗報告は入力しないでください'
-
-        choose '出席'
-        choose '昼の部'
-        choose '欠席'
-        fill_in '欠席理由', with: ''
-        fill_in '進捗報告', with: ''
-        click_button '出席を登録'
-        expect(page).to have_content '出席時間帯は入力しないでください'
         expect(page).to have_content '欠席理由を入力してください'
         expect(page).to have_content '進捗報告を入力してください'
       end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -176,15 +176,14 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can edit attendance to absence', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can change from present to absent', :js do
       attendance = FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         click_link '出席予定を変更する'
         expect(current_path).to eq edit_attendance_path(attendance)
 
-        choose '昼の部'
-        choose '昼の部' # チェックがついている'昼の部'を2度クリックして、チェックを外す
+        expect(page).to have_checked_field '昼の部に出席'
         choose '欠席'
         fill_in '欠席理由', with: '体調不良のため。'
         fill_in '進捗報告', with: '#1000 チームメンバーのレビュー待ちの状態です。'
@@ -203,18 +202,15 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can edit absence to attendance', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can change from absent to present', :js do
       attendance = FactoryBot.create(:attendance, :absence, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         click_link '出席予定を変更する'
         expect(current_path).to eq edit_attendance_path(attendance)
 
-        choose '欠席'
-        fill_in '欠席理由', with: ''
-        fill_in '進捗報告', with: ''
-        choose '出席'
-        choose '夜の部'
+        expect(page).to have_checked_field '欠席'
+        choose '夜の部に出席'
         click_button '出席を更新'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -228,7 +224,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member treated as unexcused absentee can create attendance', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'unexcused absentee can create attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         within('#unexcused_absentees') do
@@ -238,8 +234,7 @@ RSpec.describe 'Attendances', type: :system do
         click_link '出席予定を登録する'
         expect(current_path).to eq new_minute_attendance_path(minute)
 
-        choose '出席'
-        choose '昼の部'
+        choose '昼の部に出席'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -253,26 +248,14 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot update attendance with invalid input', { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member cannot update attendance with invalid input' do
       FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         click_link '出席予定を変更する'
 
         choose '欠席'
-        fill_in '欠席理由', with: '体調不良のため。'
-        fill_in '進捗報告', with: '今週の進捗はありません。'
-        choose '出席'
-        choose '夜の部'
         click_button '出席を更新'
-        expect(page).to have_content '欠席理由は入力しないでください'
-        expect(page).to have_content '進捗報告は入力しないでください'
-
-        choose '欠席'
-        fill_in '欠席理由', with: ''
-        fill_in '進捗報告', with: ''
-        click_button '出席を更新'
-        expect(page).to have_content '出席時間帯は入力しないでください'
         expect(page).to have_content '欠席理由を入力してください'
         expect(page).to have_content '進捗報告を入力してください'
       end


### PR DESCRIPTION
## Issue
- #286 

## 概要
出席登録ページと出席編集ページで、入力欄を以下のように変更した。

変更前
- 出欠の項目を選択してもらう
- 出席を選択した場合、出席時間帯を選択してもらう

変更後
- 昼の部に出席、夜の部に出席、欠席の中から選択してもらう

## Screenshot
### 出席登録ページ
変更前
[![Image from Gyazo](https://i.gyazo.com/a03560187562d1878a952a283c257a7a.gif)](https://gyazo.com/a03560187562d1878a952a283c257a7a)

変更後
[![Image from Gyazo](https://i.gyazo.com/db60810b51be724618f7939e0b2ab612.gif)](https://gyazo.com/db60810b51be724618f7939e0b2ab612)


### 出席編集ページ
変更前
出席登録ページと同じであるため省略。

変更後
[![Image from Gyazo](https://i.gyazo.com/9f4bf998db632bce0843fa17d266e552.gif)](https://gyazo.com/9f4bf998db632bce0843fa17d266e552)


