### PR TITLE
アクセス可能なブラウザのバージョンを再設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,7 @@
 
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  # devツールのSafariなど、古いバージョンのブラウザからアクセスする必要があるため、一時的にコメントアウトする
-  # allow_browser versions: :modern
+  allow_browser versions: :modern
   devise_group :development_member, contains: %i[member admin]
   before_action :authenticate_development_member!
   before_action :prohibit_hibernated_member_access


### PR DESCRIPTION
## Issue
- #234 

## 概要
デザインレビュー提出時に無効化していた`allow_browser versions: :modern`を再び有効化した。
これにより求められるブラウザのバージョンは以下のとおり。

> In addition to specifically named browser versions, you can also pass :modern as the set to restrict support to browsers natively supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has. This includes Safari 17.2+, Chrome 120+, Firefox 121+, Opera 106+.

https://api.rubyonrails.org/classes/ActionController/AllowBrowser/ClassMethods.html#method-i-allow_browser
