### PR TITLE
メンバー一覧ページのデザインを修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -34,6 +34,12 @@
     .input_type_text {
         @apply bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block max-w-full field-sizing-content p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500;
     }
+    .active_course_tab_item {
+        @apply translate-y-[1px] inline-block px-2 py-4 w-52 md:w-[280px] rounded-t-lg text-blue-700 font-bold bg-white border border-l-gray-300 border-t-gray-300 border-r-gray-300 border-b-white hover:no-underline text-xs md:px-4 md:text-base;
+    }
+    .inactive_course_tab_item {
+        @apply translate-y-[1px] inline-block px-2 py-4 w-52 md:w-[280px] rounded-t-lg text-gray-500 font-bold bg-gray-300 border border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
+    }
     .large_tab_item {
         @apply inline-block px-2 py-4 rounded-t-lg text-gray-500 border border-b-0 border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -50,7 +50,7 @@
         @apply inline-block px-4 py-2 text-gray-600 border border-gray-300 rounded-3xl hover:bg-blue-50 hover:no-underline;
     }
     .active_small_tab_item {
-        @apply inline-block px-4 py-2 text-white bg-blue-700 border border-gray-300 rounded-3xl hover:no-underline;
+        @apply inline-block px-4 py-2 text-white bg-blue-700 border border-blue-700 rounded-3xl hover:no-underline;
     }
     .flash_notice {
         @apply py-2.5 px-4 my-5 text-green-500 bg-green-100 font-medium rounded-lg inline-block;

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-4">
+<div class="mb-8">
   <% if course.members.any? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <li class="me-2">

--- a/app/views/courses/members/index.html.erb
+++ b/app/views/courses/members/index.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
   <div>
-    <ul class="list-disc list-inside pl-0">
+    <ul class="list-none pl-0">
       <% @members.each do |member| %>
         <li class="mb-6" data-member="<%= member.id %>">
           <%= image_tag member.avatar_url, alt: "#{member.name}の画像", class: 'w-12 h-12 inline-block rounded-full border border-gray-300' %>
@@ -20,17 +20,19 @@
           <% if member.hibernated? %>
             <span class="text-sm text-gray-500">離脱中</span>
           <% end %>
-          <% if admin_signed_in? && !member.hibernated? %>
-            <div class="mt-2">
-              <%= link_to 'チームメンバーから外す', member_hibernations_path(member), data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんをチームメンバーから外します、よろしいですか？" },
-                                                                                  class: "text-sm text-gray-400" %>
-            </div>
-          <% end %>
+
           <% if member.recent_attendances.empty? %>
             <p class="mt-2"><%= member.name %>さんはまだミーティングに出席していません</p>
           <% else %>
             <div class="my-2">
               <%= render 'shared/attendance_table', attendances: member.recent_attendances %>
+            </div>
+          <% end %>
+
+          <% if admin_signed_in? && !member.hibernated? %>
+            <div class="mt-2">
+              <%= link_to 'チームメンバーから外す', member_hibernations_path(member), data: { turbo: true, turbo_method: :post, turbo_confirm: "#{member.name}さんをチームメンバーから外します、よろしいですか？" },
+                                                                                  class: "text-sm text-gray-400" %>
             </div>
           <% end %>
         </li>

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -1,13 +1,11 @@
-<div class="pt-4 mb-8">
+<div class="pt-4 mb-8 bg-gray-100">
   <div class="border-b border-gray-300">
-    <div class="md:max-w-5xl md:mx-auto">
-      <ul class="flex flex-wrap text-center pl-0 !list-none">
-        <% Course.all.each do |course| %>
-          <li class="me-2">
-            <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_large_tab_item' : 'large_tab_item' %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
+    <ul class="flex flex-wrap text-center pl-0 !list-none md:max-w-5xl md:mx-auto">
+      <% Course.all.each do |course| %>
+        <li class="me-2">
+          <%= link_to course.name, polymorphic_path([course, resource]), class: active_tab == course ? 'active_course_tab_item' : 'inactive_course_tab_item' %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
## Issue
- #271 

## 概要
メンバー一覧ページのデザインレビューで指摘された箇所を修正した。

## Screenshot
- コース選択タブ
  - 各タブの幅を揃えた
  - 選択されていないタブは目立たない色にした
  - コース選択タブに背景色を追加
- 現役・全て選択タブ
  - 選択時のborderを背景色と揃える
- 各ユーザーの先頭のリストを消す
- `チームメンバーから外す`リンクの位置を変更  

![C2C1EB01-0C68-4BB8-98A7-3B50B2BDA731](https://github.com/user-attachments/assets/3a664c9a-3be6-4efc-aed1-48da68bafc06)

