### PR TITLE
URLを返す処理をCourseモデルに持たせるようにした

### DIFF
--- a/app/helpers/minutes_helper.rb
+++ b/app/helpers/minutes_helper.rb
@@ -2,7 +2,6 @@
 
 module MinutesHelper
   def github_wiki_url(minute)
-    repository_url = minute.course.name == 'Railsエンジニアコース' ? ENV.fetch('BOOTCAMP_WIKI_URL', nil) : ENV.fetch('AGENT_WIKI_URL', nil)
-    URI.join(repository_url.sub('.wiki.git', '/wiki/'), URI.encode_www_form_component(minute.title)).to_s
+    URI.join(minute.course.wiki_repository_url.sub('.wiki.git', '/wiki/'), URI.encode_www_form_component(minute.title)).to_s
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -13,4 +13,8 @@ class Course < ApplicationRecord
   def repository_url
     { 'Railsエンジニアコース' => 'https://github.com/fjordllc/bootcamp', 'フロントエンドエンジニアコース' => 'https://github.com/fjordllc/agent' }[name]
   end
+
+  def wiki_repository_url
+    { 'Railsエンジニアコース' => ENV.fetch('BOOTCAMP_WIKI_URL', nil), 'フロントエンドエンジニアコース' => ENV.fetch('AGENT_WIKI_URL', nil) }[name]
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -17,4 +17,8 @@ class Course < ApplicationRecord
   def wiki_repository_url
     { 'Railsエンジニアコース' => ENV.fetch('BOOTCAMP_WIKI_URL', nil), 'フロントエンドエンジニアコース' => ENV.fetch('AGENT_WIKI_URL', nil) }[name]
   end
+
+  def discord_webhook_url
+    { 'Railsエンジニアコース' => ENV.fetch('RAILS_COURSE_CHANNEL_URL', nil), 'フロントエンドエンジニアコース' => ENV.fetch('FRONT_END_COURSE_CHANNEL_URL', nil) }[name]
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -9,4 +9,8 @@ class Course < ApplicationRecord
   def meeting_years
     minutes.map { |minute| minute.meeting_date.year }.uniq
   end
+
+  def repository_url
+    { 'Railsエンジニアコース' => 'https://github.com/fjordllc/bootcamp', 'フロントエンドエンジニアコース' => 'https://github.com/fjordllc/agent' }[name]
+  end
 end

--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -55,8 +55,7 @@ class MarkdownBuilder
   end
 
   def rewrite_issue_number_as_link(progress_report)
-    repository_url = @minute.course.name == 'Railsエンジニアコース' ? 'https://github.com/fjordllc/bootcamp' : 'https://github.com/fjordllc/agent'
-    progress_report.gsub(/#(\d+)/, "[#\\1](#{repository_url}/issues/\\1)")
+    progress_report.gsub(/#(\d+)/, "[#\\1](#{@minute.course.repository_url}/issues/\\1)")
   end
 
   def member_link(name)

--- a/app/models/meeting_secretary.rb
+++ b/app/models/meeting_secretary.rb
@@ -25,7 +25,7 @@ class MeetingSecretary
 
     new_minute = @course.minutes.create!(meeting_date:, next_meeting_date:)
     leave_log("create_minute, #{@course.name}, executed")
-    Discord::Notifier.message(NotificationMessageBuilder.build(:minute_creation, @course, new_minute), url: webhook_url)
+    Discord::Notifier.message(NotificationMessageBuilder.build(:minute_creation, @course, new_minute), url: @course.discord_webhook_url)
   end
 
   def create_first_minute
@@ -41,7 +41,7 @@ class MeetingSecretary
 
     new_minute = @course.minutes.create!(meeting_date:, next_meeting_date:)
     leave_log("create_first_minute, #{@course.name}, executed")
-    Discord::Notifier.message(NotificationMessageBuilder.build(:minute_creation, @course, new_minute), url: webhook_url)
+    Discord::Notifier.message(NotificationMessageBuilder.build(:minute_creation, @course, new_minute), url: @course.discord_webhook_url)
   end
 
   def notify_today_meeting
@@ -61,7 +61,7 @@ class MeetingSecretary
       return
     end
 
-    Discord::Notifier.message(NotificationMessageBuilder.build(:today_meeting, @course, latest_minute), url: webhook_url)
+    Discord::Notifier.message(NotificationMessageBuilder.build(:today_meeting, @course, latest_minute), url: @course.discord_webhook_url)
     leave_log("notify_today_meeting, #{@course.name}, executed")
     latest_minute.update!(notified_at: Time.zone.now)
   end
@@ -80,10 +80,6 @@ class MeetingSecretary
     minute_content = File.read(File.join(repository_path, filename))
     _, year, month, day = *minute_content.match(/# 次回のMTG\n\n- (\d{4})年(\d{2})月(\d{2})日/)
     Time.zone.local(year.to_i, month.to_i, day.to_i)
-  end
-
-  def webhook_url
-    @course.name == 'Railsエンジニアコース' ? ENV.fetch('RAILS_COURSE_CHANNEL_URL', nil) : ENV.fetch('FRONT_END_COURSE_CHANNEL_URL', nil)
   end
 
   def leave_log(message)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe Course, type: :model do
       expect(FactoryBot.build(:front_end_course).wiki_repository_url).to eq 'https://example.com/fjordllc/agent-wiki.wiki.git'
     end
   end
+
+  describe '#discord_webhook_url' do
+    before do
+      allow(ENV).to receive(:fetch).with('RAILS_COURSE_CHANNEL_URL', nil).and_return('https://discord.com/api/webhooks/111/abcdef')
+      allow(ENV).to receive(:fetch).with('FRONT_END_COURSE_CHANNEL_URL', nil).and_return('https://discord.com/api/webhooks/222/ghijkl')
+    end
+
+    it 'returns Discord webhook URL for each course' do
+      expect(FactoryBot.build(:rails_course).discord_webhook_url).to eq 'https://discord.com/api/webhooks/111/abcdef'
+      expect(FactoryBot.build(:front_end_course).discord_webhook_url).to eq 'https://discord.com/api/webhooks/222/ghijkl'
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -13,4 +13,11 @@ RSpec.describe Course, type: :model do
       expect(course.meeting_years).to contain_exactly(2024, 2025, 2026)
     end
   end
+
+  describe '#repositoory_url' do
+    it 'returns GitHub repository URL for each course' do
+      expect(FactoryBot.build(:rails_course).repository_url).to eq 'https://github.com/fjordllc/bootcamp'
+      expect(FactoryBot.build(:front_end_course).repository_url).to eq 'https://github.com/fjordllc/agent'
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -20,4 +20,16 @@ RSpec.describe Course, type: :model do
       expect(FactoryBot.build(:front_end_course).repository_url).to eq 'https://github.com/fjordllc/agent'
     end
   end
+
+  describe '#wiki_repository_url' do
+    before do
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL', nil).and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
+    end
+
+    it 'returns GitHub Wiki repository URL for each course' do
+      expect(FactoryBot.build(:rails_course).wiki_repository_url).to eq 'https://example.com/fjordllc/bootcamp-wiki.wiki.git'
+      expect(FactoryBot.build(:front_end_course).wiki_repository_url).to eq 'https://example.com/fjordllc/agent-wiki.wiki.git'
+    end
+  end
 end

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -278,6 +278,7 @@ RSpec.describe 'Minutes', type: :system do
     scenario 'display github wiki link when the minute is exported' do
       # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
       allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL', nil).and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
 
       exported_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 1), exported: true, course: rails_course)
       not_exported_minute = FactoryBot.create(:minute, meeting_date: Time.zone.local(2024, 1, 15), course: rails_course)


### PR DESCRIPTION
## Issue
- #323 

## 概要
コースごとに異なるURLを返す処理を、コースモデルのインスタンスメソッドとして呼べるようにした。
URLの種類は以下の三つ。

- リポジトリのURL
- GitHub WikiリポジトリのURL
- Discord WebhookのURL


