### PR TITLE
GitHub Wikiにpushする毎に、.netrcファイルを作り直すようにした

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -6,7 +6,7 @@ class ExportsController < ApplicationController
   def create
     current_admin.initialize_github_credential(params['code'])
     minute = Minute.find(params['state'])
-    MinuteGithubExporter.export_to_github_wiki(minute, current_admin.github_credential.access_token)
+    MinuteGithubExporter.export_to_github_wiki(minute, current_admin.name, current_admin.github_credential.access_token)
     minute.update!(exported: true) unless minute.exported?
     redirect_to course_minutes_path(minute.course), notice: t('.success')
   end

--- a/app/controllers/minutes/exports_controller.rb
+++ b/app/controllers/minutes/exports_controller.rb
@@ -6,7 +6,7 @@ class Minutes::ExportsController < Minutes::ApplicationController
   def create
     current_admin.github_credential.update_access_token if current_admin.github_credential.expired?
 
-    MinuteGithubExporter.export_to_github_wiki(@minute, current_admin.github_credential.access_token)
+    MinuteGithubExporter.export_to_github_wiki(@minute, current_admin.name, current_admin.github_credential.access_token)
     @minute.update!(exported: true) unless @minute.exported?
     redirect_to course_minutes_path(@minute.course), notice: 'GitHub Wikiに議事録を反映させました'
   end

--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -4,8 +4,8 @@ class MinuteGithubExporter
   CLONED_BOOTCAMP_WIKI_PATH = Rails.root.join('bootcamp_wiki_repository').freeze
   CLONED_AGENT_WIKI_PATH = Rails.root.join('agent_wiki_repository').freeze
 
-  def self.export_to_github_wiki(minute, access_token)
-    new(minute.course).commit_and_push(minute, access_token)
+  def self.export_to_github_wiki(minute, github_account_name, access_token)
+    new(minute.course).commit_and_push(minute, github_account_name, access_token)
   end
 
   attr_reader :working_directory
@@ -21,12 +21,12 @@ class MinuteGithubExporter
            end
   end
 
-  def commit_and_push(minute, access_token)
+  def commit_and_push(minute, github_account_name, access_token)
     @git.pull
     set_github_account
     commit_minute_markdown(minute)
 
-    create_credential_file(access_token)
+    create_credential_file(github_account_name, access_token)
     @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
   end
 
@@ -45,13 +45,12 @@ class MinuteGithubExporter
     @git.commit("#{filename} committed")
   end
 
-  def create_credential_file(access_token)
+  def create_credential_file(github_account_name, access_token)
     credential_file_path = Rails.root.join('.netrc')
-    return if File.exist?(credential_file_path)
 
     content = <<~CREDENTIAL
       machine github.com
-      login #{ENV.fetch('GITHUB_USER_NAME', nil)}
+      login #{github_account_name}
       password #{access_token}
     CREDENTIAL
 

--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -27,7 +27,11 @@ class MinuteGithubExporter
     commit_minute_markdown(minute)
 
     create_credential_file(github_account_name, access_token)
-    @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
+    begin
+      @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
+    ensure
+      File.delete('.netrc')
+    end
   end
 
   private

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe 'Minutes', type: :system do
 
         # GitHub Wikiリポジトリにpushされないようにする
         allow(MinuteGithubExporter).to receive(:export_to_github_wiki).and_call_original
-        allow(MinuteGithubExporter).to receive(:export_to_github_wiki).with(minute, admin.github_credential.access_token).and_return(nil)
+        allow(MinuteGithubExporter).to receive(:export_to_github_wiki).with(minute, admin.name, admin.github_credential.access_token).and_return(nil)
 
         login_as_admin admin
         visit minute_path(minute)


### PR DESCRIPTION
## Issue
- #329 

## 概要
以下のようなケースに対応するため、GitHub Wikiにpushする毎にそのユーザーの認証情報を記述した`.netrc`ファイルを作成するようにした。

伊藤さんのご指摘。

> ユーザーAが最初に .netrc を作成すると、以後はAの .netrc が残り続け、ユーザーBが操作しようとした場合はBのaccess_tokenが使われずに権限エラーが起きる、というシナリオがありうるのでは？と思いました。

これに関連して、GitHub Wikiにpushする処理が成功しようとしまいと、`.netrc`を削除する処理を実行するようにしている。
