### PR TITLE
ログイン時にキャンセルを選択した場合エラー画面が出る問題を修正

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -27,15 +27,8 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
     end
   end
 
-  # OmniAuthエラー時の処理は、Deviseで実装されている処理をそのまま追加
-  # https://github.com/heartcombo/devise/blob/72884642f5700439cc96ac560ee19a44af5a2d45/app/controllers/devise/omniauth_callbacks_controller.rb#L6
-  def passthru
-    render status: :not_found, plain: 'Not found. Authentication passthru.'
-  end
-
   def failure
-    set_flash_message! :alert, :failure, kind: OmniAuth::Utils.camelize(failed_strategy.name), reason: failure_message
-    redirect_to root_path
+    redirect_to root_path, alert: t('.failure')
   end
 
   private
@@ -43,23 +36,5 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
   def admin?(email)
     admin_emails = [ENV.fetch('KOMAGATA_EMAIL', 'no_email'), ENV.fetch('MACHIDA_EMAIL', 'no_email'), ENV.fetch('KASSY_EMAIL', 'no_email')]
     admin_emails.include? email
-  end
-
-  protected
-
-  def failed_strategy
-    request.respond_to?(:get_header) ? request.get_header('omniauth.error.strategy') : request.env['omniauth.error.strategy']
-  end
-
-  def failure_message
-    exception = request.respond_to?(:get_header) ? request.get_header('omniauth.error') : request.env['omniauth.error']
-    error   = exception.error_reason if exception.respond_to?(:error_reason)
-    error ||= exception.error        if exception.respond_to?(:error)
-    error ||= (request.respond_to?(:get_header) ? request.get_header('omniauth.error.type') : request.env['omniauth.error.type']).to_s
-    error.to_s.humanize if error # rubocop:disable Style/SafeNavigation
-  end
-
-  def translation_scope
-    'devise.omniauth_callbacks'
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer, fields: [ :email, :nickname, :image ], uid_field: :email if Rails.env.development?
   provider :github, ENV["AUTH_APP_ID"], ENV["AUTH_APP_SECRET"]
-  on_failure { |env| AuthenticationsController.action(:failure).call(env) }
+  on_failure { |env| OmniAuth::FailureEndpoint.new(env).redirect_to_failure }
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -77,6 +77,8 @@ ja:
     update:
       success: 出席予定を更新しました
       failure: 終了したミーティングの出席予定は変更できません
+  authentications:
+    failure: GitHub アカウントによる認証に失敗しました。
   date:
     abbr_day_names:
       - 日

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   devise_for :admins, skip: :all
   devise_scope :member do
     get "/auth/:provider/callback" => "authentications#create"
+    get "/auth/failure" => "authentications#failure"
     delete "logout", to: "members/sessions#destroy", as: "logout"
   end
 


### PR DESCRIPTION
## Issue
- #323 

## 概要
ログイン時にGitHubの認証画面でcancelを押すと以下のエラーが発生するようになっていたため、このエラーが発生しないように修正した。

![8E46D88F-DF58-4598-9276-F84DEB3B64FB](https://github.com/user-attachments/assets/d8e3cc4f-d303-40f5-be01-168b09f93c3f)


## Screenshot
[![Image from Gyazo](https://i.gyazo.com/20535f74ab00da6b1e4910264998f878.gif)](https://gyazo.com/20535f74ab00da6b1e4910264998f878)

