### PR TITLE
ホームディレクトリの.netrcファイルの中身をログに出力するようにした

### DIFF
--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -28,8 +28,8 @@ class MinuteGithubExporter
 
     create_credential_file(github_account_name, access_token)
     Rails.logger.info('debug start -----------------------------')
-    Rails.logger.info(`cat #{Rails.root.join('.netrc')}`)
-    Rails.logger.info(`wc #{Rails.root.join('.netrc')}`)
+    Rails.logger.info(`cat ~/.netrc`)
+    Rails.logger.info(`wc ~/.netrc`)
     Rails.logger.info('debug finish -----------------------------')
     begin
       @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster


### PR DESCRIPTION
## Issue
- #329 

## 概要
`.netrc`ファイルはホームディレクトリに作成することが適切であるため、ホームディレクトリにある`.netrc`ファイルをログに出力するようにした。
