### PR TITLE
レコードの存在確認をany?ではなくexists?で行うように修正

### DIFF
--- a/app/controllers/minutes/attendances_controller.rb
+++ b/app/controllers/minutes/attendances_controller.rb
@@ -26,7 +26,7 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   end
 
   def already_registered_attendance
-    @minute.attendances.where(member_id: current_member.id).any?
+    @minute.attendances.exists?(member_id: current_member.id)
   end
 
   def redirect_admin_access
@@ -34,7 +34,7 @@ class Minutes::AttendancesController < Minutes::ApplicationController
   end
 
   def prohibit_duplicate_access
-    redirect_to edit_minute_url(@minute), alert: t('.failure.duplicate_access') if @minute.attendances.where(member_id: current_member.id).any?
+    redirect_to edit_minute_url(@minute), alert: t('.failure.duplicate_access') if @minute.attendances.exists?(member_id: current_member.id)
   end
 
   def prohibit_access_to_finished_minute

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -24,7 +24,7 @@ class Member < ApplicationRecord
   end
 
   def hibernated?
-    hibernations.where(finished_at: nil).any?
+    hibernations.exists?(finished_at: nil)
   end
 
   def all_attendances
@@ -49,6 +49,6 @@ class Member < ApplicationRecord
   end
 
   def was_hibernated?
-    hibernations.where.not(finished_at: nil).any?
+    hibernations.where.not(finished_at: nil).exists?
   end
 end

--- a/app/views/courses/members/_status_tab.html.erb
+++ b/app/views/courses/members/_status_tab.html.erb
@@ -1,5 +1,5 @@
 <div id="status_tab" class="mb-8">
-  <% if course.members.any? %>
+  <% if course.members.exists? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <li class="me-2">
         <%= link_to '現役', course_members_path(course, status: 'active'), class: active_tab == 'active' ? 'active_small_tab_item' : 'inactive_small_tab_item' %>

--- a/app/views/courses/minutes/_years_tab.html.erb
+++ b/app/views/courses/minutes/_years_tab.html.erb
@@ -1,5 +1,5 @@
 <div id="years_tab" class="mb-8">
-  <% if course.minutes.any? %>
+  <% if course.minutes.exists? %>
     <ul class="flex flex-wrap text-sm font-medium text-center text-gray-500 pl-0 !list-none">
       <% course.meeting_years.sort.each do |year| %>
         <li class="me-2">


### PR DESCRIPTION
## Issue
- #323 

## 概要
あるレコードが存在しているかどうかを確認する際`any?`よりも`exists?`の方が明確であるため、`exists?`を利用するように修正した。

## 備考
以下のケースはそのまま`any?`を利用している。
- フォームでエラーの存在確認
- 存在条件をブロックで渡している箇所(AttendancesHelper#L:13)
