### PR TITLE
Minuteモデルのテストで、テスト内の日付移動メソッドを分かりやすいものに変更

### DIFF
--- a/spec/models/minute_spec.rb
+++ b/spec/models/minute_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Minute, type: :model do
     let(:minute) { FactoryBot.build(:minute) }
 
     it 'returns false if today is before the meeting date' do
-      travel_to minute.meeting_date.days_ago(1) do
+      travel_to minute.meeting_date.yesterday do
         expect(minute.already_finished?).to be false
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe Minute, type: :model do
     end
 
     it 'returns true if today is after the meeting date' do
-      travel_to minute.meeting_date.days_since(1) do
+      travel_to minute.meeting_date.tomorrow do
         expect(minute.already_finished?).to be true
       end
     end


### PR DESCRIPTION
## Issue
- #265 

## 概要
spec/models/minute_spec.rb内で、日付の移動に`days_ago`と`days_since`を利用していた。
ただ、日付の移動が一日であるため`yesterday`と`tomorrow`を利用した方が分かりやすくなると判断し、そのメソッドを利用するように変更した。
