### PR TITLE
APIコントローラーが返すJSONのデータに制限をかけるようにした

### DIFF
--- a/app/controllers/api/minutes/topics_controller.rb
+++ b/app/controllers/api/minutes/topics_controller.rb
@@ -5,7 +5,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
     topic = current_development_member.topics.new(topic_params)
     topic.minute_id = @minute.id
     if topic.save
-      render json: topic, status: :created
+      render json: topic.as_json(root: 'topic', only: [:id]), status: :created
       broadcast_to_channel
     else
       render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity
@@ -15,7 +15,7 @@ class API::Minutes::TopicsController < API::Minutes::ApplicationController
   def update
     topic = current_development_member.topics.find(params[:id])
     if topic.update(topic_params)
-      render json: topic, status: :ok
+      render json: topic.as_json(root: 'topic', only: [:id]), status: :ok
       broadcast_to_channel
     else
       render json: { errors: topic.errors.full_messages }, status: :unprocessable_entity

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -7,7 +7,7 @@ class API::MinutesController < API::BaseController
     minute = Minute.find(params[:id])
 
     if minute.update(minute_params)
-      render json: minute, status: :ok
+      render json: minute.as_json(root: 'minute', only: [:id]), status: :ok
       MinuteChannel.broadcast_to(minute, body: { minute: minute.as_json(only: %i[release_branch release_note other next_meeting_date]) })
     else
       render json: { errors: minute.errors.full_messages }, status: :unprocessable_entity


### PR DESCRIPTION
## Issue
- #323 

## 概要
APIコントローラーのレスポンスとして返されるJSONがモデルの全てのカラムを返すようになっていたため、リソースのIDのみを返すように修正した。

## Screenshot
### 修正前
`API::MinutesController`のレスポンス。
![C36A833F-94EB-4BDA-A80C-4FDC1EDAC953](https://github.com/user-attachments/assets/3e565421-4976-43c8-8c05-0fe01a36bec8)

`API::Minutes::TopicsController`のレスポンス。
![0A0138FA-01EF-49BF-8D27-46263B8B4674_4_5005_c](https://github.com/user-attachments/assets/9da411be-36a7-4a82-b9c2-aeca886eff69)


### 修正後
`API::MinutesController`のレスポンス。
![A930DB77-CFF4-4665-B102-721FBD070D07](https://github.com/user-attachments/assets/b98aba9c-b4a7-40b3-9787-95b2f9a4694e)

`API::Minutes::TopicsController`のレスポンス。
![9A65C307-C581-41D8-974F-28002F58C46A](https://github.com/user-attachments/assets/1f5a4e4f-7104-4544-9642-ce22363aac2d)

