### PR TITLE
デバッグのため、.netrcファイルの中身をログに出力するように変更

### DIFF
--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -27,6 +27,10 @@ class MinuteGithubExporter
     commit_minute_markdown(minute)
 
     create_credential_file(github_account_name, access_token)
+    Rails.logger.info('debug start -----------------------------')
+    Rails.logger.info(`cat #{Rails.root.join('.netrc')}`)
+    Rails.logger.info(`wc #{Rails.root.join('.netrc')}`)
+    Rails.logger.info('debug finish -----------------------------')
     begin
       @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
     ensure


### PR DESCRIPTION
## Issue
- #329 

## 概要
開発環境と本番環境で`.netrc`ファイルに差があるかどうかを確認するため、`.netrc`ファイルの中身と文字数・行数・バイト数を表示するようにした。
