### PR TITLE
GitHub Wikiにpushする処理の問題点を修正

### DIFF
--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -49,7 +49,7 @@ class Minute < ApplicationRecord
   def wiki_repository_url
     token = create_install_access_token
     url = rails_course? ? ENV.fetch('BOOTCAMP_WIKI_URL') : ENV.fetch('AGENT_WIKI_URL')
-    url.sub(%r{(https://)(github\.com.+)}, "\\1x-access-token:#{token}@\\2")
+    url.sub(%r{(?<=^https://)}, "x-access-token:#{token}@")
   end
 
   def create_install_access_token

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -4,6 +4,8 @@ class Minute < ApplicationRecord
   CLONED_BOOTCAMP_WIKI_PATH = Rails.root.join('bootcamp_wiki_repository').freeze
   CLONED_AGENT_WIKI_PATH = Rails.root.join('agent_wiki_repository').freeze
   DEFAULT_BRANCH_FOR_GITHUB_WIKI = 'master'
+  CLOCK_DRIFT_BUFFER = 60
+  TOKEN_EXPIRATION_TIME = 600
   TEMPLATE_PATH = 'config/templates/minute.md'
 
   belongs_to :meeting
@@ -55,8 +57,8 @@ class Minute < ApplicationRecord
   def create_install_access_token
     private_key = OpenSSL::PKey::RSA.new(Rails.application.credentials.github_app_private_key)
     payload = {
-      iat: Time.now.to_i - 60,
-      exp: Time.now.to_i + (10 * 60),
+      iat: Time.now.to_i - CLOCK_DRIFT_BUFFER,
+      exp: Time.now.to_i + TOKEN_EXPIRATION_TIME,
       iss: ENV.fetch('GITHUB_APP_ID')
     }
     jwt = JWT.encode(payload, private_key, 'RS256')

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -20,8 +20,8 @@ class Minute < ApplicationRecord
     # インストールアクセストークンを更新するため、ワーキングディレクトリが残っていれば削除する
     FileUtils.rm_r(working_directory) if File.exist?(working_directory)
     git = Git.clone(wiki_repository_url, working_directory, log: Logger.new($stdout))
-    git.config('user.name', ENV.fetch('GITHUB_USER_NAME', nil))
-    git.config('user.email', ENV.fetch('GITHUB_USER_EMAIL', nil))
+    git.config('user.name', ENV.fetch('GITHUB_USER_NAME'))
+    git.config('user.email', ENV.fetch('GITHUB_USER_EMAIL'))
 
     filename = "#{title}.md"
     File.write(File.join(working_directory, filename), to_markdown)
@@ -48,7 +48,7 @@ class Minute < ApplicationRecord
 
   def wiki_repository_url
     token = create_install_access_token
-    url = rails_course? ? ENV.fetch('BOOTCAMP_WIKI_URL', nil) : ENV.fetch('AGENT_WIKI_URL', nil)
+    url = rails_course? ? ENV.fetch('BOOTCAMP_WIKI_URL') : ENV.fetch('AGENT_WIKI_URL')
     url.sub(%r{(https://)(github\.com.+)}, "\\1x-access-token:#{token}@\\2")
   end
 
@@ -57,12 +57,12 @@ class Minute < ApplicationRecord
     payload = {
       iat: Time.now.to_i - 60,
       exp: Time.now.to_i + (10 * 60),
-      iss: ENV.fetch('GITHUB_APP_ID', nil)
+      iss: ENV.fetch('GITHUB_APP_ID')
     }
     jwt = JWT.encode(payload, private_key, 'RS256')
 
     response = Net::HTTP.post(
-      URI("https://api.github.com/app/installations/#{ENV.fetch('GITHUB_APP_INSTALLATIONS_ID', nil)}/access_tokens"),
+      URI("https://api.github.com/app/installations/#{ENV.fetch('GITHUB_APP_INSTALLATIONS_ID')}/access_tokens"),
       nil,
       {
         Accept: 'application/vnd.github+json',

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -3,6 +3,7 @@
 class Minute < ApplicationRecord
   CLONED_BOOTCAMP_WIKI_PATH = Rails.root.join('bootcamp_wiki_repository').freeze
   CLONED_AGENT_WIKI_PATH = Rails.root.join('agent_wiki_repository').freeze
+  DEFAULT_BRANCH_FOR_GITHUB_WIKI = 'master'
   TEMPLATE_PATH = 'config/templates/minute.md'
 
   belongs_to :meeting
@@ -26,7 +27,7 @@ class Minute < ApplicationRecord
     File.write(File.join(working_directory, filename), to_markdown)
     git.add(filename)
     git.commit("#{filename} committed")
-    git.push('origin', 'master') # GitHub Wiki のデフォルトブランチはmaster
+    git.push('origin', DEFAULT_BRANCH_FOR_GITHUB_WIKI)
   end
 
   def to_markdown


### PR DESCRIPTION
## Issue
- #367 

## 概要
伊藤さんに指摘された箇所で、以下の点を修正した。

- `master`ブランチを説明用の定数で表現
- `ENV.fetch`の第二引数を指定せず、環境変数が存在しない場合は例外が発生するようにする
- 正規表現で後読みを利用する
- マジックナンバーを削除
