### PR TITLE
Memberモデルの出席データを返すメソッドを修正

### DIFF
--- a/app/helpers/attendances_helper.rb
+++ b/app/helpers/attendances_helper.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 module AttendancesHelper
+  def split_attendances(attendances, member)
+    # 以下の条件で出席を分割する
+    # 1. 年ごとに分割
+    # 2. チームメンバーが過去にチーム開発を離脱していた場合、離脱期間内の出席とそうでない出席を分割し、離脱期間内の出席は削除
+    # 3. 出席を半年分(12回)ごとに分割
+    attendances_by_year = attendances.group_by { |attendance| attendance[:date].year }
+    attendances_by_year.transform_values do |annual_attendances|
+      hibernation_periods = member.hibernations.where.not(finished_at: nil).map { |hibernation| hibernation.created_at.to_date..hibernation.finished_at }
+      attendances_outside_of_hibernation_period = annual_attendances.chunk do |attendance|
+        hibernation_periods.any? { |period| period.cover?(attendance[:date]) } ? nil : false
+      end
+      attendances_outside_of_hibernation_period.flat_map { |chunked_attendances| chunked_attendances[1].each_slice(12).to_a }
+    end
+  end
+
   def attendance_status(present, time)
     return '---' if present.nil?
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -28,7 +28,7 @@ class Member < ApplicationRecord
   end
 
   def all_attendances
-    attendances = hibernated? ? attendance_list(to: hibernations.last.created_at) : attendance_list
+    attendances = hibernated? ? attendance_records(to: hibernations.last.created_at) : attendance_records
     attendances_by_year = attendances.group_by { |attendance| attendance[:date].year }
     attendances_by_year.transform_values do |annual_attendances|
       split_for_display(annual_attendances)
@@ -38,12 +38,12 @@ class Member < ApplicationRecord
   def recent_attendances
     from = was_hibernated? ? hibernations.where.not(finished_at: nil).last.finished_at : created_at
     to = hibernated? ? hibernations.last.created_at : nil
-    attendance_list(from:, to:).pop(12)
+    attendance_records(from:, to:).pop(12)
   end
 
   private
 
-  def attendance_list(from: created_at, to: nil)
+  def attendance_records(from: created_at, to: nil)
     Minute.joins("LEFT JOIN (SELECT * FROM attendances WHERE member_id = #{id}) AS attendances ON minutes.id = attendances.minute_id")
           .where(course_id:)
           .where(meeting_date: from..to)

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -31,7 +31,7 @@
     <% if @member.all_attendances.empty? %>
       <p><%= @member.name %>さんはまだミーティングに出席していません</p>
     <% else %>
-      <% @member.all_attendances.each do |year, attendances_by_year| %>
+      <% split_attendances(@member.all_attendances, @member).each do |year, attendances_by_year| %>
         <div class="mb-8" data-meeting-year="<%= year %>">
           <p class="mb-4 font-bold border-b-[1px] border-gray-200"><%= year %>年</p>
           <% attendances_by_year.each.with_index do |attendances, i| %>

--- a/spec/helpers/attendances_helper_spec.rb
+++ b/spec/helpers/attendances_helper_spec.rb
@@ -3,6 +3,58 @@
 require 'rails_helper'
 
 RSpec.describe AttendancesHelper, type: :helper do
+  let(:member) { FactoryBot.create :member, course: FactoryBot.create(:rails_course) }
+
+  describe '#split_attendances' do
+    it 'splits attendances by year' do
+      attendance_records = [
+        { minute_id: 1, date: Date.new(2024, 12, 18), attendance_id: 1, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 2, date: Date.new(2025, 1, 15), attendance_id: 2, present: false, session: nil, absence_reason: '体調不良のため。' }
+      ]
+      expect(helper.split_attendances(attendance_records, member)).to eq({ 2024 => [[attendance_records.first]], 2025 => [[attendance_records.second]] })
+    end
+
+    it 'does not include attendances during hibernated period' do
+      FactoryBot.create(:hibernation, finished_at: Time.zone.local(2024, 8, 10), member:, created_at: Time.zone.local(2024, 7, 10))
+
+      attendance_records = [
+        { minute_id: 1, date: Date.new(2024, 7, 3), attendance_id: 1, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 2, date: Date.new(2024, 7, 17), attendance_id: 2, present: nil, session: nil, absence_reason: nil },
+        { minute_id: 3, date: Date.new(2024, 8, 7), attendance_id: 3, present: nil, session: nil, absence_reason: nil },
+        { minute_id: 4, date: Date.new(2024, 8, 21), attendance_id: 4, present: true, session: 'afternoon', absence_reason: nil }
+      ]
+      attendance_record_before_hibernation = { minute_id: 1, date: Date.new(2024, 7, 3), attendance_id: 1, present: true, session: 'afternoon', absence_reason: nil }
+      attendance_record_after_hibernation = { minute_id: 4, date: Date.new(2024, 8, 21), attendance_id: 4, present: true, session: 'afternoon', absence_reason: nil }
+
+      expect(helper.split_attendances(attendance_records, member)).to eq({ 2024 => [[attendance_record_before_hibernation], [attendance_record_after_hibernation]] })
+    end
+
+    it 'splits attendances in half year' do
+      attendance_records = [
+        { minute_id: 1, date: Date.new(2024, 1, 3), attendance_id: 1, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 2, date: Date.new(2024, 1, 17), attendance_id: 2, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 3, date: Date.new(2024, 2, 7), attendance_id: 3, present: true, session: 'night', absence_reason: nil },
+        { minute_id: 4, date: Date.new(2024, 2, 21), attendance_id: 4, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 5, date: Date.new(2024, 3, 6), attendance_id: 5, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 6, date: Date.new(2024, 3, 20), attendance_id: 6, present: true, session: 'night', absence_reason: nil },
+        { minute_id: 7, date: Date.new(2024, 4, 3), attendance_id: 7, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 8, date: Date.new(2024, 4, 17), attendance_id: 8, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 9, date: Date.new(2024, 5, 1), attendance_id: 9, present: true, session: 'night', absence_reason: nil },
+        { minute_id: 10, date: Date.new(2024, 5, 15), attendance_id: 10, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 11, date: Date.new(2024, 6, 5), attendance_id: 11, present: true, session: 'afternoon', absence_reason: nil },
+        { minute_id: 12, date: Date.new(2024, 6, 19), attendance_id: 12, present: true, session: 'night', absence_reason: nil },
+        { minute_id: 13, date: Date.new(2024, 7, 3), attendance_id: 13, present: true, session: 'afternoon', absence_reason: nil }
+      ]
+
+      divided_attendances = helper.split_attendances(attendance_records, member)[2024]
+      expect(divided_attendances.length).to eq 2
+      expect(divided_attendances.first.length).to eq 12
+      expect(divided_attendances.first.last).to eq({ minute_id: 12, date: Date.new(2024, 6, 19), attendance_id: 12, present: true, session: 'night', absence_reason: nil })
+      expect(divided_attendances.second.length).to eq 1
+      expect(divided_attendances.second.first).to eq({ minute_id: 13, date: Date.new(2024, 7, 3), attendance_id: 13, present: true, session: 'afternoon', absence_reason: nil })
+    end
+  end
+
   describe '#attendance_status' do
     it 'returns 昼 for afternoon session attendance' do
       expect(helper.attendance_status(true, 'afternoon')).to eq '昼'

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Member, type: :model do
       expected_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil },
                               { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, present: false, session: nil, absence_reason: '体調不良のため。' },
                               { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
-      expect(member.all_attendances).to eq({ 2024 => [expected_attendances] })
+      expect(member.all_attendances).to eq(expected_attendances)
     end
 
     it 'returns attendances until the hibernation started if the member is hibernated' do
@@ -46,36 +46,7 @@ RSpec.describe Member, type: :model do
 
       attendances_until_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil },
                                        { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, present: false, session: nil, absence_reason: '体調不良のため。' }]
-      expect(member.all_attendances).to eq({ 2024 => [attendances_until_hibernation] })
-    end
-
-    it 'does not include attendances during hibernated period' do
-      FactoryBot.create(:hibernation, finished_at: Time.zone.local(2024, 10, 31), member:, created_at: Time.zone.local(2024, 10, 3))
-
-      attendances_before_hibernation = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil }]
-      attendances_after_hibernation = [{ minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
-      expect(member.all_attendances).to eq({ 2024 => [attendances_before_hibernation, attendances_after_hibernation] })
-    end
-
-    it 'divides attendances by year' do
-      latest_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2025, 1, 1), course: rails_course)
-      first_year_attendances = [{ minute_id: present_minute.id, date: Date.new(2024, 10, 2), attendance_id: Attendance.first.id, present: true, session: 'afternoon', absence_reason: nil },
-                                { minute_id: absent_minute.id, date: Date.new(2024, 10, 16), attendance_id: Attendance.second.id, present: false, session: nil, absence_reason: '体調不良のため。' },
-                                { minute_id: unexcused_absent_minute.id, date: Date.new(2024, 11, 6), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
-      second_year_attendances = [{ minute_id: latest_minute.id, date: Date.new(2025, 1, 1), attendance_id: nil, present: nil, session: nil, absence_reason: nil }]
-      expect(member.all_attendances).to eq({ 2024 => [first_year_attendances], 2025 => [second_year_attendances] })
-    end
-
-    it 'divides attendances in half of the year' do
-      create_minutes(course: rails_course, first_meeting_date: Time.zone.local(2025, 1, 1), count: 13)
-
-      attendances_in_the_latest_year = member.all_attendances[2025]
-      expect(attendances_in_the_latest_year.length).to eq 2
-      expect(attendances_in_the_latest_year.first.length).to eq 12
-      expect(attendances_in_the_latest_year.first.last[:date]).to eq Date.new(2025, 6, 18)
-
-      expect(attendances_in_the_latest_year.second.length).to eq 1
-      expect(attendances_in_the_latest_year.second.last[:date]).to eq Date.new(2025, 7, 2)
+      expect(member.all_attendances).to eq(attendances_until_hibernation)
     end
   end
 


### PR DESCRIPTION
## Issue
- #265 

## 概要
Memberモデルの出席データを返すメソッドに、以下の修正を行なった。

- `attendance_llist`
  - メソッド名をより適切なものに修正
- `all_attendances`
  - 表示に関わるロジックを`AttendancesHelper#split_attendances`に切り出した 


