### PR TITLE
GithubWikiManagerの命名を修正

### DIFF
--- a/app/controllers/minutes/exports_controller.rb
+++ b/app/controllers/minutes/exports_controller.rb
@@ -4,7 +4,7 @@ class Minutes::ExportsController < Minutes::ApplicationController
   before_action :authenticate_admin!
 
   def create
-    GithubWikiManager.export_minute(@minute)
+    MinuteGithubExporter.export_to_github_wiki(@minute)
     @minute.update!(exported: true) unless @minute.exported?
     redirect_to course_minutes_path(@minute.course), notice: 'GitHub Wikiに議事録を反映させました'
   end

--- a/app/models/meeting_secretary.rb
+++ b/app/models/meeting_secretary.rb
@@ -29,7 +29,7 @@ class MeetingSecretary
   end
 
   def create_first_minute
-    cloned_repository_path = GithubWikiManager.new(@course).working_directory
+    cloned_repository_path = MinuteGithubExporter.new(@course).working_directory
     latest_meeting_date = get_latest_meeting_date_from_cloned_minutes(cloned_repository_path)
     unless latest_meeting_date.before? Time.zone.today
       leave_log("create_first_minute, #{@course.name}, not_executed, latest meeting isn't finished.")

--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-class GithubWikiManager
+class MinuteGithubExporter
   CLONED_BOOTCAMP_WIKI_PATH = Rails.root.join('bootcamp_wiki_repository').freeze
   CLONED_AGENT_WIKI_PATH = Rails.root.join('agent_wiki_repository').freeze
 
-  def self.export_minute(minute)
+  def self.export_to_github_wiki(minute)
     new(minute.course).commit_and_push(minute)
   end
 

--- a/spec/models/meeting_secretary_spec.rb
+++ b/spec/models/meeting_secretary_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe MeetingSecretary, type: :model do
     let(:latest_meeting_date) { Date.new(2024, 11, 6) }
 
     before do
-      # GithubWikiManager.new が呼ばれると Git.clone が実行されてしまい困るため、newメソッドをスタブする
-      github_wiki_manager_double = instance_double(GithubWikiManager)
-      allow(GithubWikiManager).to receive(:new).and_return(github_wiki_manager_double)
+      # MinuteGithubExporter.new が呼ばれると Git.clone が実行されてしまい困るため、newメソッドをスタブする
+      github_wiki_manager_double = instance_double(MinuteGithubExporter)
+      allow(MinuteGithubExporter).to receive(:new).and_return(github_wiki_manager_double)
       allow(github_wiki_manager_double).to receive(:working_directory).and_return(Rails.root.join('stubbed_repository'))
       # クローンしたリポジトリを利用するメソッドをスタブ
       allow(meeting_secretary).to receive_messages(get_latest_meeting_date_from_cloned_minutes: latest_meeting_date,

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -324,8 +324,8 @@ RSpec.describe 'Minutes', type: :system do
 
     scenario 'admin can export minute to GitHub Wiki' do
       # GitHub Wikiリポジトリにpushされないようにする
-      allow(GithubWikiManager).to receive(:export_minute).and_call_original
-      allow(GithubWikiManager).to receive(:export_minute).with(minute).and_return(nil)
+      allow(MinuteGithubExporter).to receive(:export_to_github_wiki).and_call_original
+      allow(MinuteGithubExporter).to receive(:export_to_github_wiki).with(minute).and_return(nil)
 
       login_as_admin FactoryBot.create(:admin)
       visit minute_path(minute)


### PR DESCRIPTION
## Issue
- #265 

## 概要
`GithubWikiManager`は議事録を GitHub Wiiki にエクスポートする処理を行うクラスだが、`...Manager`という命名だとクラスの責務がとても広くなってしまうため、このクラスが行う処理が伝わるようにクラス名とメソッドを変更した。

- `GithubWikiManager` → `MinuteGithubExporter`
- `export_minute` → `export_to_github_wiki`