### PR TITLE
メンバー表示のテストを修正

### DIFF
--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-8">
+<div id="status_tab" class="mb-8">
   <% if course.members.any? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <li class="me-2">

--- a/app/views/courses/tabs/_course_tab.html.erb
+++ b/app/views/courses/tabs/_course_tab.html.erb
@@ -1,4 +1,4 @@
-<div class="pt-4 mb-8 bg-gray-100">
+<div id="course_tab" class="pt-4 mb-8 bg-gray-100">
   <div class="border-b border-gray-300">
     <ul class="flex flex-wrap text-center pl-0 !list-none md:max-w-5xl md:mx-auto">
       <% Course.all.each do |course| %>

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -146,8 +146,10 @@ RSpec.describe 'Members', type: :system do
 
       login_as member
       visit course_members_path(rails_course)
-      expect(page).to have_link 'Railsエンジニアコース'
-      expect(page).to have_link 'フロントエンドエンジニアコース'
+      within('#course_tab') do
+        expect(page).to have_link 'Railsエンジニアコース'
+        expect(page).to have_link 'フロントエンドエンジニアコース'
+      end
       rails_course.members.each do |member|
         within("li[data-member='#{member.id}']") do
           expect(page).to have_link member.name, href: member_path(member)
@@ -157,7 +159,9 @@ RSpec.describe 'Members', type: :system do
       end
       expect(page).not_to have_link 'bob', href: member_path(front_end_member)
 
-      click_link 'フロントエンドエンジニアコース'
+      within('#course_tab') do
+        click_link 'フロントエンドエンジニアコース'
+      end
       rails_course.members.each do |member|
         expect(page).not_to have_link member.name, href: member_path(member)
       end
@@ -211,14 +215,20 @@ RSpec.describe 'Members', type: :system do
       admin = FactoryBot.create(:admin)
       login_as_admin admin
       visit course_members_path(rails_course)
-      expect(page).to have_link '現役', href: course_members_path(rails_course, status: 'active')
-      expect(page).to have_link '全て', href: course_members_path(rails_course, status: 'all')
+      within('#status_tab') do
+        expect(page).to have_link '現役', href: course_members_path(rails_course, status: 'active')
+        expect(page).to have_link '全て', href: course_members_path(rails_course, status: 'all')
+      end
 
-      click_link '現役'
+      within('#status_tab') do
+        click_link '現役'
+      end
       expect(page).to have_content 'alice'
       expect(page).not_to have_content hibernated_member.name
 
-      click_link '全て'
+      within('#status_tab') do
+        click_link '全て'
+      end
       expect(page).to have_content 'alice'
       within("li[data-member='#{hibernated_member.id}']") do
         expect(page).to have_content hibernated_member.name
@@ -232,8 +242,7 @@ RSpec.describe 'Members', type: :system do
 
       login_as member
       visit course_members_path(rails_course)
-      expect(page).not_to have_link '現役', href: course_members_path(rails_course, status: 'active')
-      expect(page).not_to have_link '全て', href: course_members_path(rails_course, status: 'all')
+      expect(page).not_to have_selector 'div#status_tab'
       expect(page).to have_content 'alice'
       expect(page).not_to have_content hibernated_member.name
 

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -243,12 +243,12 @@ RSpec.describe 'Members', type: :system do
       login_as member
       visit course_members_path(rails_course)
       expect(page).not_to have_selector 'div#status_tab'
-      expect(page).to have_content 'alice'
-      expect(page).not_to have_content hibernated_member.name
+      expect(page).to have_link member.name, href: member_path(member)
+      expect(page).not_to have_link hibernated_member.name, href: member_path(hibernated_member)
 
       visit course_members_path(rails_course, status: 'hibernated')
-      expect(page).to have_content 'alice'
-      expect(page).not_to have_content hibernated_member.name
+      expect(page).to have_link member.name, href: member_path(member)
+      expect(page).not_to have_link hibernated_member.name, href: member_path(hibernated_member)
     end
 
     scenario 'admin can make member hibernated' do

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'Members', type: :system do
         within("li[data-member='#{member.id}']") do
           expect(page).to have_link member.name, href: member_path(member)
           expect(page).to have_selector "img[src='#{member.avatar_url}']"
-          expect(page).not_to have_selector 'button.open_modal', text: '休止中にする'
+          expect(page).not_to have_link 'チームメンバーから外す'
         end
       end
       expect(page).not_to have_link 'bob', href: member_path(front_end_member)

--- a/spec/system/members_spec.rb
+++ b/spec/system/members_spec.rb
@@ -212,8 +212,7 @@ RSpec.describe 'Members', type: :system do
       hibernated_member = FactoryBot.create(:member, :another_member, course: rails_course)
       FactoryBot.create(:hibernation, member: hibernated_member, created_at: Time.zone.local(2025, 1, 1))
 
-      admin = FactoryBot.create(:admin)
-      login_as_admin admin
+      login_as_admin FactoryBot.create(:admin)
       visit course_members_path(rails_course)
       within('#status_tab') do
         expect(page).to have_link '現役', href: course_members_path(rails_course, status: 'active')
@@ -252,8 +251,7 @@ RSpec.describe 'Members', type: :system do
     end
 
     scenario 'admin can make member hibernated' do
-      admin = FactoryBot.create(:admin)
-      login_as_admin admin
+      login_as_admin FactoryBot.create(:admin)
       visit course_members_path(rails_course)
       within("li[data-member='#{member.id}']") do
         expect(page).to have_content 'alice'
@@ -273,8 +271,7 @@ RSpec.describe 'Members', type: :system do
     end
 
     scenario 'admin cannot make member hibernated who already hibernated' do
-      admin = FactoryBot.create(:admin)
-      login_as_admin admin
+      login_as_admin FactoryBot.create(:admin)
       visit course_members_path(rails_course)
 
       FactoryBot.create(:hibernation, member:)


### PR DESCRIPTION
## Issue
- #265 

## 概要
spec/system/members_spec.rbの以下を修正した。

- すでに存在していない要素を検証している箇所があったので修正した
- タブのテストが分かりづらかったので、タブをテストしていることがわかりやすくなるように修正した
- 表示の確認で、文字列ではなく要素が表示されていることを確認するようにした
- 省略可能な変数を削除した
- describeとcontextを修正し、一部テストのネスト構造を変更した

