### PR TITLE
.netrcファイルが作成されているか確認するコードを追加

### DIFF
--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -27,6 +27,13 @@ class MinuteGithubExporter
     commit_minute_markdown(minute)
 
     create_credential_file(access_token)
+
+    # TODO: デバッグが完了したらこの箇所は削除する
+    Rails.logger.info('-------- debug start --------')
+    Rails.logger.info(`ls -a | grep netrc`)
+    Rails.logger.info(`cat .netrc`)
+    Rails.logger.info('-------- debug finish --------')
+
     @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
   end
 


### PR DESCRIPTION
## Issue
なし

関連PR : #340 

## 概要
本番環境で以下の問題が発生するようになったため、`.netrc`ファイルを確認するデバッグのコードを追加した。

議事録をGitHub Wikiにエクスポートすると、`remote: Permission to Kassy0220/example-bootcamp-wiki.wiki.git denied to Kassy0220.\nfatal: unable to access 'https://github.com/Kassy0220/example-bootcamp-wiki.wiki.git/': The requested URL returned error: 403"`というエラーが発生する。