### PR TITLE
日付のフォーマットにI18nを利用するように修正

### DIFF
--- a/app/models/markdown_builder.rb
+++ b/app/models/markdown_builder.rb
@@ -70,8 +70,7 @@ class MarkdownBuilder
   end
 
   def next_date
-    day_of_the_week = %w[日 月 火 水 木 金 土][@minute.next_meeting_date.wday]
-    meeting_date = "#{@minute.next_meeting_date.strftime('%Y年%m月%d日')}(#{day_of_the_week})"
+    meeting_date = I18n.l(@minute.next_meeting_date, format: :long)
     return "- #{meeting_date}" unless HolidayJp.holiday?(@minute.next_meeting_date)
 
     holiday_name = HolidayJp.between(@minute.next_meeting_date, @minute.next_meeting_date).first.name

--- a/app/models/meeting_secretary.rb
+++ b/app/models/meeting_secretary.rb
@@ -76,7 +76,7 @@ class MeetingSecretary
   end
 
   def get_next_meeting_date_from_cloned_minutes(meeting_date, repository_path)
-    filename = "ふりかえり・計画ミーティング#{meeting_date.strftime('%Y年%m月%d日')}.md"
+    filename = "ふりかえり・計画ミーティング#{I18n.l(meeting_date)}.md"
     minute_content = File.read(File.join(repository_path, filename))
     _, year, month, day = *minute_content.match(/# 次回のMTG\n\n- (\d{4})年(\d{2})月(\d{2})日/)
     Time.zone.local(year.to_i, month.to_i, day.to_i)

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -10,6 +10,6 @@ class Minute < ApplicationRecord
   end
 
   def title
-    "ふりかえり・計画ミーティング#{meeting_date.strftime('%Y年%m月%d日')}"
+    "ふりかえり・計画ミーティング#{I18n.l(meeting_date)}"
   end
 end

--- a/app/models/notification_message_builder.rb
+++ b/app/models/notification_message_builder.rb
@@ -15,7 +15,7 @@ class NotificationMessageBuilder
 
   def build(course, minute)
     ERB.new(@template)
-       .result_with_hash({ role_id:, course_name: course.name, meeting_date: formatted_date(minute.meeting_date), url: new_minute_attendance_url(minute) })
+       .result_with_hash({ role_id:, course_name: course.name, meeting_date: I18n.l(minute.meeting_date, format: :long), url: new_minute_attendance_url(minute) })
   end
 
   private
@@ -26,10 +26,5 @@ class NotificationMessageBuilder
 
   def role_id
     ENV.fetch('TEAM_MEMBER_ROLE_ID', nil).to_i
-  end
-
-  def formatted_date(date)
-    day_of_the_week = %w[日 月 火 水 木 金 土][date.wday]
-    "#{date.strftime('%Y年%m月%d日')}(#{day_of_the_week})"
   end
 end

--- a/app/views/attendances/edit.html.erb
+++ b/app/views/attendances/edit.html.erb
@@ -8,7 +8,7 @@
 
 <div class="page_body">
   <div>
-    <p class="text-lg text-center"><%= @attendance_form.attendance.minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を編集</p>
+    <p class="text-lg text-center"><%= l(@attendance_form.attendance.minute.meeting_date) %>のMTGの出席予定を編集</p>
 
     <%= form_with(model: @attendance_form, **@attendance_form.form_with_options, id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance_form.errors.any? %>

--- a/app/views/minutes/attendances/new.html.erb
+++ b/app/views/minutes/attendances/new.html.erb
@@ -8,7 +8,7 @@
 
 <div class="page_body">
   <div>
-    <p class="text-lg text-center"><%= @minute.meeting_date.strftime('%Y年%m月%d日') %>のMTGの出席予定を登録</p>
+    <p class="text-lg text-center"><%= l(@minute.meeting_date) %>のMTGの出席予定を登録</p>
 
     <%= form_with(model: [ @minute, @attendance_form ], **@attendance_form.form_with_options, id: "attendance_form", class: "contents") do |form| %>
       <% if @attendance_form.errors.any? %>

--- a/app/views/shared/_attendance_table.html.erb
+++ b/app/views/shared/_attendance_table.html.erb
@@ -2,11 +2,11 @@
   <dl class="flex flex-wrap gap-x-0 gap-y-1">
     <% attendances.each do |attendance| %>
       <div class="flex flex-col justify-center items-center text-center -mr-[1px]">
-        <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]" data-attendance-on="<%= attendance[:date].strftime('%Y-%m-%d') %>">
-          <%= attendance[:date].strftime('%m/%d') %>
+        <dt class="bg-blue-100 p-1 text-sm border border-gray-400 w-12 -mb-[1px]" data-attendance-on="<%= l(attendance[:date], format: :ymd_hyphen) %>">
+          <%= l(attendance[:date], format: :short) %>
         </dt>
         <% background_color = attendance[:present].nil? ? 'bg-gray-200' : 'bg-white' %>
-        <dd class="p-1 text-sm border border-gray-400 w-12 text-center <%= background_color %>" data-attendance-on="<%= attendance[:date].strftime('%Y-%m-%d') %>">
+        <dd class="p-1 text-sm border border-gray-400 w-12 text-center <%= background_color %>" data-attendance-on="<%= l(attendance[:date], format: :ymd_hyphen) %>">
           <% if attendance[:present] == false %>
             <span data-tooltip-target="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>">欠席</span>
             <div id="<%= "absence_reason_for_attendance_#{attendance[:attendance_id]}" %>" role="tooltip" class="absolute z-10 invisible inline-block px-3 py-2 text-sm font-medium text-white transition-opacity duration-300 bg-gray-700 rounded-lg shadow-sm opacity-0 tooltip">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -109,9 +109,10 @@ ja:
       - 金曜日
       - 土曜日
     formats:
-      default: "%Y/%m/%d"
+      default: "%Y年%m月%d日"
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
+      ymd_hyphen: "%Y-%m-%d"
     month_names:
       -
       - 1月


### PR DESCRIPTION
## Issue
- #323 

## 概要
Pull Requestの概要を記載。

## Screenshot
日付のフォーマットに`strftime`を利用していたが、多言語対応がしづらいため`I18n.l`を利用するようにした。

[Rails 国際化（I18n）API \- Railsガイド](https://railsguides.jp/i18n.html#%E6%97%A5%E4%BB%98%E3%83%BB%E6%99%82%E5%88%BB%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%83%E3%83%88%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%99%E3%82%8B)
