### PR TITLE
GitHub認証時にユーザーのメールアドレスを参照できるようにスコープを追加

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :developer, fields: [ :email, :nickname, :image ], uid_field: :email if Rails.env.development?
-  provider :github, ENV["AUTH_APP_ID"], ENV["AUTH_APP_SECRET"]
+  provider :github, ENV["AUTH_APP_ID"], ENV["AUTH_APP_SECRET"], scope: 'user'
   on_failure { |env| OmniAuth::FailureEndpoint.new(env).redirect_to_failure }
 end


### PR DESCRIPTION
## Issue
- #385 

## 概要
omniauth-githubでGitHub認証を行う際、ユーザーのメールアドレスにアクセスできるように`scope`の設定を行った。


## 備考
`scope`の設定を行わない場合、メールアドレスにアクセスすることができないようになっている。

> If the scope is nil or 'public', github denies access to the email and omniauth raises a failure.  This makes it so that if you want to use github for read-only authentication, you can't (at least in an obvious fashion).

https://github.com/omniauth/omniauth-github/commit/728bd78f71058441bc1cb342e1540ba0ee37bfa3

設定可能なスコープについては以下参照。

https://docs.github.com/ja/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
