### PR TITLE
リリース情報を表示するコンポーネントを修正

### DIFF
--- a/app/javascript/application.jsx
+++ b/app/javascript/application.jsx
@@ -3,7 +3,7 @@ Turbo.session.drive = false
 
 import mountComponent from './mountComponent.jsx'
 import AttendeesList from './components/AttendeesList.jsx'
-import ReleaseInformationForm from './components/ReleaseInformationForm.jsx'
+import Release from './components/Release.jsx'
 import TopicList from './components/TopicList.jsx'
 import OtherForm from './components/OtherForm.jsx'
 import NextMeetingDateForm from './components/NextMeetingDateForm.jsx'
@@ -15,8 +15,8 @@ import './toggleAttendanceForm'
 import 'flowbite'
 
 mountComponent('attendees_list', AttendeesList)
-mountComponent('release_branch_form', ReleaseInformationForm)
-mountComponent('release_note_form', ReleaseInformationForm)
+mountComponent('release_branch', Release)
+mountComponent('release_note', Release)
 mountComponent('topics', TopicList)
 mountComponent('other_form', OtherForm)
 mountComponent('next_meeting_date_form', NextMeetingDateForm)

--- a/app/javascript/components/Release.jsx
+++ b/app/javascript/components/Release.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import sendRequest from '../sendRequest.js'
 import useChannel from '../hooks/useChannel.js'
 
-export default function ReleaseInformationForm({
+export default function Release({
   minuteId,
   description,
   content,
@@ -40,7 +40,7 @@ export default function ReleaseInformationForm({
               setIsEditing={setIsEditing}
             />
           ) : (
-            <ReleaseInformation
+            <ReleaseDetail
               content={informationContent}
               setIsEditing={setIsEditing}
               isAdmin={isAdmin}
@@ -106,7 +106,7 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
   )
 }
 
-function ReleaseInformation({ content, setIsEditing, isAdmin }) {
+function ReleaseDetail({ content, setIsEditing, isAdmin }) {
   return (
     <li>
       <span>{content}</span>
@@ -123,7 +123,7 @@ function ReleaseInformation({ content, setIsEditing, isAdmin }) {
   )
 }
 
-ReleaseInformationForm.propTypes = {
+Release.propTypes = {
   minuteId: PropTypes.number,
   description: PropTypes.string,
   content: PropTypes.string,
@@ -139,7 +139,7 @@ EditForm.propTypes = {
   setIsEditing: PropTypes.func,
 }
 
-ReleaseInformation.propTypes = {
+ReleaseDetail.propTypes = {
   content: PropTypes.string,
   setIsEditing: PropTypes.func,
   isAdmin: PropTypes.bool,

--- a/app/javascript/components/Release.jsx
+++ b/app/javascript/components/Release.jsx
@@ -16,20 +16,21 @@ export default function Release({
   const onReceivedData = useCallback(
     function (data) {
       if ('minute' in data.body) {
-        const key = `release_${description}`
-        setInformationContent(data.body.minute[key])
+        setInformationContent(data.body.minute[description])
       }
     },
     [description]
   )
   useChannel(minuteId, onReceivedData)
 
-  const label = description === 'branch' ? 'リリースブランチ' : 'リリースノート'
-
   return (
     <ul>
       <li>
-        <span className="block mb-2">{label}</span>
+        <span className="block mb-2">
+          {description === 'release_branch'
+            ? 'リリースブランチ'
+            : 'リリースノート'}
+        </span>
         <ul>
           {isEditing ? (
             <EditForm
@@ -60,10 +61,7 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
 
   const handleClick = async function (e) {
     e.preventDefault()
-    const parameter =
-      description === 'branch'
-        ? { minute: { release_branch: inputValue } }
-        : { minute: { release_note: inputValue } }
+    const parameter = { minute: { [description]: inputValue } }
 
     const response = await sendRequest(
       `/api/minutes/${minuteId}`,
@@ -80,7 +78,7 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
   }
 
   const placeholder = (description, course) => {
-    if (description === 'note') {
+    if (description === 'release_note') {
       return 'https://bootcamp.fjord.jp/announcements/1000'
     } else {
       return course === 'Railsエンジニアコース'
@@ -96,7 +94,7 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
         value={inputValue}
         placeholder={placeholder(description, course)}
         onChange={handleInput}
-        id={`release_${description}_field`}
+        id={`${description}_field`}
         className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-600 focus:border-blue-500 inline-block w-[500px] p-2.5 "
       />
       <button type="button" onClick={handleClick} className="button mt-2">

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -42,8 +42,8 @@
 
     <h2>今週のリリースの確認</h2>
     <p>木曜日の15時頃リリースします。</p>
-    <%= content_tag :div, id: 'release_branch_form', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
-    <%= content_tag :div, id: 'release_note_form', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_branch', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_note', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
 
     <h2>話題にしたいこと・心配事</h2>
     <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -42,8 +42,8 @@
 
     <h2>今週のリリースの確認</h2>
     <p>木曜日の15時頃リリースします。</p>
-    <%= content_tag :div, id: 'release_branch', data: {minuteId: @minute.id, description: 'branch', content: @minute.release_branch, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
-    <%= content_tag :div, id: 'release_note', data: {minuteId: @minute.id, description: 'note', content: @minute.release_note, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_branch', data: {minuteId: @minute.id, description: 'release_branch', content: @minute.release_branch, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
+    <%= content_tag :div, id: 'release_note', data: {minuteId: @minute.id, description: 'release_note', content: @minute.release_note, isAdmin: admin_signed_in?, course: @minute.course.name}.to_json do %><% end %>
 
     <h2>話題にしたいこと・心配事</h2>
     <p>明確に共有すべき事・困っている事以外にも、気分的に心配な事などを話すためにあります。</p>

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe 'Minutes', type: :system do
       end
 
       scenario 'can edit all minute content', :js do
-        within('#release_branch_form') do
+        within('#release_branch') do
           expect(page).to have_selector 'button', text: '編集'
         end
-        within('#release_note_form') do
+        within('#release_note') do
           expect(page).to have_selector 'button', text: '編集'
         end
         within('#topics') do
@@ -35,7 +35,7 @@ RSpec.describe 'Minutes', type: :system do
       end
 
       scenario 'can edit release branch and release note', :js do
-        within('#release_branch_form') do
+        within('#release_branch') do
           expect(page).to have_selector 'li', text: 'https://example.com/fjordllc/bootcamp/pull/1000'
           expect(page).not_to have_selector 'input[type="text"]'
 
@@ -48,7 +48,7 @@ RSpec.describe 'Minutes', type: :system do
           expect(page).not_to have_selector 'input[type="text"]'
         end
 
-        within('#release_note_form') do
+        within('#release_note') do
           expect(page).to have_selector 'li', text: 'https://example.com/announcements/100'
           expect(page).not_to have_selector 'input[type="text"]'
 
@@ -148,10 +148,10 @@ RSpec.describe 'Minutes', type: :system do
 
       scenario 'can edit only topics', :js do
         visit edit_minute_path(minute)
-        within('#release_branch_form') do
+        within('#release_branch') do
           expect(page).not_to have_selector 'button', text: '編集'
         end
-        within('#release_note_form') do
+        within('#release_note') do
           expect(page).not_to have_selector 'button', text: '編集'
         end
         within('#topics') do


### PR DESCRIPTION
## Issue
- #265 

## 概要
議事録編集ページで、リリース情報を表示するコンポーネントに以下の修正を行なった。

- コンポーネント名を`ReleaseInformationForm`から`Release`に変更
- ビューからコンポーネントに渡していた変数の値を変更した



