### PR TITLE
ページ下部に余白を追加した

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
 
   <body class="flex flex-col h-screen">
     <%= render 'layouts/header' %>
-    <main>
+    <main class="mb-16">
       <%= render 'layouts/flash' %>
       <%= yield %>
     </main>


### PR DESCRIPTION
## Issue
- #271 

## 概要
一部のページでディスプレイの高さが狭いとページの表示が詰まってしまうため、ページ下部に余白を追加した。

## Screenshot
変更前

![BCEF474F-C85F-432C-87B3-E2EEB8F510C4](https://github.com/user-attachments/assets/85579d20-9b1b-406b-95f3-9e78468e39df)


変更後

![CF3C3AD5-BF6E-4BAF-8F70-5BA3362041C8](https://github.com/user-attachments/assets/5920d8c4-6fbb-4559-a03e-1bf14bf77218)
