### PR TITLE
議事録一覧ページで発生していたN+1クエリを修正

### DIFF
--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -5,6 +5,6 @@ class Courses::MinutesController < Courses::ApplicationController
     return @minutes = [] if @course.minutes.none?
 
     year = params[:year] ? params[:year].to_i : @course.meeting_years.max
-    @minutes = @course.minutes.includes(:meeting).where(meetings: { date: Time.zone.local(year, 1, 1, 0, 0, 0)..Time.zone.local(year, 12, 31, 23, 59, 59) }).order(meetings: { date: :asc })
+    @minutes = @course.minutes.includes(:course, :meeting).where(meetings: { date: Time.zone.local(year, 1, 1, 0, 0, 0)..Time.zone.local(year, 12, 31, 23, 59, 59) }).order(meetings: { date: :asc })
   end
 end


### PR DESCRIPTION
## Issue
- #323 

## 概要
議事録一覧ページでN+1クエリが発生していたため、修正を行なった。

## 問題の原因
議事録一覧ページにて、GitHub Wikiにエクスポートした議事録は、GitHub Wikiに遷移できるリンクを表示するようにしている。
そのリンクは`github_wiki_url`ヘルパーメソッドでURLを作成している。
```
      <ul class="list-none pl-0">
        <% @minutes.each do |minute| %>
          <li class="border-b-[1px] border-gray-300 first:border-t-[1px] first:border-gray-300">
            <%= link_to "#{minute.title}", minute, class: "py-3 inline-block text-sm md:text-base" %>
            <% if minute.exported? %>
              <span class="ml-2">
                <%= link_to 'GitHub Wikiで確認', github_wiki_url(minute), target: "_blank", rel: "nofollow" %>
              </span>
            <% end %>
          </li>
        <% end %>
      </ul>
```

```ruby
  def github_wiki_url(minute)
    URI.join(minute.course.wiki_repository_url.sub('.wiki.git', '/wiki/'), URI.encode_www_form_component(minute.title)).to_s
  end
```
`github_wiki_url`内で、`minute.course`と`inute`に紐づく`course`を読み込んでいる。
よって、議事録の数だけ`course`を読み込む処理が実行され、N+1クエリが発生してしまった。

<details><summary>N+1クエリが発生したログ</summary>

```
15:51:45 web.1  | Started GET "/courses/1/minutes?year=2025" for ::1 at 2025-04-16 15:51:45 +0900
15:51:46 web.1  |   ActiveRecord::SchemaMigration Load (0.5ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
15:51:46 web.1  | Processing by Courses::MinutesController#index as HTML
15:51:46 web.1  |   Parameters: {"year" => "2025", "course_id" => "1"}
15:51:46 web.1  |   Admin Load (0.7ms)  SELECT "admins".* FROM "admins" WHERE "admins"."id" = $1 ORDER BY "admins"."id" ASC LIMIT $2  [["id", 1], ["LIMIT", 1]]
15:51:46 web.1  |   Course Load (0.7ms)  SELECT "courses".* FROM "courses" WHERE "courses"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/controllers/courses/application_controller.rb:9:in 'Courses::ApplicationController#set_course'
15:51:46 web.1  |   Minute Exists? (4.3ms)  SELECT 1 AS one FROM "minutes" INNER JOIN "meetings" ON "minutes"."meeting_id" = "meetings"."id" WHERE "meetings"."course_id" = $1 LIMIT $2  [["course_id", 1], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/controllers/courses/minutes_controller.rb:5:in 'Courses::MinutesController#index'
15:51:46 web.1  |   Rendering layout layouts/application.html.erb
15:51:46 web.1  |   Rendering courses/minutes/index.html.erb within layouts/application
15:51:46 web.1  |   Course Load (2.4ms)  SELECT "courses".* FROM "courses" ORDER BY "courses"."id" ASC
15:51:46 web.1  |   ↳ app/views/courses/tabs/_course_tab.html.erb:4
15:51:46 web.1  |   Rendered courses/tabs/_course_tab.html.erb (Duration: 4.0ms | GC: 0.0ms)
15:51:46 web.1  |   CACHE Minute Exists? (0.0ms)  SELECT 1 AS one FROM "minutes" INNER JOIN "meetings" ON "minutes"."meeting_id" = "meetings"."id" WHERE "meetings"."course_id" = $1 LIMIT $2  [["course_id", 1], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/views/courses/minutes/_years_tab.html.erb:2
15:51:46 web.1  |   Meeting Load (0.7ms)  SELECT "meetings".* FROM "meetings" WHERE "meetings"."course_id" = $1  [["course_id", 1]]
15:51:46 web.1  |   ↳ app/models/course.rb:16:in 'Enumerable#map'
15:51:46 web.1  |   Rendered courses/minutes/_years_tab.html.erb (Duration: 5.3ms | GC: 0.6ms)
15:51:46 web.1  |   Minute Exists? (0.8ms)  SELECT 1 AS one FROM "minutes" INNER JOIN "meetings" ON "minutes"."meeting_id" = "meetings"."id" WHERE "meetings"."course_id" = $1 AND "meetings"."date" BETWEEN $2 AND $3 LIMIT $4  [["course_id", 1], ["date", "2025-01-01"], ["date", "2025-12-31"], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/views/courses/minutes/index.html.erb:13
15:51:46 web.1  |   Minute Load (0.5ms)  SELECT "minutes".* FROM "minutes" INNER JOIN "meetings" ON "minutes"."meeting_id" = "meetings"."id" WHERE "meetings"."course_id" = $1 AND "meetings"."date" BETWEEN $2 AND $3 ORDER BY "meetings"."date" ASC  [["course_id", 1], ["date", "2025-01-01"], ["date", "2025-12-31"]]
15:51:46 web.1  |   ↳ app/views/courses/minutes/index.html.erb:17
15:51:46 web.1  |   Meeting Load (0.6ms)  SELECT "meetings".* FROM "meetings" WHERE "meetings"."id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)  [["id", 85], ["id", 86], ["id", 87], ["id", 88], ["id", 89], ["id", 90], ["id", 91], ["id", 92], ["id", 93], ["id", 94], ["id", 95], ["id", 96], ["id", 97], ["id", 98], ["id", 99], ["id", 100], ["id", 101], ["id", 102], ["id", 103], ["id", 104], ["id", 105], ["id", 106], ["id", 107]]
15:51:46 web.1  |   ↳ app/views/courses/minutes/index.html.erb:17
15:51:46 web.1  |   Course Load (0.3ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 85], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.2ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 86], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.2ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 87], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.2ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 88], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.2ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 89], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.2ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 90], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.1ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 91], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.1ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 92], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.1ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 93], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.1ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 94], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Course Load (0.1ms)  SELECT "courses".* FROM "courses" INNER JOIN "meetings" ON "courses"."id" = "meetings"."course_id" WHERE "meetings"."id" = $1 LIMIT $2  [["id", 95], ["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/helpers/minutes_helper.rb:5:in 'MinutesHelper#github_wiki_url'
15:51:46 web.1  |   Rendered courses/minutes/index.html.erb within layouts/application (Duration: 172.4ms | GC: 10.2ms)
15:51:46 web.1  |   Course Load (0.1ms)  SELECT "courses".* FROM "courses" ORDER BY "courses"."id" ASC LIMIT $1  [["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/views/layouts/_header.html.erb:11
15:51:46 web.1  |   CACHE Course Load (0.0ms)  SELECT "courses".* FROM "courses" ORDER BY "courses"."id" ASC LIMIT $1  [["LIMIT", 1]]
15:51:46 web.1  |   ↳ app/views/layouts/_header.html.erb:14
15:51:46 web.1  |   Rendered layouts/_header.html.erb (Duration: 2.0ms | GC: 0.0ms)
15:51:46 web.1  |   Rendered layouts/_flash.html.erb (Duration: 0.1ms | GC: 0.0ms)
15:51:46 web.1  |   Rendered layouts/_footer.html.erb (Duration: 0.1ms | GC: 0.0ms)
15:51:46 web.1  |   Rendered layout layouts/application.html.erb (Duration: 184.5ms | GC: 10.2ms)
15:51:46 web.1  | Completed 200 OK in 324ms (Views: 178.3ms | ActiveRecord: 52.3ms (22 queries, 2 cached) | GC: 34.4ms)
```
</details>

対策として、`includes`を利用して`course`をeager loadするようにしている。

