### PR TITLE
出席登録/編集ページのデザインレビュー対応を行った

### DIFF
--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -22,7 +22,7 @@ class AttendancesController < ApplicationController
   private
 
   def attendance_params
-    params.require(:attendance).permit(:status, :time, :absence_reason, :progress_report)
+    params.require(:attendance).permit(:status, :session, :absence_reason, :progress_report)
   end
 
   def remove_unnecessary_values
@@ -30,7 +30,7 @@ class AttendancesController < ApplicationController
       @attendance.absence_reason = nil
       @attendance.progress_report = nil
     elsif attendance_params['status'] == 'absent'
-      @attendance.time = nil
+      @attendance.session = nil
     end
   end
 end

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -2,18 +2,19 @@
 
 class AttendancesController < ApplicationController
   def edit
-    @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if @attendance.minute.already_finished?
+    attendance = current_member.attendances.find(params[:id])
+    redirect_to edit_minute_url(attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if attendance.minute.already_finished?
+
+    @attendance_form = AttendanceForm.new(model: attendance)
   end
 
   def update
-    @attendance = current_member.attendances.find(params[:id])
-    redirect_to edit_minute_url(@attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if @attendance.minute.already_finished?
+    attendance = current_member.attendances.find(params[:id])
+    redirect_to edit_minute_url(attendance.minute), alert: '終了したミーティングの出席予定は変更できません' if attendance.minute.already_finished?
 
-    remove_unnecessary_values
-
-    if @attendance.update(attendance_params)
-      redirect_to edit_minute_path(@attendance.minute_id), notice: '出席予定を更新しました'
+    @attendance_form = AttendanceForm.new(model: attendance, **attendance_form_params)
+    if @attendance_form.save
+      redirect_to edit_minute_path(attendance.minute), notice: '出席予定を更新しました'
     else
       render :edit, status: :unprocessable_entity
     end
@@ -21,16 +22,7 @@ class AttendancesController < ApplicationController
 
   private
 
-  def attendance_params
-    params.require(:attendance).permit(:status, :session, :absence_reason, :progress_report)
-  end
-
-  def remove_unnecessary_values
-    if attendance_params['status'] == 'present'
-      @attendance.absence_reason = nil
-      @attendance.progress_report = nil
-    elsif attendance_params['status'] == 'absent'
-      @attendance.session = nil
-    end
+  def attendance_form_params
+    params.require(:attendance_form).permit(:status, :absence_reason, :progress_report)
   end
 end

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -23,7 +23,7 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   private
 
   def attendance_params
-    params.require(:attendance).permit(:status, :time, :absence_reason, :progress_report)
+    params.require(:attendance).permit(:status, :session, :absence_reason, :progress_report)
   end
 
   def already_registered_attendance

--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -6,14 +6,13 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   before_action :prohibit_access_to_finished_minute, only: %i[new create]
 
   def new
-    @attendance = Attendance.new
+    @attendance_form = AttendanceForm.new(model: Attendance.new, minute: @minute, member: current_member)
   end
 
   def create
-    @attendance = @minute.attendances.new(attendance_params)
-    @attendance.member_id = current_member.id
+    @attendance_form = AttendanceForm.new(model: Attendance.new, minute: @minute, member: current_member, **attendance_form_params)
 
-    if @attendance.save
+    if @attendance_form.save
       redirect_to edit_minute_url(@minute), notice: '出席予定を登録しました'
     else
       render :new, status: :unprocessable_entity
@@ -22,8 +21,8 @@ class Minutes::AttendancesController < Minutes::ApplicationController
 
   private
 
-  def attendance_params
-    params.require(:attendance).permit(:status, :session, :absence_reason, :progress_report)
+  def attendance_form_params
+    params.require(:attendance_form).permit(:status, :absence_reason, :progress_report)
   end
 
   def already_registered_attendance

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class AttendanceForm
+  include ActiveModel::API
+  include ActiveModel::Attributes
+
+  attribute :status, :string
+  attribute :absence_reason, :string
+  attribute :progress_report, :string
+
+  validates :status, presence: true
+  validates :absence_reason, presence: true, if: -> { status == 'absent' }
+  validates :progress_report, presence: true, if: -> { status == 'absent' }
+
+  attr_accessor :attendance
+
+  def initialize(model: nil, minute: nil, member: nil, **attrs)
+    attrs.symbolize_keys!
+    if model
+      @attendance = model
+      @minute = @attendance.minute || minute
+      @member = @attendance.member || member
+      attrs = transfer_attributes_from_model.merge(attrs)
+    end
+    super(**attrs)
+  end
+
+  def save(...)
+    return false unless valid?
+
+    transfer_attributes_to_model
+    attendance.save(...)
+  end
+
+  private
+
+  def transfer_attributes_from_model
+    if attendance.present?
+      { status: attendance.session }
+    else
+      { status: 'absent', absence_reason: attendance.absence_reason, progress_report: attendance.progress_report }
+    end
+  end
+
+  def transfer_attributes_to_model
+    attendance.minute = @minute
+    attendance.member = @member
+
+    if status == 'absent'
+      attendance.present = false
+      attendance.session = nil
+      attendance.absence_reason = absence_reason
+      attendance.progress_report = progress_report
+    else
+      attendance.present = true
+      attendance.session = status
+      attendance.absence_reason = nil
+      attendance.progress_report = nil
+    end
+  end
+end

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -8,7 +8,7 @@ class AttendanceForm
   attribute :absence_reason, :string
   attribute :progress_report, :string
 
-  validates :status, presence: { message: "#{AttendanceForm.human_attribute_name('status')}を選択してください" }
+  validates :status, presence: true
   validates :absence_reason, presence: true, if: -> { status == 'absent' }
   validates :progress_report, presence: true, if: -> { status == 'absent' }
 

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -32,9 +32,19 @@ class AttendanceForm
     attendance.save(...)
   end
 
+  def form_with_options
+    if attendance.persisted?
+      { url: Rails.application.routes.url_helpers.attendance_path(attendance), method: :patch }
+    else
+      { url: Rails.application.routes.url_helpers.minute_attendances_path(@minute), method: :post }
+    end
+  end
+
   private
 
   def transfer_attributes_from_model
+    return {} if attendance.present.nil? # model: Attendance.new が渡された場合は空のハッシュを返しておく
+
     if attendance.present?
       { status: attendance.session }
     else

--- a/app/forms/attendance_form.rb
+++ b/app/forms/attendance_form.rb
@@ -8,7 +8,7 @@ class AttendanceForm
   attribute :absence_reason, :string
   attribute :progress_report, :string
 
-  validates :status, presence: true
+  validates :status, presence: { message: "#{AttendanceForm.human_attribute_name('status')}を選択してください" }
   validates :absence_reason, presence: true, if: -> { status == 'absent' }
   validates :progress_report, presence: true, if: -> { status == 'absent' }
 

--- a/app/helpers/attendances_helper.rb
+++ b/app/helpers/attendances_helper.rb
@@ -4,6 +4,6 @@ module AttendancesHelper
   def attendance_status(status, time)
     return '---' if status.nil?
 
-    { 'day' => '昼', 'night' => '夜' }[time]
+    { 'afternoon' => '昼', 'night' => '夜' }[time]
   end
 end

--- a/app/helpers/attendances_helper.rb
+++ b/app/helpers/attendances_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module AttendancesHelper
-  def attendance_status(status, time)
-    return '---' if status.nil?
+  def attendance_status(present, time)
+    return '---' unless present
 
     { 'afternoon' => '昼', 'night' => '夜' }[time]
   end

--- a/app/helpers/attendances_helper.rb
+++ b/app/helpers/attendances_helper.rb
@@ -2,7 +2,7 @@
 
 module AttendancesHelper
   def attendance_status(present, time)
-    return '---' unless present
+    return '---' if present.nil?
 
     { 'afternoon' => '昼', 'night' => '夜' }[time]
   end

--- a/app/javascript/components/AttendeesList.jsx
+++ b/app/javascript/components/AttendeesList.jsx
@@ -14,8 +14,8 @@ export default function AttendeesList({ minuteId }) {
   return (
     <>
       <h3>昼の部</h3>
-      <ul id="day_attendees">
-        {data.day_attendees.map((attendee) => (
+      <ul id="afternoon_attendees">
+        {data.afternoon_attendees.map((attendee) => (
           <Attendee key={attendee.attendance_id} attendee={attendee} />
         ))}
       </ul>

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -6,9 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 出欠のラジオボタンでフォームの表示を切り替える処理
   const statusRadioButtons = document.querySelectorAll(
-    '[name="attendance[status]"]'
+    '[name="attendance_form[status]"]'
   )
-  const presentFields = document.querySelectorAll('.present_entry_field')
   const absentFields = document.querySelectorAll('.absent_entry_field')
 
   const handleChange = function () {
@@ -16,26 +15,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const toggleForm = function () {
-    const checkedStatus = attendanceForm.elements['attendance[status]'].value
-    if (checkedStatus === 'present') {
-      showPresentField()
-      hideAbsentField()
-    } else if (checkedStatus === 'absent') {
-      hidePresentField()
+    const checkedStatus =
+      attendanceForm.elements['attendance_form[status]'].value
+    if (checkedStatus === 'absent') {
       showAbsentField()
+    } else {
+      hideAbsentField()
     }
-  }
-
-  const showPresentField = function () {
-    presentFields.forEach((field) => {
-      field.style.display = 'block'
-    })
-  }
-
-  const hidePresentField = function () {
-    presentFields.forEach((field) => {
-      field.style.display = 'none'
-    })
   }
 
   const showAbsentField = function () {
@@ -55,29 +41,10 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   const isStatusChecked =
-    attendanceForm.elements['attendance[status]'].value !== ''
+    attendanceForm.elements['attendance_form[status]'].value !== ''
   if (isStatusChecked) {
     toggleForm()
   } else {
-    // 出欠が未選択の場合、まず出欠を入力してもらうために他の入力欄を隠しておく
-    hidePresentField()
     hideAbsentField()
   }
-
-  // 出席時間帯のラジオボタンを2度クリックするとチェックを消せるようにする処理
-  const sessionRadioButtons = document.querySelectorAll(
-    '[name="attendance[session]"]'
-  )
-  let lastCheckedTimeRadioButton = null
-
-  sessionRadioButtons.forEach((button) => {
-    button.addEventListener('click', function () {
-      if (lastCheckedTimeRadioButton === this) {
-        this.checked = false
-        lastCheckedTimeRadioButton = null
-      } else {
-        lastCheckedTimeRadioButton = this
-      }
-    })
-  })
 })

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -4,14 +4,15 @@ document.addEventListener('DOMContentLoaded', () => {
     return null
   }
 
-  // 出欠のラジオボタンでフォームの表示を切り替える処理
   const statusRadioButtons = document.querySelectorAll(
     '[name="attendance_form[status]"]'
   )
   const absentFields = document.querySelectorAll('.absent_entry_field')
+  const submitButton = document.querySelector('#submit_button')
 
   const handleChange = function () {
     toggleForm()
+    activeSubmitButton()
   }
 
   const toggleForm = function () {
@@ -36,6 +37,12 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
 
+  const activeSubmitButton = function () {
+    submitButton.disabled = false
+    submitButton.classList.remove('cursor-not-allowed')
+    submitButton.classList.add('cursor-pointer')
+  }
+
   statusRadioButtons.forEach((button) => {
     button.addEventListener('change', handleChange)
   })
@@ -46,5 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     toggleForm()
   } else {
     hideAbsentField()
+    submitButton.disabled = true
+    submitButton.classList.add('cursor-not-allowed')
   }
 })

--- a/app/javascript/toggleAttendanceForm.js
+++ b/app/javascript/toggleAttendanceForm.js
@@ -65,12 +65,12 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // 出席時間帯のラジオボタンを2度クリックするとチェックを消せるようにする処理
-  const timeRadioButtons = document.querySelectorAll(
-    '[name="attendance[time]"]'
+  const sessionRadioButtons = document.querySelectorAll(
+    '[name="attendance[session]"]'
   )
   let lastCheckedTimeRadioButton = null
 
-  timeRadioButtons.forEach((button) => {
+  sessionRadioButtons.forEach((button) => {
     button.addEventListener('click', function () {
       if (lastCheckedTimeRadioButton === this) {
         this.checked = false

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 class Attendance < ApplicationRecord
-  enum :status, { present: 0, absent: 1 }
   enum :session, { afternoon: 0, night: 1 }
 
   belongs_to :minute
   belongs_to :member
 
-  validates :status, presence: true
+  validates :present, inclusion: { in: [true, false] }
   validates :session, presence: true, if: proc { |attendance| attendance.present? }
-  validates :session, absence: true, if: proc { |attendance| attendance.absent? }
-  validates :absence_reason, presence: true, if: proc { |attendance| attendance.absent? }
-  validates :progress_report, presence: true, if: proc { |attendance| attendance.absent? }
+  validates :session, absence: true, unless: proc { |attendance| attendance.present? }
+  validates :absence_reason, presence: true, unless: proc { |attendance| attendance.present? }
+  validates :progress_report, presence: true, unless: proc { |attendance| attendance.present? }
   validates :absence_reason, absence: true, if: proc { |attendance| attendance.present? }
   validates :progress_report, absence: true, if: proc { |attendance| attendance.present? }
 end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -2,14 +2,14 @@
 
 class Attendance < ApplicationRecord
   enum :status, { present: 0, absent: 1 }
-  enum :time, { day: 0, night: 1 }, suffix: true
+  enum :session, { day: 0, night: 1 }, suffix: true
 
   belongs_to :minute
   belongs_to :member
 
   validates :status, presence: true
-  validates :time, presence: true, if: proc { |attendance| attendance.present? }
-  validates :time, absence: true, if: proc { |attendance| attendance.absent? }
+  validates :session, presence: true, if: proc { |attendance| attendance.present? }
+  validates :session, absence: true, if: proc { |attendance| attendance.absent? }
   validates :absence_reason, presence: true, if: proc { |attendance| attendance.absent? }
   validates :progress_report, presence: true, if: proc { |attendance| attendance.absent? }
   validates :absence_reason, absence: true, if: proc { |attendance| attendance.present? }

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -2,7 +2,7 @@
 
 class Attendance < ApplicationRecord
   enum :status, { present: 0, absent: 1 }
-  enum :session, { day: 0, night: 1 }, suffix: true
+  enum :session, { afternoon: 0, night: 1 }
 
   belongs_to :minute
   belongs_to :member

--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -15,7 +15,7 @@ class MarkdownBuilder
     template = File.read(TEMPLATE_PATH)
     minute_data = {
       minute: @minute,
-      day_attendees:,
+      afternoon_attendees:,
       night_attendees:,
       absentees:,
       topics:,
@@ -26,7 +26,7 @@ class MarkdownBuilder
 
   private
 
-  def day_attendees
+  def afternoon_attendees
     @minute.attendances.where(session: :afternoon)
            .includes(:member)
            .order(:member_id)

--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -27,7 +27,7 @@ class MarkdownBuilder
   private
 
   def day_attendees
-    @minute.attendances.where(time: :day)
+    @minute.attendances.where(session: :afternoon)
            .includes(:member)
            .order(:member_id)
            .pluck(:name)
@@ -36,7 +36,7 @@ class MarkdownBuilder
   end
 
   def night_attendees
-    @minute.attendances.where(time: :night)
+    @minute.attendances.where(session: :night)
            .includes(:member)
            .order(:member_id)
            .pluck(:name)

--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -45,7 +45,7 @@ class MarkdownBuilder
   end
 
   def absentees
-    @minute.attendances.where(status: :absent)
+    @minute.attendances.where(present: false)
            .includes(:member)
            .order(:member_id)
            .pluck(:absence_reason, :progress_report, :name)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -48,8 +48,8 @@ class Member < ApplicationRecord
           .where(course_id:)
           .where(meeting_date: from..to)
           .order(:meeting_date)
-          .pluck(:id, :meeting_date, attendances: %i[id status session absence_reason])
-          .map { |data| { minute_id: data[0], date: data[1], attendance_id: data[2], status: data[3], session: data[4], absence_reason: data[5] } }
+          .pluck(:id, :meeting_date, attendances: %i[id present session absence_reason])
+          .map { |data| { minute_id: data[0], date: data[1], attendance_id: data[2], present: data[3], session: data[4], absence_reason: data[5] } }
   end
 
   def split_for_display(attendances)

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -48,8 +48,8 @@ class Member < ApplicationRecord
           .where(course_id:)
           .where(meeting_date: from..to)
           .order(:meeting_date)
-          .pluck(:id, :meeting_date, attendances: %i[id status time absence_reason])
-          .map { |data| { minute_id: data[0], date: data[1], attendance_id: data[2], status: data[3], time: data[4], absence_reason: data[5] } }
+          .pluck(:id, :meeting_date, attendances: %i[id status session absence_reason])
+          .map { |data| { minute_id: data[0], date: data[1], attendance_id: data[2], status: data[3], session: data[4], absence_reason: data[5] } }
   end
 
   def split_for_display(attendances)

--- a/app/views/api/minutes/attendances/index.json.jbuilder
+++ b/app/views/api/minutes/attendances/index.json.jbuilder
@@ -1,4 +1,4 @@
-json.day_attendees do
+json.afternoon_attendees do
   json.array! @attendances.where(session: :afternoon) do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id

--- a/app/views/api/minutes/attendances/index.json.jbuilder
+++ b/app/views/api/minutes/attendances/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.day_attendees do
-  json.array! @attendances.where(time: :day) do |attendance|
+  json.array! @attendances.where(session: :afternoon) do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id
     json.name attendance.member.name
@@ -7,7 +7,7 @@ json.day_attendees do
 end
 
 json.night_attendees do
-  json.array! @attendances.where(time: :night) do |attendance|
+  json.array! @attendances.where(session: :night) do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id
     json.name attendance.member.name

--- a/app/views/api/minutes/attendances/index.json.jbuilder
+++ b/app/views/api/minutes/attendances/index.json.jbuilder
@@ -15,7 +15,7 @@ json.night_attendees do
 end
 
 json.absentees do
-  json.array! @attendances.where(status: :absent) do |attendance|
+  json.array! @attendances.where(present: false) do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id
     json.name attendance.member.name

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -32,11 +32,11 @@
       </div>
 
       <div class="my-5 text-center present_entry_field">
-        <p><%= Attendance.human_attribute_name('time') %></p>
-        <%= form.radio_button :time, "day", class: "cursor-pointer" %>
-        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :time, "night", class: "cursor-pointer" %>
-        <%= form.label :time_night, Attendance.human_attribute_name('time.night'), class: "cursor-pointer" %>
+        <p><%= Attendance.human_attribute_name('session') %></p>
+        <%= form.radio_button :session, "afternoon", class: "cursor-pointer" %>
+        <%= form.label :session_afternoon, Attendance.human_attribute_name('session.afternoon'), class: "mr-10 cursor-pointer" %>
+        <%= form.radio_button :session, "night", class: "cursor-pointer" %>
+        <%= form.label :session_night, Attendance.human_attribute_name('session.night'), class: "cursor-pointer" %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -1,42 +1,41 @@
-<% set_meta_tags(build_meta_tags(title: "#{@attendance.minute.title}の出席変更", description: "#{@attendance.minute.title}の出席を変更するページです。")) %>
+<% set_meta_tags(build_meta_tags(title: "#{@attendance_form.attendance.minute.title}の出席変更", description: "#{@attendance_form.attendance.minute.title}の出席を変更するページです。")) %>
 <div class="bg-blue-700 mb-8">
   <div class="flex justify-between items-center md:max-w-5xl md:mx-auto">
     <h1 class="text-white font-bold text-xl py-4 md:text-2xl">出席編集</h1>
-    <%= link_to '戻る', edit_minute_path(@attendance.minute), class: "block w-28 text-center p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
+    <%= link_to '戻る', edit_minute_path(@attendance_form.attendance.minute), class: "block w-28 text-center p-2 bg-white text-blue-700 before:content-['<'] before:mr-4 hover:no-underline hover:bg-gray-200" %>
   </div>
 </div>
 
 <div class="page_body">
   <div>
-    <p class="text-lg text-center"><%= @attendance.minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を編集</p>
+    <p class="text-lg text-center"><%= @attendance_form.attendance.minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を編集</p>
 
-    <%= form_with(model: @attendance, id: "attendance_form", class: "contents") do |form| %>
-      <% if @attendance.errors.any? %>
+    <%= form_with(model: @attendance_form, **@attendance_form.form_with_options, id: "attendance_form", class: "contents") do |form| %>
+      <% if @attendance_form.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
           <h2>以下の項目で入力内容に誤りがあります:</h2>
 
           <ul>
-            <% @attendance.errors.each do |error| %>
+            <% @attendance_form.errors.each do |error| %>
               <li><%= error.full_message %></li>
             <% end %>
           </ul>
         </div>
       <% end %>
 
-      <div class="my-5 text-center">
-        <p><%= Attendance.human_attribute_name('status') %></p>
-        <%= form.radio_button :status, "present", class: "cursor-pointer" %>
-        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :status, "absent", class: "cursor-pointer" %>
-        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent'), class: "cursor-pointer" %>
-      </div>
-
-      <div class="my-5 text-center present_entry_field">
-        <p><%= Attendance.human_attribute_name('session') %></p>
-        <%= form.radio_button :session, "afternoon", class: "cursor-pointer" %>
-        <%= form.label :session_afternoon, Attendance.human_attribute_name('session.afternoon'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :session, "night", class: "cursor-pointer" %>
-        <%= form.label :session_night, Attendance.human_attribute_name('session.night'), class: "cursor-pointer" %>
+      <div class="mt-8 mb-12 flex gap-x-6 w-[550px] mx-auto">
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "afternoon", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_afternoon, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "night", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_night, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "absent", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_absent, AttendanceForm.human_attribute_name('status.absent'), class: "cursor-pointer text-blue-700 align-middle font-bold ml-4" %>
+        </div>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -32,11 +32,11 @@
       </div>
 
       <div class="my-5 text-center present_entry_field">
-        <p><%= Attendance.human_attribute_name('time') %></p>
-        <%= form.radio_button :time, "day", class: "cursor-pointer" %>
-        <%= form.label :time_day, Attendance.human_attribute_name('time.day'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :time, "night", class: "cursor-pointer" %>
-        <%= form.label :time_night, Attendance.human_attribute_name('time.night'), class: "cursor-pointer" %>
+        <p><%= Attendance.human_attribute_name('session') %></p>
+        <%= form.radio_button :session, "afternoon", class: "cursor-pointer" %>
+        <%= form.label :session_afternoon, Attendance.human_attribute_name('session.afternoon'), class: "mr-10 cursor-pointer" %>
+        <%= form.radio_button :session, "night", class: "cursor-pointer" %>
+        <%= form.label :session_night, Attendance.human_attribute_name('session.night'), class: "cursor-pointer" %>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -10,33 +10,32 @@
   <div>
     <p class="text-lg text-center"><%= @minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を登録</p>
 
-    <%= form_with(model: [ @minute, @attendance ], id: "attendance_form", class: "contents") do |form| %>
-      <% if @attendance.errors.any? %>
+    <%= form_with(model: [ @minute, @attendance_form ], **@attendance_form.form_with_options, id: "attendance_form", class: "contents") do |form| %>
+      <% if @attendance_form.errors.any? %>
         <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
           <h2>以下の項目で入力内容に誤りがあります:</h2>
 
           <ul>
-            <% @attendance.errors.each do |error| %>
+            <% @attendance_form.errors.each do |error| %>
               <li><%= error.full_message %></li>
             <% end %>
           </ul>
         </div>
       <% end %>
 
-      <div class="my-5 text-center">
-        <p><%= Attendance.human_attribute_name('status') %></p>
-        <%= form.radio_button :status, "present", class: "cursor-pointer" %>
-        <%= form.label :status_present, Attendance.human_attribute_name('status.present'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :status, "absent", class: "cursor-pointer" %>
-        <%= form.label :status_absent, Attendance.human_attribute_name('status.absent'), class: "cursor-pointer" %>
-      </div>
-
-      <div class="my-5 text-center present_entry_field">
-        <p><%= Attendance.human_attribute_name('session') %></p>
-        <%= form.radio_button :session, "afternoon", class: "cursor-pointer" %>
-        <%= form.label :session_afternoon, Attendance.human_attribute_name('session.afternoon'), class: "mr-10 cursor-pointer" %>
-        <%= form.radio_button :session, "night", class: "cursor-pointer" %>
-        <%= form.label :session_night, Attendance.human_attribute_name('session.night'), class: "cursor-pointer" %>
+      <div class="mt-8 mb-12 flex gap-x-6 w-[550px] mx-auto">
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "afternoon", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_afternoon, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "night", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_night, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        </div>
+        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
+          <%= form.radio_button :status, "absent", class: "cursor-pointer border border-blue-700 mr-2" %>
+          <%= form.label :status_absent, AttendanceForm.human_attribute_name('status.absent'), class: "cursor-pointer text-blue-700 align-middle font-bold ml-4" %>
+        </div>
       </div>
 
       <div class="my-5 text-center absent_entry_field">

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -62,7 +62,7 @@
       </div>
 
       <div class="text-center">
-        <%= form.submit "#{Attendance.model_name.human}を登録", class: "button cursor-pointer" %>
+        <%= form.submit "#{Attendance.model_name.human}を登録", id: "submit_button", class: "button" %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -5,16 +5,16 @@
         <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]" data-attendance-on="<%= attendance[:date].strftime('%Y-%m-%d') %>">
           <%= attendance[:date].strftime('%m/%d') %>
         </dt>
-        <% background_color = attendance[:status].nil? ? 'bg-gray-200' : 'bg-white' %>
+        <% background_color = attendance[:present].nil? ? 'bg-gray-200' : 'bg-white' %>
         <dd class="p-1 text-sm border border-gray-400 w-12 text-center <%= background_color %>" data-attendance-on="<%= attendance[:date].strftime('%Y-%m-%d') %>">
-          <% if attendance[:status] == 'absent' %>
+          <% if attendance[:present] == false %>
             <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
             <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">
               <%= attendance[:absence_reason] %>
               <div class="tooltip-arrow" data-popper-arrow></div>
             </div>
           <% else %>
-            <%= attendance_status(attendance[:status], attendance[:session]) %>
+            <%= attendance_status(attendance[:present], attendance[:session]) %>
           <% end %>
         </dd>
       </div>

--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -14,7 +14,7 @@
               <div class="tooltip-arrow" data-popper-arrow></div>
             </div>
           <% else %>
-            <%= attendance_status(attendance[:status], attendance[:time]) %>
+            <%= attendance_status(attendance[:status], attendance[:session]) %>
           <% end %>
         </dd>
       </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,12 @@ ja:
         afternoon: 昼の部
         night: 夜の部
         absent: 欠席
+    error:
+      models:
+        attendance_form:
+          attributes:
+            status:
+              presence: "%{attribute}を選択してください"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,10 @@ ja:
         status: 出欠
         absence_reason: 欠席理由
         progress_report: 進捗報告
+      attendance_form/status:
+        afternoon: 昼の部
+        night: 夜の部
+        absent: 欠席
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,14 +21,14 @@ ja:
         name: 名前
       attendance:
         status: 出席状況
-        time: 出席時間帯
+        session: 出席時間帯
         absence_reason: 欠席理由
         progress_report: 進捗報告
       attendance/status:
         present: 出席
         absent: 欠席
-      attendance/time:
-        day: 昼の部
+      attendance/session:
+        afternoon: 昼の部
         night: 夜の部
       course:
         name: コース名

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -20,13 +20,10 @@ ja:
         password: パスワード
         name: 名前
       attendance:
-        status: 出席状況
+        present: 出欠
         session: 出席時間帯
         absence_reason: 欠席理由
         progress_report: 進捗報告
-      attendance/status:
-        present: 出席
-        absent: 欠席
       attendance/session:
         afternoon: 昼の部
         night: 夜の部

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,11 @@
 ---
 ja:
+  activemodel:
+    attributes:
+      attendance_form:
+        status: 出欠
+        absence_reason: 欠席理由
+        progress_report: 進捗報告
   activerecord:
     errors:
       messages:

--- a/config/templates/minute.md
+++ b/config/templates/minute.md
@@ -7,7 +7,7 @@
 
 ### 昼の部
 
-<%= "#{day_attendees}" %>
+<%= "#{afternoon_attendees}" %>
 
 ### 夜の部
 

--- a/db/migrate/20250131092516_rename_time_column_to_attendances.rb
+++ b/db/migrate/20250131092516_rename_time_column_to_attendances.rb
@@ -1,0 +1,5 @@
+class RenameTimeColumnToAttendances < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :attendances, :time, :session
+  end
+end

--- a/db/migrate/20250131120304_rename_status_column_to_attendances.rb
+++ b/db/migrate/20250131120304_rename_status_column_to_attendances.rb
@@ -1,0 +1,5 @@
+class RenameStatusColumnToAttendances < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :attendances, :status, :present
+  end
+end

--- a/db/migrate/20250131120737_change_data_type_present_of_attendances.rb
+++ b/db/migrate/20250131120737_change_data_type_present_of_attendances.rb
@@ -1,0 +1,5 @@
+class ChangeDataTypePresentOfAttendances < ActiveRecord::Migration[7.2]
+  def change
+    change_column :attendances, :present, 'boolean USING CAST(present AS boolean)' , null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_31_120304) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_31_120737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_31_120304) do
   end
 
   create_table "attendances", force: :cascade do |t|
-    t.integer "present", null: false
+    t.boolean "present", null: false
     t.integer "session"
     t.string "absence_reason"
     t.text "progress_report"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_31_092516) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_31_120304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,7 +28,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_31_092516) do
   end
 
   create_table "attendances", force: :cascade do |t|
-    t.integer "status", null: false
+    t.integer "present", null: false
     t.integer "session"
     t.string "absence_reason"
     t.text "progress_report"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_25_233751) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_31_092516) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_25_233751) do
 
   create_table "attendances", force: :cascade do |t|
     t.integer "status", null: false
-    t.integer "time"
+    t.integer "session"
     t.string "absence_reason"
     t.text "progress_report"
     t.bigint "minute_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -142,15 +142,15 @@ absentee = Member.find_by(email: 'absentee@example.com')
 
 minutes.each do |minute|
   Attendance.find_or_create_by!(minute:, member: day_attendee) do |attendance|
-    attendance.status = :present
-    attendance.time = :day
+    attendance.present = true
+    attendance.session = :afternoon
   end
   Attendance.find_or_create_by!(minute:, member: night_attendee) do |attendance|
-    attendance.status = :present
-    attendance.time = :night
+    attendance.present = true
+    attendance.session = :night
   end
   Attendance.find_or_create_by!(minute:, member: absentee) do |attendance|
-    attendance.status = :absent
+    attendance.present = false
     attendance.absence_reason = '仕事の都合のため'
     attendance.progress_report = '今週の進捗はありません、仕事が忙しく時間が取れずにいます。'
   end
@@ -158,14 +158,14 @@ end
 
 Minute.where(meeting_date: ..hibernated_member_hibernation.created_at).find_each do |minute|
   Attendance.find_or_create_by!(minute:, member: hibernated_member) do |attendance|
-    attendance.status = :present
-    attendance.time = :day
+    attendance.present = true
+    attendance.session = :afternoon
   end
 end
 
 Minute.where.not(meeting_date: returned_member_hibernation.created_at..returned_member_hibernation.finished_at).find_each do |minute|
   Attendance.find_or_create_by!(minute:, member: returned_member) do |attendance|
-    attendance.status = :present
-    attendance.time = :night
+    attendance.present = true
+    attendance.session = :night
   end
 end

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -3,26 +3,26 @@
 FactoryBot.define do
   factory :attendance do
     status { :present }
-    time { :day }
+    session { :afternoon }
     absence_reason { nil }
     progress_report { nil }
     association :member, factory: :member
     association :minute, factory: :minute
 
     trait :night do
-      time { :night }
+      session { :night }
     end
 
     trait :absence do
       status { :absent }
-      time { nil }
+      session { nil }
       absence_reason { '体調不良のため。' }
       progress_report { 'PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。' }
     end
 
     trait :absence_with_multiple_progress_reports do
       status { :absent }
-      time { nil }
+      session { nil }
       absence_reason { '職場のイベントに参加するため。' }
       progress_report { "#8000 チームメンバーにレビュー依頼を行いました。\r\n#8102 問題が発生している箇所の調査を行いました(関連Issue#8100)。\r\n#8080 依頼されたレビュー対応を行いました。" }
     end

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :attendance do
-    status { :present }
+    present { true }
     session { :afternoon }
     absence_reason { nil }
     progress_report { nil }
@@ -14,14 +14,14 @@ FactoryBot.define do
     end
 
     trait :absence do
-      status { :absent }
+      present { false }
       session { nil }
       absence_reason { '体調不良のため。' }
       progress_report { 'PRのチームメンバーのレビューが通り、komagataさんにレビュー依頼をお願いしているところです。' }
     end
 
     trait :absence_with_multiple_progress_reports do
-      status { :absent }
+      present { false }
       session { nil }
       absence_reason { '職場のイベントに参加するため。' }
       progress_report { "#8000 チームメンバーにレビュー依頼を行いました。\r\n#8102 問題が発生している箇所の調査を行いました(関連Issue#8100)。\r\n#8080 依頼されたレビュー対応を行いました。" }

--- a/spec/forms/attendance_form_spec.rb
+++ b/spec/forms/attendance_form_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AttendanceForm, type: :model do
+  describe 'when create attendance' do
+    let(:minute) { FactoryBot.create(:minute) }
+    let(:member) { FactoryBot.create(:member, course: minute.course) }
+
+    it 'can create an attendance to afternoon session' do
+      attributes_when_attend_afternoon_session = { status: 'afternoon' }
+      expect do
+        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_afternoon_session).save
+      end.to change(Attendance, :count).by(1)
+    end
+
+    it 'can create an attendance to night session' do
+      attributes_when_attend_night_session = { status: 'night' }
+      expect do
+        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_night_session).save
+      end.to change(Attendance, :count).by(1)
+    end
+
+    it 'can create an attendance as absence' do
+      attributes_when_absent_from_meeting = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+      expect do
+        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_absent_from_meeting).save
+      end.to change(Attendance, :count).by(1)
+    end
+
+    it 'cannot create an attendance with invalid attributes' do
+      attributes_without_status = { status: nil }
+      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_status)
+      expect do
+        attendance_form.save
+      end.not_to change(Attendance, :count)
+
+      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+      expect do
+        attendance_form.save
+      end.not_to change(Attendance, :count)
+    end
+  end
+
+  describe 'when update attendance' do
+    let(:minute) { FactoryBot.create(:minute) }
+    let(:member) { FactoryBot.create(:member, course: minute.course) }
+    let(:attendance) { FactoryBot.create(:attendance, minute:, member:) }
+
+    it 'can update an attendance with valid attributes' do
+      expect(attendance.present).to be true
+      expect(attendance.session).to eq 'afternoon'
+      expect(attendance.absence_reason).to be_nil
+      expect(attendance.progress_report).to be_nil
+
+      valid_attributes = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+      attendance_form = described_class.new(model: attendance, minute:, member:, **valid_attributes)
+      attendance_form.save
+      expect(attendance.present).to be false
+      expect(attendance.session).to be_nil
+      expect(attendance.absence_reason).to eq '職場のイベントに参加するため'
+      expect(attendance.progress_report).to eq '#1200 PRを作成しレビュー依頼中です。'
+    end
+
+    it 'cannot update an attendance with invalid attributes' do
+      expect(attendance.present).to be true
+
+      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+      attendance_form = described_class.new(model: attendance, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+      attendance_form.save
+      expect(attendance.present).to be true
+    end
+  end
+end

--- a/spec/forms/attendance_form_spec.rb
+++ b/spec/forms/attendance_form_spec.rb
@@ -3,73 +3,91 @@
 require 'rails_helper'
 
 RSpec.describe AttendanceForm, type: :model do
-  describe 'when create attendance' do
+  describe '#form_with_options' do
     let(:minute) { FactoryBot.create(:minute) }
     let(:member) { FactoryBot.create(:member, course: minute.course) }
 
-    it 'can create an attendance to afternoon session' do
-      attributes_when_attend_afternoon_session = { status: 'afternoon' }
-      expect do
-        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_afternoon_session).save
-      end.to change(Attendance, :count).by(1)
+    it 'returns path and method for create an attendance when attendance is not saved' do
+      attendance_form = described_class.new(model: Attendance.new, minute:, member:, status: 'night')
+      expect(attendance_form.form_with_options).to eq({ url: "/minutes/#{minute.id}/attendances", method: :post })
     end
 
-    it 'can create an attendance to night session' do
-      attributes_when_attend_night_session = { status: 'night' }
-      expect do
-        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_night_session).save
-      end.to change(Attendance, :count).by(1)
-    end
-
-    it 'can create an attendance as absence' do
-      attributes_when_absent_from_meeting = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
-      expect do
-        described_class.new(model: Attendance.new, minute:, member:, **attributes_when_absent_from_meeting).save
-      end.to change(Attendance, :count).by(1)
-    end
-
-    it 'cannot create an attendance with invalid attributes' do
-      attributes_without_status = { status: nil }
-      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_status)
-      expect do
-        attendance_form.save
-      end.not_to change(Attendance, :count)
-
-      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
-      attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_absence_reason_and_progress_report)
-      expect do
-        attendance_form.save
-      end.not_to change(Attendance, :count)
+    it 'returns path and method for update an attendance when attendance is already saved' do
+      attendance = FactoryBot.create(:attendance, minute:, member:)
+      attendance_form = described_class.new(model: attendance, minute:, member:, status: 'night')
+      expect(attendance_form.form_with_options).to eq({ url: "/attendances/#{attendance.id}", method: :patch })
     end
   end
 
-  describe 'when update attendance' do
-    let(:minute) { FactoryBot.create(:minute) }
-    let(:member) { FactoryBot.create(:member, course: minute.course) }
-    let(:attendance) { FactoryBot.create(:attendance, minute:, member:) }
+  describe '#save' do
+    describe 'when create attendance' do
+      let(:minute) { FactoryBot.create(:minute) }
+      let(:member) { FactoryBot.create(:member, course: minute.course) }
 
-    it 'can update an attendance with valid attributes' do
-      expect(attendance.present).to be true
-      expect(attendance.session).to eq 'afternoon'
-      expect(attendance.absence_reason).to be_nil
-      expect(attendance.progress_report).to be_nil
+      it 'can create an attendance to afternoon session' do
+        attributes_when_attend_afternoon_session = { status: 'afternoon' }
+        expect do
+          described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_afternoon_session).save
+        end.to change(Attendance, :count).by(1)
+      end
 
-      valid_attributes = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
-      attendance_form = described_class.new(model: attendance, minute:, member:, **valid_attributes)
-      attendance_form.save
-      expect(attendance.present).to be false
-      expect(attendance.session).to be_nil
-      expect(attendance.absence_reason).to eq '職場のイベントに参加するため'
-      expect(attendance.progress_report).to eq '#1200 PRを作成しレビュー依頼中です。'
+      it 'can create an attendance to night session' do
+        attributes_when_attend_night_session = { status: 'night' }
+        expect do
+          described_class.new(model: Attendance.new, minute:, member:, **attributes_when_attend_night_session).save
+        end.to change(Attendance, :count).by(1)
+      end
+
+      it 'can create an attendance as absence' do
+        attributes_when_absent_from_meeting = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+        expect do
+          described_class.new(model: Attendance.new, minute:, member:, **attributes_when_absent_from_meeting).save
+        end.to change(Attendance, :count).by(1)
+      end
+
+      it 'cannot create an attendance with invalid attributes' do
+        attributes_without_status = { status: nil }
+        attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_status)
+        expect do
+          attendance_form.save
+        end.not_to change(Attendance, :count)
+
+        attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+        attendance_form = described_class.new(model: Attendance.new, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+        expect do
+          attendance_form.save
+        end.not_to change(Attendance, :count)
+      end
     end
 
-    it 'cannot update an attendance with invalid attributes' do
-      expect(attendance.present).to be true
+    describe 'when update attendance' do
+      let(:minute) { FactoryBot.create(:minute) }
+      let(:member) { FactoryBot.create(:member, course: minute.course) }
+      let(:attendance) { FactoryBot.create(:attendance, minute:, member:) }
 
-      attributes_without_absence_reason_and_progress_report = { status: 'absent' }
-      attendance_form = described_class.new(model: attendance, minute:, member:, **attributes_without_absence_reason_and_progress_report)
-      attendance_form.save
-      expect(attendance.present).to be true
+      it 'can update an attendance with valid attributes' do
+        expect(attendance.present).to be true
+        expect(attendance.session).to eq 'afternoon'
+        expect(attendance.absence_reason).to be_nil
+        expect(attendance.progress_report).to be_nil
+
+        valid_attributes = { status: 'absent', absence_reason: '職場のイベントに参加するため', progress_report: '#1200 PRを作成しレビュー依頼中です。' }
+        attendance_form = described_class.new(model: attendance, minute:, member:, **valid_attributes)
+        attendance_form.save
+        expect(attendance.present).to be false
+        expect(attendance.session).to be_nil
+        expect(attendance.absence_reason).to eq '職場のイベントに参加するため'
+        expect(attendance.progress_report).to eq '#1200 PRを作成しレビュー依頼中です。'
+      end
+
+      it 'cannot update an attendance with invalid attributes' do
+        expect(attendance.present).to be true
+
+        attributes_without_absence_reason_and_progress_report = { status: 'absent' }
+        attendance_form = described_class.new(model: attendance, minute:, member:, **attributes_without_absence_reason_and_progress_report)
+        attendance_form.save
+        expect(attendance.present).to be true
+      end
     end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -35,34 +35,34 @@ RSpec.describe Member, type: :model do
 
     it 'returns all attendances since the member sign up' do
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 9, 18), course: rails_course)
-      expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil },
-                              { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', time: nil, absence_reason: '体調不良のため。' },
-                              { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
+      expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil },
+                              { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', session: nil, absence_reason: '体調不良のため。' },
+                              { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [expected_attendances] })
     end
 
     it 'returns attendances until the hibernation started if the member is hibernated' do
       FactoryBot.create(:hibernation, member:, created_at: Time.zone.local(2024, 11, 1))
 
-      attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil },
-                                       { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', time: nil, absence_reason: '体調不良のため。' }]
+      attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil },
+                                       { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', session: nil, absence_reason: '体調不良のため。' }]
       expect(member.all_attendances).to eq({ 2024 => [attendances_until_hibernation] })
     end
 
     it 'does not include attendances during hibernated period' do
       FactoryBot.create(:hibernation, finished_at: Time.zone.local(2024, 10, 31), member:, created_at: Time.zone.local(2024, 10, 3))
 
-      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil }]
-      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
+      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil }]
+      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [attendances_before_hibernation, attendances_after_hibernation] })
     end
 
     it 'divides attendances by year' do
       latest_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
-      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', time: 'day', absence_reason: nil },
-                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', time: nil, absence_reason: '体調不良のため。' },
-                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
-      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, time: nil, absence_reason: nil }]
+      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil },
+                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', session: nil, absence_reason: '体調不良のため。' },
+                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
+      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [first_year_attendances], 2025 => [second_year_attendances] })
     end
 
@@ -98,9 +98,9 @@ RSpec.describe Member, type: :model do
     end
 
     it 'returns recent attendances up to twelve' do
-      first_attendance = { minute_id: rails_course.minutes.first.id, date: Date.new(2025, 12, 18), attendance_id: nil, status: nil, time: nil, absence_reason: nil }
-      second_attendance = { minute_id: rails_course.minutes.second.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, time: nil, absence_reason: nil }
-      last_attendance = { minute_id: rails_course.minutes.last.id, date: Date.new(2025, 6, 18), attendance_id: nil, status: nil, time: nil, absence_reason: nil }
+      first_attendance = { minute_id: rails_course.minutes.first.id, date: Date.new(2025, 12, 18), attendance_id: nil, status: nil, session: nil, absence_reason: nil }
+      second_attendance = { minute_id: rails_course.minutes.second.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, session: nil, absence_reason: nil }
+      last_attendance = { minute_id: rails_course.minutes.last.id, date: Date.new(2025, 6, 18), attendance_id: nil, status: nil, session: nil, absence_reason: nil }
 
       expect(member.recent_attendances.length).to eq 12
       expect(member.recent_attendances).not_to include(first_attendance)

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -35,34 +35,34 @@ RSpec.describe Member, type: :model do
 
     it 'returns all attendances since the member sign up' do
       FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 9, 18), course: rails_course)
-      expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil },
-                              { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', session: nil, absence_reason: '体調不良のため。' },
-                              { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
+      expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil },
+                              { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, present: false, session: nil, absence_reason: '体調不良のため。' },
+                              { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [expected_attendances] })
     end
 
     it 'returns attendances until the hibernation started if the member is hibernated' do
       FactoryBot.create(:hibernation, member:, created_at: Time.zone.local(2024, 11, 1))
 
-      attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil },
-                                       { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', session: nil, absence_reason: '体調不良のため。' }]
+      attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil },
+                                       { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, present: false, session: nil, absence_reason: '体調不良のため。' }]
       expect(member.all_attendances).to eq({ 2024 => [attendances_until_hibernation] })
     end
 
     it 'does not include attendances during hibernated period' do
       FactoryBot.create(:hibernation, finished_at: Time.zone.local(2024, 10, 31), member:, created_at: Time.zone.local(2024, 10, 3))
 
-      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil }]
-      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
+      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil }]
+      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [attendances_before_hibernation, attendances_after_hibernation] })
     end
 
     it 'divides attendances by year' do
       latest_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
-      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, status: 'present', session: 'afternoon', absence_reason: nil },
-                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, status: 'absent', session: nil, absence_reason: '体調不良のため。' },
-                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
-      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, session: nil, absence_reason: nil }]
+      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil },
+                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, present: false, session: nil, absence_reason: '体調不良のため。' },
+                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
+      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
       expect(member.all_attendances).to eq({ 2024 => [first_year_attendances], 2025 => [second_year_attendances] })
     end
 
@@ -98,9 +98,9 @@ RSpec.describe Member, type: :model do
     end
 
     it 'returns recent attendances up to twelve' do
-      first_attendance = { minute_id: rails_course.minutes.first.id, date: Date.new(2025, 12, 18), attendance_id: nil, status: nil, session: nil, absence_reason: nil }
-      second_attendance = { minute_id: rails_course.minutes.second.id, date: Date.new(2025, 1, 1), attendance_id: nil, status: nil, session: nil, absence_reason: nil }
-      last_attendance = { minute_id: rails_course.minutes.last.id, date: Date.new(2025, 6, 18), attendance_id: nil, status: nil, session: nil, absence_reason: nil }
+      first_attendance = { minute_id: rails_course.minutes.first.id, date: Date.new(2025, 12, 18), attendance_id: nil, present: nil, session: nil, absence_reason: nil }
+      second_attendance = { minute_id: rails_course.minutes.second.id, date: Date.new(2025, 1, 1), attendance_id: nil, present: nil, session: nil, absence_reason: nil }
+      last_attendance = { minute_id: rails_course.minutes.last.id, date: Date.new(2025, 6, 18), attendance_id: nil, present: nil, session: nil, absence_reason: nil }
 
       expect(member.recent_attendances.length).to eq 12
       expect(member.recent_attendances).not_to include(first_attendance)

--- a/spec/requests/minutes/attendances_apis_spec.rb
+++ b/spec/requests/minutes/attendances_apis_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Minutes::Attendances API', type: :request do
   it 'return attendees and absentees' do
     unexcused_absentee = FactoryBot.create(:member, :unexcused_absent_member, course: rails_course)
     expected_data = {
-      day_attendees: [{ attendance_id: alice.attendances.first.id, member_id: alice.id, name: 'alice' }],
+      afternoon_attendees: [{ attendance_id: alice.attendances.first.id, member_id: alice.id, name: 'alice' }],
       night_attendees: [{ attendance_id: bob.attendances.first.id, member_id: bob.id, name: 'bob' }],
       absentees: [{ attendance_id: absent_member.attendances.first.id,
                     member_id: absent_member.id,

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can create day attendance', :js do
+    scenario 'member can create afternoon attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can create afternoon attendance', :js do
+    scenario 'member can create afternoon attendance', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
@@ -49,7 +49,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can create night attendance', :js do
+    scenario 'member can create night attendance', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
@@ -69,7 +69,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can create absence', :js do
+    scenario 'member can create absence', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
@@ -127,7 +127,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance twice' do
+    scenario 'member cannot create attendance twice', { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
         choose '出席'
@@ -155,7 +155,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance with invalid input', :js do
+    scenario 'member cannot create attendance with invalid input', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
 
@@ -193,7 +193,7 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can edit attendance to absence', :js do
+    scenario 'member can edit attendance to absence', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
       attendance = FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
@@ -220,7 +220,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can edit absence to attendance', :js do
+    scenario 'member can edit absence to attendance', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
       attendance = FactoryBot.create(:attendance, :absence, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
@@ -245,7 +245,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member treated as unexcused absentee can create attendance', :js do
+    scenario 'member treated as unexcused absentee can create attendance', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         within('#unexcused_absentees') do
@@ -270,7 +270,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot update attendance with invalid input' do
+    scenario 'member cannot update attendance with invalid input', { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
       FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'Attendances', type: :system do
         visit new_minute_attendance_path(minute)
 
         click_button '出席を登録'
-        expect(page).to have_content '出席状況を入力してください'
+        expect(page).to have_content '出欠を選択してください'
 
         choose '欠席'
         fill_in '欠席理由', with: '仕事の都合。'

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -28,15 +28,14 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can create afternoon attendance', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can create afternoon attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
         click_link '出席予定を登録する'
 
         expect(current_path).to eq new_minute_attendance_path(minute)
-        choose '出席'
-        choose '昼の部'
+        choose '昼の部に出席'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -49,14 +48,13 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can create night attendance', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can create night attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
         click_link '出席予定を登録する'
 
-        choose '出席'
-        choose '夜の部'
+        choose '夜の部に出席'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -69,7 +67,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can create absence', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can create absence', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         expect(page).to have_link '出席予定を登録する'
@@ -127,11 +125,10 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance twice', { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member cannot create attendance twice' do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
-        choose '出席'
-        choose '昼の部'
+        choose '昼の部に出席'
         click_button '出席を登録'
 
         visit new_minute_attendance_path(minute)
@@ -155,7 +152,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot create attendance with invalid input', :js, { skip: '出席登録ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member cannot create attendance with invalid input', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
 
@@ -163,21 +160,7 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '出欠を選択してください'
 
         choose '欠席'
-        fill_in '欠席理由', with: '仕事の都合。'
-        fill_in '進捗報告', with: '今週の進捗は特にありません。'
-        choose '出席'
         click_button '出席を登録'
-        expect(page).to have_content '出席時間帯を入力してください'
-        expect(page).to have_content '欠席理由は入力しないでください'
-        expect(page).to have_content '進捗報告は入力しないでください'
-
-        choose '出席'
-        choose '昼の部'
-        choose '欠席'
-        fill_in '欠席理由', with: ''
-        fill_in '進捗報告', with: ''
-        click_button '出席を登録'
-        expect(page).to have_content '出席時間帯は入力しないでください'
         expect(page).to have_content '欠席理由を入力してください'
         expect(page).to have_content '進捗報告を入力してください'
       end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Attendances', type: :system do
         expect(page).to have_content '出席予定を登録しました'
         expect(page).not_to have_link '出席予定を登録する'
         expect(page).to have_link '出席予定を変更する'
-        within('#day_attendees') do
+        within('#afternoon_attendees') do
           expect(page).to have_selector 'li', text: member.name
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe 'Attendances', type: :system do
       expect(hibernated_member.hibernated?).to be true
 
       visit edit_minute_path(minute)
-      within('#day_attendees', visible: false) do
+      within('#afternoon_attendees', visible: false) do
         expect(page).not_to have_selector 'li', text: hibernated_member.name
       end
       within('#night_attendees', visible: false) do
@@ -209,7 +209,7 @@ RSpec.describe 'Attendances', type: :system do
 
         expect(current_path).to eq edit_minute_path(minute)
         expect(page).to have_content '出席予定を更新しました'
-        within('#day_attendees', visible: false) do
+        within('#afternoon_attendees', visible: false) do
           expect(page).not_to have_selector 'li', text: member.name
         end
         within('#absentees') do
@@ -264,7 +264,7 @@ RSpec.describe 'Attendances', type: :system do
         within('#unexcused_absentees', visible: false) do
           expect(page).not_to have_selector 'li', text: member.name
         end
-        within('#day_attendees') do
+        within('#afternoon_attendees') do
           expect(page).to have_selector 'li', text: member.name
         end
       end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -176,15 +176,14 @@ RSpec.describe 'Attendances', type: :system do
       login_as member
     end
 
-    scenario 'member can edit attendance to absence', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can change from present to absent', :js do
       attendance = FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         click_link '出席予定を変更する'
         expect(current_path).to eq edit_attendance_path(attendance)
 
-        choose '昼の部'
-        choose '昼の部' # チェックがついている'昼の部'を2度クリックして、チェックを外す
+        expect(page).to have_checked_field '昼の部に出席'
         choose '欠席'
         fill_in '欠席理由', with: '体調不良のため。'
         fill_in '進捗報告', with: '#1000 チームメンバーのレビュー待ちの状態です。'
@@ -203,18 +202,15 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member can edit absence to attendance', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member can change from absent to present', :js do
       attendance = FactoryBot.create(:attendance, :absence, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         click_link '出席予定を変更する'
         expect(current_path).to eq edit_attendance_path(attendance)
 
-        choose '欠席'
-        fill_in '欠席理由', with: ''
-        fill_in '進捗報告', with: ''
-        choose '出席'
-        choose '夜の部'
+        expect(page).to have_checked_field '欠席'
+        choose '夜の部に出席'
         click_button '出席を更新'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -228,7 +224,7 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member treated as unexcused absentee can create attendance', :js, { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'unexcused absentee can create attendance', :js do
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         within('#unexcused_absentees') do
@@ -238,8 +234,7 @@ RSpec.describe 'Attendances', type: :system do
         click_link '出席予定を登録する'
         expect(current_path).to eq new_minute_attendance_path(minute)
 
-        choose '出席'
-        choose '昼の部'
+        choose '昼の部に出席'
         click_button '出席を登録'
 
         expect(current_path).to eq edit_minute_path(minute)
@@ -253,26 +248,14 @@ RSpec.describe 'Attendances', type: :system do
       end
     end
 
-    scenario 'member cannot update attendance with invalid input', { skip: '出席編集ページの修正が完了するまで一時的にスキップする' } do
+    scenario 'member cannot update attendance with invalid input' do
       FactoryBot.create(:attendance, member:, minute:)
       travel_to minute.meeting_date.days_ago(1) do
         visit edit_minute_path(minute)
         click_link '出席予定を変更する'
 
         choose '欠席'
-        fill_in '欠席理由', with: '体調不良のため。'
-        fill_in '進捗報告', with: '今週の進捗はありません。'
-        choose '出席'
-        choose '夜の部'
         click_button '出席を更新'
-        expect(page).to have_content '欠席理由は入力しないでください'
-        expect(page).to have_content '進捗報告は入力しないでください'
-
-        choose '欠席'
-        fill_in '欠席理由', with: ''
-        fill_in '進捗報告', with: ''
-        click_button '出席を更新'
-        expect(page).to have_content '出席時間帯は入力しないでください'
         expect(page).to have_content '欠席理由を入力してください'
         expect(page).to have_content '進捗報告を入力してください'
       end

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe 'Attendances', type: :system do
       travel_to minute.meeting_date.days_ago(1) do
         visit new_minute_attendance_path(minute)
 
-        click_button '出席を登録'
-        expect(page).to have_content '出欠を選択してください'
+        # 出欠を選択していない場合、送信ボタンはdisabledとなる
+        expect(page).to have_button '出席を登録', disabled: true
 
         choose '欠席'
         click_button '出席を登録'

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Members', type: :system do
         expect(page).to have_selector 'dt[data-attendance-on="2025-02-19"]', text: '02/19'
         expect(page).to have_selector 'dd[data-attendance-on="2025-02-19"]', text: '---'
 
-        attendance = Attendance.find_by(status: :absent)
+        attendance = Attendance.find_by(present: false)
         expect(page).not_to have_selector "div#absence_reason_for_attendance_#{attendance.id}", text: '体調不良のため。'
         within('dd[data-attendance-on="2025-02-05"]') do
           find("span[data-tooltip-target='absence_reason_for_attendance_#{attendance.id}']").hover


### PR DESCRIPTION
## Issue
- #271 

## 概要
以下の対応を行った。

- #287 
  - 出席モデルの属性を変更した
    - `status` → `present`(データ型もintegerからbooleanに変更)
    - `time` → `session`  
- #288 
  - 出席登録/編集ページの選択肢を、`昼の部に出席`、`夜の部に出席`、`欠席`の3択にした 
- #289 
  - 出席登で、出欠の選択肢を選択していない場合は送信ボタンをクリックできないようにした 
- #290
  - #288 で追加したフォームオブジェクトのエラーメッセージがおかしかったため修正した 



