### PR TITLE
出席登録ページで、出欠を選択するまでフォームを送信できないようにした

### DIFF
--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -4,14 +4,15 @@ document.addEventListener('DOMContentLoaded', () => {
     return null
   }
 
-  // 出欠のラジオボタンでフォームの表示を切り替える処理
   const statusRadioButtons = document.querySelectorAll(
     '[name="attendance_form[status]"]'
   )
   const absentFields = document.querySelectorAll('.absent_entry_field')
+  const submitButton = document.querySelector('#submit_button')
 
   const handleChange = function () {
     toggleForm()
+    activeSubmitButton()
   }
 
   const toggleForm = function () {
@@ -36,6 +37,12 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
 
+  const activeSubmitButton = function () {
+    submitButton.disabled = false
+    submitButton.classList.remove('cursor-not-allowed')
+    submitButton.classList.add('cursor-pointer')
+  }
+
   statusRadioButtons.forEach((button) => {
     button.addEventListener('change', handleChange)
   })
@@ -46,5 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleForm()
   } else {
     hideAbsentField()
+    submitButton.disabled = true
+    submitButton.classList.add('cursor-not-allowed')
   }
 })

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -62,7 +62,7 @@
       </div>
 
       <div class="text-center">
-        <%= form.submit "#{Attendance.model_name.human}を登録", class: "button cursor-pointer" %>
+        <%= form.submit "#{Attendance.model_name.human}を登録", id: "submit_button", class: "button" %>
       </div>
     <% end %>
   </div>

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe 'Attendances', type: :system do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
 
-        click_button '出席を登録'
-        expect(page).to have_content '出欠を選択してください'
+        # 出欠を選択していない場合、送信ボタンはdisabledとなる
+        expect(page).to have_button '出席を登録', disabled: true
 
         choose '欠席'
         click_button '出席を登録'


### PR DESCRIPTION
## Issue
- #271 

## 概要
出席登録ページで、ユーザーが出欠を選択していない場合は送信ボタンをdisabled状態にし、フォームを送信できないようにした。
出席編集ページでは初めから出欠が選択された状態であるため、この対応は行なっていない。


## Screenshot
変更前
[![Image from Gyazo](https://i.gyazo.com/9f13f5aaac1c799fd3971a20a3b84da6.gif)](https://gyazo.com/9f13f5aaac1c799fd3971a20a3b84da6)

変更後

[![Image from Gyazo](https://i.gyazo.com/58d9108fab503f04923d923c06ddfe74.gif)](https://gyazo.com/58d9108fab503f04923d923c06ddfe74)

