### PR TITLE
APIコントローラーが誤った値をレスポンスとして返していたので修正

### DIFF
--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -5,7 +5,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     topic = current_development_member.topics.new(topic_params)
     topic.minute_id = @minute.id
     if topic.save
-      render json: @minute, status: :created
+      render json: topic, status: :created
       broadcast_to_channel
     else
       render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity


### PR DESCRIPTION
## Issue
- #265 

## 概要
話題にしたいこと・心配事を作成時、`API::Minutes::TopicsController`が議事録のデータを返すようになっていたため、作成した話題にしたいことのデータを返すように修正した。

## Screenshot
### 修正前
リクエスト
![A030EE0D-0F45-4BBE-BFA6-058C2D6203AA_4_5005_c](https://github.com/user-attachments/assets/d060e9f7-368c-41a9-b3e2-4c0bc39247cb)

レスポンス
![456E0BB4-3996-46D6-9F85-75C5BDD29099](https://github.com/user-attachments/assets/b5bce92c-7c77-4298-8683-5fb1a7c378fa)

### 修正後
リクエスト
![6474E5D2-2B1C-4573-9FB0-E23F7D1D2604_4_5005_c](https://github.com/user-attachments/assets/1e7fc856-225c-4fcc-a487-960d7d3ef24c)

レスポンス
![C631FF9B-8F1A-433F-AB81-257B53DC92A4](https://github.com/user-attachments/assets/ba886de7-b0ff-4df0-b7af-ea9c850e2736)
