### PR TITLE
テストが落ちてしまう対策として、headfulなchromeでテストを実行するようにした

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,14 @@ jobs:
       - name: Prepare asset
         run: bundle exec rake assets:precompile
       - name: setup chrome and chromedriver
+        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 132.0.6834.159
           install-chromedriver: true
       - name: Check Chromedriver version
         run: chromedriver --version
+      - name: check chrome installed path
+        run: ${{ steps.setup-chrome.outputs.chrome-path }}
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,10 @@ jobs:
         run: bin/rails db:schema:load
       - name: Prepare asset
         run: bundle exec rake assets:precompile
+      - name: setup chromedriver
+        uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: '132.0.6834.159'
       - name: Check Chromedriver version
         run: chromedriver --version
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,7 @@ jobs:
         run: bin/rails db:schema:load
       - name: Prepare asset
         run: bundle exec rake assets:precompile
+      - name: Check Chromedriver version
+        run: chromedriver --version
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,14 +52,13 @@ jobs:
       - name: Prepare asset
         run: bundle exec rake assets:precompile
       - name: setup chrome and chromedriver
-        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: 132.0.6834.159
           install-chromedriver: true
+      - name: Check Chrome version
+        run: chrome --version
       - name: Check Chromedriver version
         run: chromedriver --version
-      - name: check chrome installed path
-        run: ${{ steps.setup-chrome.outputs.chrome-path }}
       - name: Run tests
         run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,11 @@ jobs:
         run: bin/rails db:schema:load
       - name: Prepare asset
         run: bundle exec rake assets:precompile
-      - name: setup chromedriver
-        uses: nanasess/setup-chromedriver@v2
+      - name: setup chrome and chromedriver
+        uses: browser-actions/setup-chrome@v1
         with:
-          chromedriver-version: '132.0.6834.159'
+          chrome-version: 132.0.6834.159
+          install-chromedriver: true
       - name: Check Chromedriver version
         run: chromedriver --version
       - name: Run tests

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,6 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium_chrome
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,8 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium_chrome_headless do |options|
+      options.browser_version = '132.0.6834.159'
+    end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,7 +3,7 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium, using: :chrome
-    options = Selenium::WebDriver::Options.chrome
+    options = Selenium::WebDriver::Chrome::Options.new(args: ['user-data-dir=/tmp/temp_profile'])
     options.browser_version = '132.0.6834.159'
     options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,9 +2,9 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless do |options|
-      options.browser_version = '132.0.6834.159'
-      options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
-    end
+    driven_by :selenium, using: :chrome
+    options = Selenium::WebDriver::Options.chrome
+    options.browser_version = '132.0.6834.159'
+    options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,6 +4,7 @@ RSpec.configure do |config|
   config.before(:each, type: :system) do
     driven_by :selenium_chrome_headless do |options|
       options.browser_version = '132.0.6834.159'
+      options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,9 +2,11 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium, using: :chrome
-    options = Selenium::WebDriver::Chrome::Options.new(args: ['user-data-dir=/tmp/temp_profile'])
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('user-data-dir=/tmp/temp_profile')
     options.browser_version = '132.0.6834.159'
     options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
+
+    driven_by :selenium, using: :chrome, options: { browser: :chrome, options: options }
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,7 +3,6 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
     options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('user-data-dir=/tmp/temp_profile')
     options.browser_version = '132.0.6834.159'
     options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,10 +2,7 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.browser_version = '132.0.6834.159'
-    options.binary = '/opt/hostedtoolcache/setup-chrome/chromium/132.0.6834.159/x64/chrome'
-
-    driven_by :selenium, using: :chrome, options: { browser: :chrome, options: options }
+    Selenium::WebDriver.logger.ignore(:clear_local_storage, :clear_session_storage)
+    driven_by :selenium, using: :headless_firefox
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,6 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome
+    driven_by :selenium_chrome_headless
   end
 end


### PR DESCRIPTION
## Issue
なし

## 概要
chromedriverのバージョンを133以降に更新してから、ローカル・CI上でテストが落ちるようになってしまった。
この対策としてheadfulなchromeをテストで使用するようにした。

参考 : https://bootcamp.fjord.jp/questions/2006
