### PR TITLE
フォームオブジェクトのバリデーションエラーメッセージを修正

### DIFF
--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -8,7 +8,7 @@ class AttendanceForm
   attribute :absence_reason, :string
   attribute :progress_report, :string
 
-  validates :status, presence: { message: "#{AttendanceForm.human_attribute_name('status')}を選択してください" }
+  validates :status, presence: true
   validates :absence_reason, presence: true, if: -> { status == 'absent' }
   validates :progress_report, presence: true, if: -> { status == 'absent' }
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,12 @@ ja:
         afternoon: 昼の部
         night: 夜の部
         absent: 欠席
+    error:
+      models:
+        attendance_form:
+          attributes:
+            status:
+              presence: "%{attribute}を選択してください"
   activerecord:
     errors:
       messages:


### PR DESCRIPTION
## Issue
なし
関連Issue : #288 

## 概要
AttendanceFormのバリデーションエラーメッセージが`出欠出欠を選択してください`と重複して表示されていた問題を修正した。

## Screenshot
修正前
![C501734E-0446-423C-8CEE-743767D53674](https://github.com/user-attachments/assets/f68d8458-c325-4189-befc-71f87ec23e74)


修正後
![1FDC6D9F-2C9C-4220-9516-C7A68CEAEC48](https://github.com/user-attachments/assets/f752304b-42cc-4ebf-9984-4138a9fa5fda)
