### PR TITLE
ログインのテストを修正

### DIFF
--- a/spec/system/omniauth_logins_spec.rb
+++ b/spec/system/omniauth_logins_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: 'aliceさん'
+      expect(page).to have_content 'Railsエンジニアコース'
     end
 
     scenario 'user can log in as member of the front end course' do
@@ -31,6 +32,7 @@ RSpec.describe 'OmniauthLogins', type: :system do
 
       expect(page).to have_content 'GitHub アカウントによる認証に成功しました。'
       expect(page).to have_selector 'h1', text: 'aliceさん'
+      expect(page).to have_content 'フロントエンドエンジニアコース'
     end
   end
 


### PR DESCRIPTION
## Issue
- #265 

## 概要
ログインのテストで以下の項目を確認するようにした。

- トップページのボタンをクリックしてログインした際、チームメンバーはクリックしたコースに所属する
