### PR TITLE
Chore/fix routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,6 @@ Rails.application.routes.draw do
     delete "logout", to: "members/sessions#destroy", as: "logout"
   end
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
   # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,23 +3,23 @@ Rails.application.routes.draw do
   root "home#index"
   get 'pp', to: 'home#pp'
   get 'terms_of_service', to: 'home#terms_of_service'
-  resources :minutes, only: [:show, :edit] do
-    resources :attendances, only: [ :new, :create ], module: :minutes
-    resources :exports, only: [ :create ], module: :minutes
+  resources :minutes, only: %i[show edit] do
+    resources :attendances, only: %i[new create], module: :minutes
+    resources :exports, only: %i[create], module: :minutes
   end
-  resources :attendances, only: [ :edit, :update ]
+  resources :attendances, only: %i[edit update]
   resources :courses, only: [] do
-    resources :members, only: [:index], module: :courses
-    resources :minutes, only: [:index], module: :courses
+    resources :members, only: %i[index], module: :courses
+    resources :minutes, only: %i[index], module: :courses
   end
-  resources :members, only: [:show] do
-    resources :hibernations, only: [:create], module: :members
+  resources :members, only: %i[show] do
+    resources :hibernations, only: %i[create], module: :members
   end
 
   namespace :api do
-    resources :minutes, only: [ :update ] do
-      resources :topics, only: [ :create, :update, :destroy ], module: :minutes
-      resources :attendances, only: [ :index ], module: :minutes
+    resources :minutes, only: %i[update] do
+      resources :topics, only: %i[create update destroy], module: :minutes
+      resources :attendances, only: %i[index], module: :minutes
     end
   end
 


### PR DESCRIPTION
## Issue
- #265 

## 概要
config/routes.rbに以下の修正を行なった。

- 不要なルーティングの削除
- アクションを指定している箇所を、%記法で書くようにした

## 備考
以下のルーティングはアプリのPWA対応に必要なmanifest.jsonの読み込みに使われているため、削除せず残した。
```ruby
  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
```

このmanifest.jsonはウェブアプリマニフェストと呼ばれる。
詳しくは #259 を参照。