### PR TITLE
出席登録/編集ページのラジオボタンをクリックしやすくなるようにした

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -58,4 +58,7 @@
     .flash_alert {
         @apply py-2.5 px-4 my-5 text-red-500 bg-red-100 font-medium rounded-lg inline-block;
     }
+    .radio_button_label {
+        @apply flex items-center w-full h-full relative block text-blue-700 rounded-lg font-bold cursor-pointer before:content-[""] before:w-4 before:h-4 before:rounded-full before:border before:border-blue-700 before:absolute before:left-3;
+    }
 }

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -24,17 +24,23 @@
       <% end %>
 
       <div class="mt-8 mb-12 flex gap-x-6 w-[550px] mx-auto">
-        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
-          <%= form.radio_button :status, "afternoon", class: "cursor-pointer border border-blue-700 mr-2" %>
-          <%= form.label :status_afternoon, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        <div class="w-full h-10 border border-blue-700 rounded-lg">
+          <%= form.radio_button :status, "afternoon", class: "hidden peer/afternoon" %>
+          <%= form.label(:status_afternoon, id: "label_afternoon", class: "radio_button_label peer-checked/afternoon:after:content-[""] peer-checked/afternoon:after:w-2 peer-checked/afternoon:after:h-2 peer-checked/afternoon:after:rounded-full peer-checked/afternoon:after:bg-blue-700 peer-checked/afternoon:after:absolute peer-checked/afternoon:after:left-4 peer-checked/afternoon:bg-blue-100") do %>
+            <%= content_tag(:span, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "block w-full pl-10") %>
+          <% end %>
         </div>
-        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
-          <%= form.radio_button :status, "night", class: "cursor-pointer border border-blue-700 mr-2" %>
-          <%= form.label :status_night, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        <div class="w-full h-10 border border-blue-700 rounded-lg">
+          <%= form.radio_button :status, "night", class: "hidden peer/night" %>
+          <%= form.label(:status_night, id: "label_night", class: "radio_button_label peer-checked/night:after:content-[""] peer-checked/night:after:w-2 peer-checked/night:after:h-2 peer-checked/night:after:rounded-full peer-checked/night:after:bg-blue-700 peer-checked/night:after:absolute peer-checked/night:after:left-4 peer-checked/night:bg-blue-100") do %>
+            <%= content_tag(:span, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "block w-full pl-10") %>
+          <% end %>
         </div>
-        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
-          <%= form.radio_button :status, "absent", class: "cursor-pointer border border-blue-700 mr-2" %>
-          <%= form.label :status_absent, AttendanceForm.human_attribute_name('status.absent'), class: "cursor-pointer text-blue-700 align-middle font-bold ml-4" %>
+        <div class="w-full h-10 border border-blue-700 rounded-lg">
+          <%= form.radio_button :status, "absent", class: "hidden peer/absent" %>
+          <%= form.label(:status_absent, id: "label_absent", class: "radio_button_label peer-checked/absent:after:content-[""] peer-checked/absent:after:w-2 peer-checked/absent:after:h-2 peer-checked/absent:after:rounded-full peer-checked/absent:after:bg-blue-700 peer-checked/absent:after:absolute peer-checked/absent:after:left-4 peer-checked/absent:bg-blue-100") do %>
+            <%= content_tag(:span, "#{AttendanceForm.human_attribute_name('status.absent')}", class: "block w-full pl-16") %>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -24,17 +24,23 @@
       <% end %>
 
       <div class="mt-8 mb-12 flex gap-x-6 w-[550px] mx-auto">
-        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
-          <%= form.radio_button :status, "afternoon", class: "cursor-pointer border border-blue-700 mr-2" %>
-          <%= form.label :status_afternoon, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        <div class="w-full h-10 border border-blue-700 rounded-lg">
+          <%= form.radio_button :status, "afternoon", class: "hidden peer/afternoon" %>
+          <%= form.label(:status_afternoon, id: "label_afternoon", class: "radio_button_label peer-checked/afternoon:after:content-[""] peer-checked/afternoon:after:w-2 peer-checked/afternoon:after:h-2 peer-checked/afternoon:after:rounded-full peer-checked/afternoon:after:bg-blue-700 peer-checked/afternoon:after:absolute peer-checked/afternoon:after:left-4 peer-checked/afternoon:bg-blue-100") do %>
+            <%= content_tag(:span, "#{AttendanceForm.human_attribute_name('status.afternoon')}に出席", class: "block w-full pl-10") %>
+          <% end %>
         </div>
-        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
-          <%= form.radio_button :status, "night", class: "cursor-pointer border border-blue-700 mr-2" %>
-          <%= form.label :status_night, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "cursor-pointer text-blue-700 align-middle font-bold" %>
+        <div class="w-full h-10 border border-blue-700 rounded-lg">
+          <%= form.radio_button :status, "night", class: "hidden peer/night" %>
+          <%= form.label(:status_night, id: "label_night", class: "radio_button_label peer-checked/night:after:content-[""] peer-checked/night:after:w-2 peer-checked/night:after:h-2 peer-checked/night:after:rounded-full peer-checked/night:after:bg-blue-700 peer-checked/night:after:absolute peer-checked/night:after:left-4 peer-checked/night:bg-blue-100") do %>
+            <%= content_tag(:span, "#{AttendanceForm.human_attribute_name('status.night')}に出席", class: "block w-full pl-10") %>
+          <% end %>
         </div>
-        <div class="w-40 border border-blue-700 rounded-lg py-2 px-4">
-          <%= form.radio_button :status, "absent", class: "cursor-pointer border border-blue-700 mr-2" %>
-          <%= form.label :status_absent, AttendanceForm.human_attribute_name('status.absent'), class: "cursor-pointer text-blue-700 align-middle font-bold ml-4" %>
+        <div class="w-full h-10 border border-blue-700 rounded-lg">
+          <%= form.radio_button :status, "absent", class: "hidden peer/absent" %>
+          <%= form.label(:status_absent, id: "label_absent", class: "radio_button_label peer-checked/absent:after:content-[""] peer-checked/absent:after:w-2 peer-checked/absent:after:h-2 peer-checked/absent:after:rounded-full peer-checked/absent:after:bg-blue-700 peer-checked/absent:after:absolute peer-checked/absent:after:left-4 peer-checked/absent:bg-blue-100") do %>
+            <%= content_tag(:span, "#{AttendanceForm.human_attribute_name('status.absent')}", class: "block w-full pl-16") %>
+          <% end %>
         </div>
       </div>
 

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Attendances', type: :system do
           click_link '出席予定を登録する'
 
           expect(current_path).to eq new_minute_attendance_path(minute)
-          choose '昼の部に出席'
+          find('#label_afternoon').click
           click_button '出席を登録'
 
           expect(current_path).to eq edit_minute_path(minute)
@@ -47,7 +47,7 @@ RSpec.describe 'Attendances', type: :system do
           expect(page).to have_link '出席予定を登録する'
           click_link '出席予定を登録する'
 
-          choose '夜の部に出席'
+          find('#label_night').click
           click_button '出席を登録'
 
           expect(current_path).to eq edit_minute_path(minute)
@@ -66,7 +66,7 @@ RSpec.describe 'Attendances', type: :system do
           expect(page).to have_link '出席予定を登録する'
           click_link '出席予定を登録する'
 
-          choose '欠席'
+          find('#label_absent').click
           fill_in '欠席理由', with: '仕事の都合のため。'
           fill_in '進捗報告', with: '#1000 チームメンバーのレビュー待ちの状態です。'
           click_button '出席を登録'
@@ -127,7 +127,7 @@ RSpec.describe 'Attendances', type: :system do
           # 出欠を選択していない場合、送信ボタンはdisabledとなる
           expect(page).to have_button '出席を登録', disabled: true
 
-          choose '欠席'
+          find('#label_absent').click
           click_button '出席を登録'
           expect(page).to have_content '欠席理由を入力してください'
           expect(page).to have_content '進捗報告を入力してください'
@@ -137,7 +137,7 @@ RSpec.describe 'Attendances', type: :system do
       scenario 'member cannot create attendance to the same meeting twice' do
         travel_to minute.meeting_date do
           visit new_minute_attendance_path(minute)
-          choose '昼の部に出席'
+          find('#label_afternoon').click
           click_button '出席を登録'
 
           visit new_minute_attendance_path(minute)

--- a/spec/system/attendances_spec.rb
+++ b/spec/system/attendances_spec.rb
@@ -176,10 +176,11 @@ RSpec.describe 'Attendances', type: :system do
         travel_to minute.meeting_date do
           visit edit_minute_path(minute)
           click_link '出席予定を変更する'
-          expect(current_path).to eq edit_attendance_path(attendance)
 
-          expect(page).to have_checked_field '昼の部に出席'
-          choose '欠席'
+          expect(current_path).to eq edit_attendance_path(attendance)
+          # デザインの都合上ラジオボタンは display: none; となっているため、visible: false をつける
+          expect(page).to have_checked_field('昼の部に出席', visible: false)
+          find('#label_absent').click
           fill_in '欠席理由', with: '体調不良のため。'
           fill_in '進捗報告', with: '#1000 チームメンバーのレビュー待ちの状態です。'
           click_button '出席を更新'
@@ -202,10 +203,11 @@ RSpec.describe 'Attendances', type: :system do
         travel_to minute.meeting_date do
           visit edit_minute_path(minute)
           click_link '出席予定を変更する'
-          expect(current_path).to eq edit_attendance_path(attendance)
 
-          expect(page).to have_checked_field '欠席'
-          choose '夜の部に出席'
+          expect(current_path).to eq edit_attendance_path(attendance)
+          # デザインの都合上ラジオボタンは display: none; となっているため、visible: false をつける
+          expect(page).to have_checked_field('欠席', visible: false)
+          find('#label_night').click
           click_button '出席を更新'
 
           expect(current_path).to eq edit_minute_path(minute)
@@ -225,7 +227,7 @@ RSpec.describe 'Attendances', type: :system do
           visit edit_minute_path(minute)
           click_link '出席予定を変更する'
 
-          choose '欠席'
+          find('#label_absent').click
           click_button '出席を更新'
           expect(page).to have_content '欠席理由を入力してください'
           expect(page).to have_content '進捗報告を入力してください'


### PR DESCRIPTION
## Issue
- #319 

## 概要
出席登録ページと出席編集ページで出欠を選択するラジオボタンを、枠の中であればどこでもクリックできるようにした。
また、チェックしたラジオボタンには背景色を追加している。

## Screenshot
修正前
[![Image from Gyazo](https://i.gyazo.com/cef224dac8de2f6e62e2484a0afba9fd.gif)](https://gyazo.com/cef224dac8de2f6e62e2484a0afba9fd)

修正後
[![Image from Gyazo](https://i.gyazo.com/85b059dd2153cab77a6edf38904c394d.gif)](https://gyazo.com/85b059dd2153cab77a6edf38904c394d)

