### PR TITLE
GitHub WikiのURLを取得する際は、Courseモデルのメソッドを使用するように修正

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -22,7 +22,7 @@ class Course < ApplicationRecord
   end
 
   def wiki_repository_url
-    { 'back_end' => ENV.fetch('BOOTCAMP_WIKI_URL', nil), 'front_end' => ENV.fetch('AGENT_WIKI_URL', nil) }[kind]
+    { 'back_end' => ENV.fetch('BOOTCAMP_WIKI_URL'), 'front_end' => ENV.fetch('AGENT_WIKI_URL') }[kind]
   end
 
   def discord_webhook_url

--- a/app/models/minute.rb
+++ b/app/models/minute.rb
@@ -55,8 +55,7 @@ class Minute < ApplicationRecord
 
   def wiki_repository_url
     token = create_install_access_token
-    url = rails_course? ? ENV.fetch('BOOTCAMP_WIKI_URL') : ENV.fetch('AGENT_WIKI_URL')
-    url.sub(%r{(?<=^https://)}, "x-access-token:#{token}@")
+    course.wiki_repository_url.sub(%r{(?<=^https://)}, "x-access-token:#{token}@")
   end
 
   def create_install_access_token

--- a/spec/helpers/minutes_helper_spec.rb
+++ b/spec/helpers/minutes_helper_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe MinutesHelper, type: :helper do
   describe '#github_wiki_url' do
     before do
-      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp.wiki.git')
-      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL', nil).and_return('https://example.com/fjordllc/agent.wiki.git')
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL').and_return('https://example.com/fjordllc/bootcamp.wiki.git')
+      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL').and_return('https://example.com/fjordllc/agent.wiki.git')
     end
 
     it 'returns minute url on GitHub Wiki' do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe Course, type: :model do
 
   describe '#wiki_repository_url' do
     before do
-      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
-      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL', nil).and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL').and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL').and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
     end
 
     it 'returns GitHub Wiki repository URL for each course' do
@@ -54,7 +54,8 @@ RSpec.describe Course, type: :model do
       before do
         # Git.cloneが実行されないようにスタブを行う
         allow(ENV).to receive(:fetch).and_call_original
-        allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+        allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL').and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+        allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL').and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
         allow(Git).to receive(:clone).with('https://example.com/fjordllc/bootcamp-wiki.wiki.git', Rails.root.join('bootcamp_wiki_repository')).and_return(nil)
         # クローンしたリポジトリを利用するメソッドをスタブ
         allow(rails_course).to receive_messages(get_latest_meeting_date_from_cloned_minutes: latest_meeting_date,

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -280,8 +280,8 @@ RSpec.describe 'Minutes', type: :system do
 
     scenario 'display github wiki link when the minute is exported' do
       # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
-      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
-      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL', nil).and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
+      allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL').and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+      allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL').and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
 
       exported_minute = FactoryBot.create(:minute, exported: true, meeting: FactoryBot.create(:meeting, date: Time.zone.local(2024, 1, 1), course: rails_course))
       not_exported_minute = FactoryBot.create(:minute, meeting: FactoryBot.create(:meeting, date: Time.zone.local(2024, 1, 15), course: rails_course))
@@ -342,7 +342,8 @@ RSpec.describe 'Minutes', type: :system do
         expect(page).not_to have_link 'GitHub Wikiで確認'
 
         # CI上でリポジトリのwikiのURLを参照した際にエラーが発生しないように、適当な値を返すようにする
-        allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL', nil).and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+        allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL').and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')
+        allow(ENV).to receive(:fetch).with('AGENT_WIKI_URL').and_return('https://example.com/fjordllc/agent-wiki.wiki.git')
         # GitHub Wikiリポジトリにpushされないように、コントローラー内で取得されるMinuteオブジェクトをスタブする
         allow(Minute).to receive(:find).with(minute.id.to_s).and_return(minute)
         allow(minute).to receive(:export_to_github_wiki).and_return(nil)


### PR DESCRIPTION
## Issue
- #323 

## 概要
`Minute#wiki_repository_url`でGitHub WikiのURLを取得する処理を記述していたが、`Course#wiki_repository_url`を利用するように修正した。

これに関連して、`Course#wiki_repository_url`内の環境変数の取得を修正し、環境変数が設定されていない場合は例外を発生するようにした。
