### PR TITLE
システムテストでFirefoxを使用するように変更

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,6 +2,7 @@
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    Selenium::WebDriver.logger.ignore(:clear_local_storage, :clear_session_storage)
+    driven_by :selenium, using: :headless_firefox
   end
 end


### PR DESCRIPTION
## Issue
- #346 

## 概要
chromedriverのバージョンを上げるとsystem testが失敗するようになったため、system testでヘッドレスFirefoxを使用するようにした。

## Screenshot
ローカルでテスト実行時のリザルト。

![412E07C7-4794-4EFF-B12C-8569C0B8A061_4_5005_c](https://github.com/user-attachments/assets/dadd53dd-388d-4d3d-942d-4493b0c57950)

