### PR TITLE
Courseを判別できるようにkind属性を追加

### DIFF
--- a/app/javascript/components/Absentees.jsx
+++ b/app/javascript/components/Absentees.jsx
@@ -3,7 +3,7 @@ import fetcher from '../fetcher.js'
 import DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 
-export default function Absentees({ meetingId, course_name }) {
+export default function Absentees({ meetingId, course_kind }) {
   const { data, error, isLoading } = useSWR(
     `/api/meetings/${meetingId}/attendances`,
     fetcher
@@ -18,14 +18,14 @@ export default function Absentees({ meetingId, course_name }) {
         <Absentee
           key={absentee.attendance_id}
           absentee={absentee}
-          course_name={course_name}
+          course_kind={course_kind}
         />
       ))}
     </ul>
   )
 }
 
-function Absentee({ absentee, course_name }) {
+function Absentee({ absentee, course_kind }) {
   return (
     <li className="mb-4">
       <a href={`https://github.com/${absentee.name}`}>{`@${absentee.name}`}</a>
@@ -44,7 +44,7 @@ function Absentee({ absentee, course_name }) {
                 <span
                   dangerouslySetInnerHTML={{
                     __html: DOMPurify.sanitize(
-                      convertIssueNumberToLink(report, course_name)
+                      convertIssueNumberToLink(report, course_kind)
                     ),
                   }}
                 ></span>
@@ -57,9 +57,9 @@ function Absentee({ absentee, course_name }) {
   )
 }
 
-function convertIssueNumberToLink(progress_report, course_name) {
+function convertIssueNumberToLink(progress_report, course_kind) {
   const repositoryUrl =
-    course_name === 'Railsエンジニアコース'
+    course_kind === 'back_end'
       ? 'https://github.com/fjordllc/bootcamp'
       : 'https://github.com/fjordllc/agent'
 
@@ -71,10 +71,10 @@ function convertIssueNumberToLink(progress_report, course_name) {
 
 Absentees.propTypes = {
   meetingId: PropTypes.number,
-  course_name: PropTypes.string,
+  course_kind: PropTypes.string,
 }
 
 Absentee.propTypes = {
   absentee: PropTypes.object,
-  course_name: PropTypes.string,
+  course_kind: PropTypes.string,
 }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,6 +7,7 @@ class Course < ApplicationRecord
   TEMPLATE_FOR_MINUTE_CREATION = 'config/templates/minute_creation_message.md'
 
   enum :meeting_week, { odd: 0, even: 1 }, suffix: true
+  enum :kind, { back_end: 0, front_end: 1 }, suffix: true
 
   has_many :meetings, dependent: :restrict_with_exception
   has_many :minutes, through: :meetings

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -18,15 +18,15 @@ class Course < ApplicationRecord
   end
 
   def repository_url
-    { 'Railsエンジニアコース' => 'https://github.com/fjordllc/bootcamp', 'フロントエンドエンジニアコース' => 'https://github.com/fjordllc/agent' }[name]
+    { 'back_end' => 'https://github.com/fjordllc/bootcamp', 'front_end' => 'https://github.com/fjordllc/agent' }[kind]
   end
 
   def wiki_repository_url
-    { 'Railsエンジニアコース' => ENV.fetch('BOOTCAMP_WIKI_URL', nil), 'フロントエンドエンジニアコース' => ENV.fetch('AGENT_WIKI_URL', nil) }[name]
+    { 'back_end' => ENV.fetch('BOOTCAMP_WIKI_URL', nil), 'front_end' => ENV.fetch('AGENT_WIKI_URL', nil) }[kind]
   end
 
   def discord_webhook_url
-    { 'Railsエンジニアコース' => ENV.fetch('RAILS_COURSE_CHANNEL_URL', nil), 'フロントエンドエンジニアコース' => ENV.fetch('FRONT_END_COURSE_CHANNEL_URL', nil) }[name]
+    { 'back_end' => ENV.fetch('RAILS_COURSE_CHANNEL_URL', nil), 'front_end' => ENV.fetch('FRONT_END_COURSE_CHANNEL_URL', nil) }[kind]
   end
 
   def create_next_meeting_and_minute
@@ -53,7 +53,7 @@ class Course < ApplicationRecord
       return [latest_meeting.date, latest_meeting.next_date]
     end
 
-    cloned_repository_path = name == 'Railsエンジニアコース' ? CLONED_BOOTCAMP_WIKI_PATH : CLONED_AGENT_WIKI_PATH
+    cloned_repository_path = kind == 'back_end' ? CLONED_BOOTCAMP_WIKI_PATH : CLONED_AGENT_WIKI_PATH
     Git.clone(wiki_repository_url, cloned_repository_path) unless File.exist?(cloned_repository_path)
 
     latest_meeting_date = get_latest_meeting_date_from_cloned_minutes(cloned_repository_path)

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -84,7 +84,7 @@ class Minute < ApplicationRecord
   end
 
   def rails_course?
-    course.name == 'Railsエンジニアコース'
+    course.kind == 'back_end'
   end
 
   def afternoon_attendees

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -20,7 +20,7 @@
     <%= content_tag :div, id: 'attendees', data: {meetingId: @minute.meeting.id}.to_json do %><% end %>
 
     <h2>欠席者</h2>
-    <%= content_tag :div, id: 'absentees', data: {meetingId: @minute.meeting.id, course_name: @minute.course.name}.to_json do %><% end %>
+    <%= content_tag :div, id: 'absentees', data: {meetingId: @minute.meeting.id, course_kind: @minute.course.kind}.to_json do %><% end %>
 
     <h3>連絡なし</h3>
     <%= content_tag :div, id: 'unexcused_absentees', data: {meetingId: @minute.meeting.id}.to_json do %><% end %>

--- a/db/migrate/20250421073326_add_kind_to_courses.rb
+++ b/db/migrate/20250421073326_add_kind_to_courses.rb
@@ -1,0 +1,5 @@
+class AddKindToCourses < ActiveRecord::Migration[7.2]
+  def change
+    add_column :courses, :kind, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_10_072039) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_21_073326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_10_072039) do
     t.integer "meeting_week"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "kind"
   end
 
   create_table "hibernations", force: :cascade do |t|

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -4,10 +4,12 @@ FactoryBot.define do
   factory :rails_course, class: 'Course' do
     name { 'Railsエンジニアコース' }
     meeting_week { 0 }
+    kind { 0 }
   end
 
   factory :front_end_course, class: 'Course' do
     name { 'フロントエンドエンジニアコース' }
     meeting_week { 1 }
+    kind { 1 }
   end
 end


### PR DESCRIPTION
## Issue
- #323 

## 概要
`Course`モデルに`kind`属性を追加し、コースがRailsエンジニアコースかフロントエンドエンジニアコースか判別を行う際は`kind`属性を利用するようにした。

