### PR TITLE
.netrcファイルの中身をログに出力するコードを削除

### DIFF
--- a/app/models/minute_github_exporter.rb
+++ b/app/models/minute_github_exporter.rb
@@ -27,10 +27,6 @@ class MinuteGithubExporter
     commit_minute_markdown(minute)
 
     create_credential_file(github_account_name, access_token)
-    Rails.logger.info('debug start -----------------------------')
-    Rails.logger.info(`cat ~/.netrc`)
-    Rails.logger.info(`wc ~/.netrc`)
-    Rails.logger.info('debug finish -----------------------------')
     begin
       @git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
     ensure


### PR DESCRIPTION
## Issue
なし

## 概要
#329 にて、本番環境で`git push`できない問題を調査するために追加したコードを削除した。

