### PR TITLE
日付の範囲指定をall_yearで行うように修正

### DIFF
--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -5,6 +5,6 @@ class Courses::MinutesController < Courses::ApplicationController
     return @minutes = [] if @course.minutes.none?
 
     year = params[:year] ? params[:year].to_i : @course.meeting_years.max
-    @minutes = @course.minutes.includes(:course, :meeting).where(meetings: { date: Time.zone.local(year, 1, 1, 0, 0, 0)..Time.zone.local(year, 12, 31, 23, 59, 59) }).order(meetings: { date: :asc })
+    @minutes = @course.minutes.includes(:course, :meeting).where(meetings: { date: Time.zone.local(year).all_year }).order(meetings: { date: :asc })
   end
 end


### PR DESCRIPTION
## Issue
- #323 

## 概要
議事録一覧ページである年度の議事録を取得する際、日付の範囲指定で`all_year`を利用するようにした。

## 備考
`all_year`は内部で`beginning_of_year`と`end_of_year`を呼んでいる。
```ruby
def all_year
  beginning_of_year..end_of_year
end
```

[DateAndTime::Calculations](https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-all_year)
