### PR TITLE
AuthenticationsController内でURLヘルパーメソッドの使用を統一

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -23,7 +23,7 @@ class AuthenticationsController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success_with_hibernation)
     else
       session['devise.github_data'] = request.env['omniauth.auth'].except(:extra)
-      redirect_to root_url
+      redirect_to root_path
     end
   end
 


### PR DESCRIPTION
## Issue
- #323 

## 概要
AuthenticationsController内で`root_path`と`root_url`の二種類を使用していたため、`root_path`を使用するように統一した。