### PR TITLE
不要なファイルの権限変更を削除した

### DIFF
--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -61,7 +61,6 @@ class MinuteGithubExporter
     File.open(credential_file_path, 'w+') do |file|
       file.puts content
     end
-    File.chmod(0o400, credential_file_path)
   end
 
   def rails_course?


### PR DESCRIPTION
## Issue
なし

## 概要
GitHub Wikiにpushする際の認証ファイル(`.netrc`)が他のユーザーから扱えないように当ファイルの権限を変更するようにしていたが、pushが行われた後そのファイルを削除するように変更されたことに伴い権限の変更も必要がなくなったため、この処理を削除した。
