### PR TITLE
トップページとヘッダー・フッターのデザインを修正

### DIFF
--- a/app/views/home/_developer_login_button.html.erb
+++ b/app/views/home/_developer_login_button.html.erb
@@ -1,7 +1,10 @@
-<div class="my-8 text-center md:flex md:justify-center">
+<div class="my-8 text-center w-fit mx-auto md:flex md:gap-x-8">
   <% Course.all.each do |course| %>
     <%= form_tag("/auth/developer?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-      <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mb-4 mx-10 w-[300px]"><%= course.name %>でログイン(開発環境用)</button>
+      <button type='submit' class="text-blue-600  border border-blue-600 hover:bg-blue-100 font-medium rounded-lg text-sm px-6 py-4 mb-4 w-72">
+        <%= course.name %>
+        で<br>ログイン(開発環境用)
+      </button>
     <% end %>
   <% end %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,11 +23,12 @@
     </div>
   </div>
 
-  <div class="text-center md:flex md:justify-center">
+  <div class="text-center w-fit mx-auto md:flex md:gap-x-8">
     <% Course.all.order(id: :asc).each do |course| %>
       <%= form_tag("/auth/github?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
-        <button type='submit' class="text-white bg-blue-600 hover:bg-blue-700 font-medium rounded-lg text-sm px-6 py-4 mb-4 w-[300px] md:mx-10">
-          <%= "#{course.name}で登録" %>
+        <button type='submit' class="text-white bg-blue-600 hover:bg-blue-700 font-bold rounded-lg px-6 py-4 mb-4 w-72">
+          <%= course.name.delete_suffix('コース') %>
+          <br>コースで登録
         </button>
       <% end %>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,24 +2,24 @@
 <h1 class="font-bold text-2xl text-blue-700 text-center mt-16 mb-12 md:text-4xl">FBCチーム開発プラクティスの<br>議事録の作成と出席管理ツール</h1>
 
 <div class="page_body">
-  <div class="flex justify-around mb-12">
-    <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
+  <div class="flex gap-x-8 w-96 md:w-fit mx-auto mb-12">
+    <div class="py-4 px-0.5 border-dashed border-2 border-blue-200 rounded-md w-28 flex flex-col items-center md:w-64">
       <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 5V4a1 1 0 0 0-1-1H8.914a1 1 0 0 0-.707.293L4.293 7.207A1 1 0 0 0 4 7.914V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-5M9 3v4a1 1 0 0 1-1 1H4m11.383.772 2.745 2.746m1.215-3.906a2.089 2.089 0 0 1 0 2.953l-6.65 6.646L9 17.95l.739-3.692 6.646-6.646a2.087 2.087 0 0 1 2.958 0Z" />
       </svg>
-      <p class="text-xs text-center mt-2 md:text-base">議事録を自動で作成</p>
+      <p class="text-xs text-center mt-2 text-blue-700 md:text-base">議事録を<br>自動で作成</p>
     </div>
-    <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
+    <div class="py-4 px-0.5 border-dashed border-2 border-blue-200 rounded-md w-28 flex flex-col items-center md:w-64">
       <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 10V4a1 1 0 0 0-1-1H9.914a1 1 0 0 0-.707.293L5.293 7.207A1 1 0 0 0 5 7.914V20a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2M10 3v4a1 1 0 0 1-1 1H5m5 6h9m0 0-2-2m2 2-2 2" />
       </svg>
-      <p class="text-xs text-center mt-2 md:text-base">議事録の内容からMarkdownを<br>作成し、GitHub Wikiに出力</p>
+      <p class="text-xs text-center mt-2 text-blue-700 md:text-base">議事録を<br>GitHub Wikiに出力</p>
     </div>
-    <div class="py-4 px-0.5 border border-gray-400 rounded-md w-28 flex flex-col items-center md:w-64">
+    <div class="py-4 px-0.5 border-dashed border-2 border-blue-200 rounded-md w-28 flex flex-col items-center md:w-64">
       <svg class="w-10 h-10 md:w-20 md:h-20 text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h16m-8-3V4M7 7V4m10 3V4M5 20h14a1 1 0 0 0 1-1V7a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1Zm3-7h.01v.01H8V13Zm4 0h.01v.01H12V13Zm4 0h.01v.01H16V13Zm-8 4h.01v.01H8V17Zm4 0h.01v.01H12V17Zm4 0h.01v.01H16V17Z" />
       </svg>
-      <p class="text-xs text-center mt-2 md:text-base">チームメンバーのミーティング<br>出席状況を一括表示</p>
+      <p class="text-xs text-center mt-2 text-blue-700 md:text-base">チームメンバーの<br>出席状況を一括表示</p>
     </div>
   </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -23,7 +23,7 @@
     </div>
   </div>
 
-  <div class="text-center w-fit mx-auto md:flex md:gap-x-8">
+  <div class="text-center w-fit mx-auto mb-4 md:flex md:gap-x-8">
     <% Course.all.order(id: :asc).each do |course| %>
       <%= form_tag("/auth/github?course_id=#{course.id}", method: 'post', data: {turbo: false}) do %>
         <button type='submit' class="text-white bg-blue-600 hover:bg-blue-700 font-bold rounded-lg px-6 py-4 mb-4 w-72">
@@ -33,11 +33,11 @@
       <% end %>
     <% end %>
   </div>
-  <p class="text-red-700 text-sm text-center">
-    <a href="https://github.com/fjordllc/bootcamp" class="text-red-700">bootcampリポジトリ</a>
+  <p class="text-red-500 text-sm text-center">
+    <a href="https://github.com/fjordllc/bootcamp" class="text-red-500 underline">bootcampリポジトリ</a>
     または
-    <a href="https://github.com/fjordllc/agent" class="text-red-700">agentリポジトリ</a>
-    のコラボレーターの方だけメンバー登録をお願いします。
+    <a href="https://github.com/fjordllc/agent" class="text-red-500 underline">agentリポジトリ</a>
+    の<br>コラボレーターの方だけメンバー登録をお願いします。
   </p>
 
   <% if Rails.env.development? %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,5 @@
 <% set_meta_tags(build_meta_tags(description: 'FjordBootCampで行われているチーム開発ミーティングを、議事録の自動生成と出席管理でより便利にするサービスです。')) %>
-<h1 class="font-bold text-xl text-center my-12 md:text-2xl">フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを<br>議事録の自動作成と出席管理で<br class="md:hidden">より効率的に</h1>
+<h1 class="font-bold text-2xl text-blue-700 text-center mt-16 mb-12 md:text-4xl">FBCチーム開発プラクティスの<br>議事録の作成と出席管理ツール</h1>
 
 <div class="page_body">
   <div class="flex justify-around mb-12">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,13 +1,13 @@
-<footer class="border-t-2 border-gray-200 mt-auto h-16">
-  <div class="w-full max-w-screen-lg mx-auto p-2">
-    <ul class="flex items-center justify-center text-sm font-medium !list-none !p-0">
-      <li class="mr-4">
+<footer class="border-t-2 border-blue-200 mt-auto">
+  <div class="w-full max-w-screen-lg mx-auto my-4 p-2">
+    <ul class="flex items-center gap-x-10 w-fit mx-auto mb-4 text-sm font-medium !list-none !p-0">
+      <li>
         <%= link_to '利用規約', terms_of_service_path %>
       </li>
-      <li class="mr-4">
+      <li>
         <%= link_to 'プライバシーポリシー', pp_path %>
       </li>
-      <li class="mr-4">
+      <li>
         <a href="https://github.com/Kassy0220/fjord-minutes" target="_blank" rel="nofollow">
           <svg class="w-6 h-6 text-gray-800 hover:text-blue-700" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
             <path fill-rule="evenodd" d="M12.006 2a9.847 9.847 0 0 0-6.484 2.44 10.32 10.32 0 0 0-3.393 6.17 10.48 10.48 0 0 0 1.317 6.955 10.045 10.045 0 0 0 5.4 4.418c.504.095.683-.223.683-.494 0-.245-.01-1.052-.014-1.908-2.78.62-3.366-1.21-3.366-1.21a2.711 2.711 0 0 0-1.11-1.5c-.907-.637.07-.621.07-.621.317.044.62.163.885.346.266.183.487.426.647.71.135.253.318.476.538.655a2.079 2.079 0 0 0 2.37.196c.045-.52.27-1.006.635-1.37-2.219-.259-4.554-1.138-4.554-5.07a4.022 4.022 0 0 1 1.031-2.75 3.77 3.77 0 0 1 .096-2.713s.839-.275 2.749 1.05a9.26 9.26 0 0 1 5.004 0c1.906-1.325 2.74-1.05 2.74-1.05.37.858.406 1.828.101 2.713a4.017 4.017 0 0 1 1.029 2.75c0 3.939-2.339 4.805-4.564 5.058a2.471 2.471 0 0 1 .679 1.897c0 1.372-.012 2.477-.012 2.814 0 .272.18.592.687.492a10.05 10.05 0 0 0 5.388-4.421 10.473 10.473 0 0 0 1.313-6.948 10.32 10.32 0 0 0-3.39-6.165A9.847 9.847 0 0 0 12.007 2Z" clip-rule="evenodd" />

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<nav id="header" class="border-b-2 border-gray-200">
+<nav id="header" class="border-b-2 border-blue-200">
   <div class="max-w-screen-lg flex flex-wrap items-center justify-between mx-auto py-2">
     <a href="/" class="flex items-center">
       <%= image_tag('logo.png', alt: 'Fjord Minutesのロゴ画像', class: "h-8 md:h-12") %>

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -7,7 +7,7 @@ module LoginSupport
                                                 email: member.email,
                                                 image: member.avatar_url } })
     visit root_path
-    click_button "#{member.course.name}で登録"
+    find('button', text: "#{member.course.name.delete_suffix('コース')}\nコースで登録").click
   end
 
   def login_as_admin(admin)
@@ -18,7 +18,7 @@ module LoginSupport
                                                 email: admin.email,
                                                 image: admin.avatar_url } })
     visit root_path
-    click_button 'Railsエンジニアコースで登録'
+    find('button', text: "Railsエンジニア\nコースで登録").click
   end
 end
 

--- a/spec/system/hibernations_spec.rb
+++ b/spec/system/hibernations_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Hibernations', type: :system do
     expect(page).to have_content 'ログアウトしました'
     expect(member.reload.hibernated?).to be true
 
-    click_button 'Railsエンジニアコースで登録'
+    find('button', text: "Railsエンジニア\nコースで登録").click
     expect(page).to have_content 'チーム開発に復帰しました。'
     expect(member.reload.hibernated?).to be false
   end
@@ -34,6 +34,6 @@ RSpec.describe 'Hibernations', type: :system do
     expect(current_path).to eq root_path
     expect(page).to have_content 'チームメンバーから外れているため、再度ログインをお願いします。'
     expect(page).not_to have_content 'aliceさんの出席一覧(Railsエンジニアコース)'
-    expect(page).to have_button 'Railsエンジニアコースで登録'
+    expect(page).to have_selector 'button', text: "Railsエンジニア\nコースで登録"
   end
 end

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Homes', type: :system do
 
     visit root_path
     expect(page).to have_selector 'h1', text: "FBCチーム開発プラクティスの\n議事録の作成と出席管理ツール"
-    expect(page).to have_button 'Railsエンジニアコースで登録'
-    expect(page).to have_button 'フロントエンドエンジニアコースで登録'
+    expect(page).to have_selector 'button', text: "Railsエンジニア\nコースで登録"
+    expect(page).to have_selector 'button', text: "フロントエンドエンジニア\nコースで登録"
   end
 
   context 'with header' do

--- a/spec/system/homes_spec.rb
+++ b/spec/system/homes_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Homes', type: :system do
     FactoryBot.create(:front_end_course)
 
     visit root_path
-    expect(page).to have_selector 'h1', text: "フィヨルドブートキャンプのチーム開発プラクティスで行われるミーティングを\n議事録の自動作成と出席管理で\nより効率的に"
+    expect(page).to have_selector 'h1', text: "FBCチーム開発プラクティスの\n議事録の作成と出席管理ツール"
     expect(page).to have_button 'Railsエンジニアコースで登録'
     expect(page).to have_button 'フロントエンドエンジニアコースで登録'
   end

--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'user can log in as member of the Rails course' do
       visit root_path
-      click_button 'Railsエンジニアコースで登録'
+      find('button', text: "Railsエンジニア\nコースで登録").click
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: 'aliceさん'
@@ -27,7 +27,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'user can log in as member of the front end course' do
       visit root_path
-      click_button 'フロントエンドエンジニアコースで登録'
+      find('button', text: "フロントエンドエンジニア\nコースで登録").click
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: 'aliceさん'
@@ -48,7 +48,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'user can log in as admin' do
       visit root_path
-      click_button 'Railsエンジニアコースで登録'
+      find('button', text: "Railsエンジニア\nコースで登録").click
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: '管理ページ'
@@ -63,7 +63,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
     scenario 'redirect root page when login fails' do
       visit root_path
-      click_button 'Railsエンジニアコースで登録'
+      find('button', text: "Railsエンジニア\nコースで登録").click
 
       expect(current_path).to eq root_path
       expect(page).to have_content 'GitHub アカウントによる認証に失敗しました。'


### PR DESCRIPTION
## Issue
- #271 

## 概要
トップページ、ヘッダー、フッターに関してデザインレビューで指摘された点を修正した

## Screenshot
### ヘッダー
![5E33C480-B63D-422B-941C-EB8DDE474AD0](https://github.com/user-attachments/assets/9bb4bbeb-0db3-402a-b160-8bde804aa695)


### トップページ
- キャッチコピーの文言を修正し、文字を青色に変更
- アプリの説明を簡潔にし、枠線は点線に変更
- ログインボタンのテキストは改行し、幅はアプリの説明と揃えた
- 注意の文言内のリンクには下線を追加

![33491EEF-964A-4BAA-BBE8-795A41C23692](https://github.com/user-attachments/assets/d6f89453-ad8a-477b-8322-c986b4a22626)


### フッター
- 四角の枠は幅を広くした

![E31E1528-D0DE-43D3-B7D9-0F1A82033F4F](https://github.com/user-attachments/assets/f3a140a4-9148-4d75-b0e3-ac593cdf9416)



