### PR TITLE
基底コントローラーの名前を修正

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class API::ApplicationController < ApplicationController
+end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class API::BaseController < ApplicationController
-end

--- a/app/controllers/api/meetings/application_controller.rb
+++ b/app/controllers/api/meetings/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::Meetings::ApplicationController < API::BaseController
+class API::Meetings::ApplicationController < API::ApplicationController
   before_action :set_meeting
 
   private

--- a/app/controllers/api/minutes/application_controller.rb
+++ b/app/controllers/api/minutes/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::Minutes::ApplicationController < API::BaseController
+class API::Minutes::ApplicationController < API::ApplicationController
   before_action :set_minute
 
   private

--- a/app/controllers/api/minutes_controller.rb
+++ b/app/controllers/api/minutes_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::MinutesController < API::BaseController
+class API::MinutesController < API::ApplicationController
   before_action :authenticate_admin!
 
   def update


### PR DESCRIPTION
## Issue
- #323 

## 概要
API用のコントローラーの継承元となるコントローラーの名前を、`API::BaseController`から`API::ApplicationController`に変更した。

`BaseController`よりも`ApplicationController`の方が一般的な命名。
