### PR TITLE
議事録詳細ページのタブのデザインを修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -41,10 +41,10 @@
         @apply translate-y-[1px] inline-block px-2 py-4 w-52 md:w-[280px] rounded-t-lg text-gray-500 font-bold bg-gray-300 border border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }
     .large_tab_item {
-        @apply inline-block px-2 py-4 rounded-t-lg text-gray-500 border border-b-0 border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
+        @apply translate-y-[1px] inline-block px-2 py-4 w-24 md:w-40 rounded-t-lg text-gray-500 font-bold bg-gray-300 border border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }
     .active_large_tab_item {
-        @apply inline-block px-2 py-4 rounded-t-lg text-white font-bold bg-blue-700 border border-b-0 border-gray-300 hover:no-underline text-xs md:px-4 md:text-base;
+        @apply translate-y-[1px] inline-block px-2 py-4 w-24 md:w-40 rounded-t-lg text-blue-700 font-bold bg-white border border-l-gray-300 border-t-gray-300 border-r-gray-300 border-b-white hover:no-underline text-xs md:px-4 md:text-base;
     }
     .small_tab_item {
         @apply inline-block px-4 py-2 w-24 text-gray-600 border border-gray-300 rounded-3xl hover:bg-blue-50 hover:no-underline;

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -40,17 +40,17 @@
     .inactive_course_tab_item {
         @apply translate-y-[1px] inline-block px-2 py-4 w-52 md:w-[280px] rounded-t-lg text-gray-500 font-bold bg-gray-300 border border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }
-    .large_tab_item {
-        @apply translate-y-[1px] inline-block px-2 py-4 w-24 md:w-40 rounded-t-lg text-gray-500 font-bold bg-gray-300 border border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
-    }
-    .active_large_tab_item {
+    .active_preview_tab_item {
         @apply translate-y-[1px] inline-block px-2 py-4 w-24 md:w-40 rounded-t-lg text-blue-700 font-bold bg-white border border-l-gray-300 border-t-gray-300 border-r-gray-300 border-b-white hover:no-underline text-xs md:px-4 md:text-base;
     }
-    .small_tab_item {
-        @apply inline-block px-4 py-2 w-24 text-gray-600 border border-gray-300 rounded-3xl hover:bg-blue-50 hover:no-underline;
+    .inactive_preview_tab_item {
+        @apply translate-y-[1px] inline-block px-2 py-4 w-24 md:w-40 rounded-t-lg text-gray-500 font-bold bg-gray-300 border border-gray-300 hover:bg-blue-50 hover:no-underline text-xs md:px-4 md:text-base;
     }
     .active_small_tab_item {
         @apply inline-block px-4 py-2 w-24 text-white bg-blue-700 border border-blue-700 rounded-3xl hover:no-underline;
+    }
+    .inactive_small_tab_item {
+        @apply inline-block px-4 py-2 w-24 text-gray-600 border border-gray-300 rounded-3xl hover:bg-blue-50 hover:no-underline;
     }
     .flash_notice {
         @apply py-2.5 px-4 my-5 text-green-500 bg-green-100 font-medium rounded-lg inline-block;

--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -13,7 +13,7 @@ export default function MinutePreview({ markdown }) {
   return (
     <div>
       <div className="mb-8">
-        <ul className="flex flex-wrap text-sm text-center border-b border-gray-300 !list-none">
+        <ul className="flex flex-wrap text-sm text-center border-b border-gray-300 pl-4 !list-none">
           <li className="me-2">
             <button
               onClick={() => setSelectedTab('markdown')}

--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -19,8 +19,8 @@ export default function MinutePreview({ markdown }) {
               onClick={() => setSelectedTab('markdown')}
               className={
                 selectedTab === 'markdown'
-                  ? 'active_large_tab_item'
-                  : 'large_tab_item'
+                  ? 'active_preview_tab_item'
+                  : 'inactive_preview_tab_item'
               }
             >
               Markdown
@@ -31,8 +31,8 @@ export default function MinutePreview({ markdown }) {
               onClick={() => setSelectedTab('preview')}
               className={
                 selectedTab === 'preview'
-                  ? 'active_large_tab_item'
-                  : 'large_tab_item'
+                  ? 'active_preview_tab_item'
+                  : 'inactive_preview_tab_item'
               }
             >
               Preview

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -2,10 +2,10 @@
   <% if course.members.any? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <li class="me-2">
-        <%= link_to '現役', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'small_tab_item' %>
+        <%= link_to '現役', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'inactive_small_tab_item' %>
       </li>
       <li class="me-2">
-        <%= link_to '全て', course_members_path(course, status: 'all'), class: active_tab == 'all' ? 'active_small_tab_item' : 'small_tab_item' %>
+        <%= link_to '全て', course_members_path(course, status: 'all'), class: active_tab == 'all' ? 'active_small_tab_item' : 'inactive_small_tab_item' %>
       </li>
     </ul>
   <% end %>

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -3,7 +3,7 @@
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <% course.meeting_years.sort.each do |year| %>
         <li class="me-2">
-          <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab_item' : 'small_tab_item' %>
+          <%= link_to "#{year}年", course_minutes_path(course, year: year), class: active_tab == year ? 'active_small_tab_item' : 'inactive_small_tab_item' %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
## Issue
- #271 
- #294 

## 概要
#294 で議事録一覧ページとメンバー一覧ページのタブの見た目が変わったため、それに合わせる形で議事録詳細ページのタブのデザインを修正した。

背景色を追加すると見た目がおかしくなってしまうため、背景色は追加していない。

また、上記の変更と関連してTailwindのカスタムクラスの命名が一貫するように各カスタムクラス名を変更している。

## Screenshot
変更前
![0614F60A-F28A-4D4C-8EF6-1AD13DF5D25C](https://github.com/user-attachments/assets/25d26d64-937f-4a7d-8dc0-f5e9809c06bb)


変更後
![E5854C05-6834-4BC4-ACD9-C7B4DB675D93](https://github.com/user-attachments/assets/e1ea593d-bb5c-4cd7-a54d-e38ec88e0def)


