### PR TITLE
出席モデルにスコープを追加

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -6,6 +6,11 @@ class Attendance < ApplicationRecord
   belongs_to :minute
   belongs_to :member
 
+  scope :at_afternoon_session, -> { where(session: :afternoon) }
+  scope :at_night_session, -> { where(session: :night) }
+  scope :absent, -> { where(present: false) }
+  scope :with_members, -> { includes(:member) }
+
   validates :present, inclusion: { in: [true, false] }
   validates :session, presence: true, if: proc { |attendance| attendance.present? }
   validates :session, absence: true, unless: proc { |attendance| attendance.present? }

--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -27,8 +27,7 @@ class MarkdownBuilder
   private
 
   def afternoon_attendees
-    @minute.attendances.where(session: :afternoon)
-           .includes(:member)
+    @minute.attendances.at_afternoon_session.with_members
            .order(:member_id)
            .pluck(:name)
            .map { |name| "- #{member_link(name)}" }
@@ -36,8 +35,7 @@ class MarkdownBuilder
   end
 
   def night_attendees
-    @minute.attendances.where(session: :night)
-           .includes(:member)
+    @minute.attendances.at_night_session.with_members
            .order(:member_id)
            .pluck(:name)
            .map { |name| "- #{member_link(name)}" }
@@ -45,8 +43,7 @@ class MarkdownBuilder
   end
 
   def absentees
-    @minute.attendances.where(present: false)
-           .includes(:member)
+    @minute.attendances.absent.with_members
            .order(:member_id)
            .pluck(:absence_reason, :progress_report, :name)
            .map { |absence_reason, progress_report, name| "- #{member_link(name)}\n  - 欠席理由\n    - #{absence_reason}\n  - 進捗報告\n#{split_line_to_list(progress_report)}" }

--- a/app/views/api/minutes/attendances/index.json.jbuilder
+++ b/app/views/api/minutes/attendances/index.json.jbuilder
@@ -1,5 +1,5 @@
 json.afternoon_attendees do
-  json.array! @attendances.where(session: :afternoon) do |attendance|
+  json.array! @attendances.at_afternoon_session do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id
     json.name attendance.member.name
@@ -7,7 +7,7 @@ json.afternoon_attendees do
 end
 
 json.night_attendees do
-  json.array! @attendances.where(session: :night) do |attendance|
+  json.array! @attendances.at_night_session do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id
     json.name attendance.member.name
@@ -15,7 +15,7 @@ json.night_attendees do
 end
 
 json.absentees do
-  json.array! @attendances.where(present: false) do |attendance|
+  json.array! @attendances.absent do |attendance|
     json.attendance_id attendance.id
     json.member_id attendance.member_id
     json.name attendance.member.name


### PR DESCRIPTION
## Issue
- #323 

## 概要
出席を時間帯で絞り込む際にコードが重複していたため、Attendanceモデルに絞り込みを行うスコープを追加して、そのスコープを利用するようにした。


