### PR TITLE
NotificationMessageBuilder内で変数名を省略していた箇所を修正

### DIFF
--- a/app/models/notification_message_builder.rb
+++ b/app/models/notification_message_builder.rb
@@ -20,8 +20,8 @@ class NotificationMessageBuilder
 
   private
 
-  def template_path(type)
-    { minute_creation: TEMPLATE_PATH_FOR_MINUTE_CREATION, today_meeting: TEMPLATE_PATH_FOR_TODAY_MEETING }[type]
+  def template_path(message_type)
+    { minute_creation: TEMPLATE_PATH_FOR_MINUTE_CREATION, today_meeting: TEMPLATE_PATH_FOR_TODAY_MEETING }[message_type]
   end
 
   def role_id


### PR DESCRIPTION
## Issue
- #265 

## 概要
NotificationMessageBuilder内で変数名を省略して何を表しているのか分かりづらくなっている変数名があったため、修正した。
