### PR TITLE
Attendanceのsession属性にsuffixを追加

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Attendance < ApplicationRecord
-  enum :session, { afternoon: 0, night: 1 }
+  enum :session, { afternoon: 0, night: 1 }, suffix: true
 
   belongs_to :minute
   belongs_to :member


### PR DESCRIPTION
## Issue
- #323 

## 概要
アプリ内のenumがsuffixのあるものとないものが存在するため、suffixをつけるように統一した。

分かりやすさの観点から、enumにはプレフィックスやサフィックスをつけた方が良いとのこと。

> enumの値だけだと意味がわからないこともあるので、enum名にプレフィックスやサフィックスを適用する方がよいでしょう。

[Railsのenumを使いこなす方法（翻訳）｜TechRacho by BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2022_02_18/115735)
