### PR TITLE
コメント内で言及していたURLが誤ったものであったため修正

### DIFF
--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ApplicationCable::Connection, type: :channel do
 
   it 'successfully connect when admin has valid remember cookie' do
     # ユーザーのログインを記憶する処理を簡易的に実行する
-    # https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/controllers/rememberable.rb#L22
+    # https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/models/rememberable.rb#L50
     admin.remember_me!
     cookies.signed[:remember_admin_token] = Admin.serialize_into_cookie(admin)
 


### PR DESCRIPTION
## Issue
- #265 

## 概要
参考URLをコメントで追記していた箇所で、誤ったURLをコメント内に記載していたため、正しいURLに修正した。

