### PR TITLE
議事録詳細ページのデフォルトで選択されるタブを変更

### DIFF
--- a/app/javascript/components/MinutePreview.jsx
+++ b/app/javascript/components/MinutePreview.jsx
@@ -4,7 +4,7 @@ import DOMPurify from 'dompurify'
 import PropTypes from 'prop-types'
 
 export default function MinutePreview({ markdown }) {
-  const [selectedTab, setSelectedTab] = useState('markdown')
+  const [selectedTab, setSelectedTab] = useState('preview')
 
   const sanitizedHTML = {
     __html: DOMPurify.sanitize(marked.parse(markdown, [{ gfm: true }])),
@@ -14,18 +14,6 @@ export default function MinutePreview({ markdown }) {
     <div>
       <div id="preview_tab" className="mb-8">
         <ul className="flex flex-wrap text-sm text-center border-b border-gray-300 pl-4 !list-none">
-          <li className="me-2">
-            <button
-              onClick={() => setSelectedTab('markdown')}
-              className={
-                selectedTab === 'markdown'
-                  ? 'active_preview_tab_item'
-                  : 'inactive_preview_tab_item'
-              }
-            >
-              Markdown
-            </button>
-          </li>
           <li className="me-2">
             <button
               onClick={() => setSelectedTab('preview')}
@@ -38,23 +26,35 @@ export default function MinutePreview({ markdown }) {
               Preview
             </button>
           </li>
+          <li className="me-2">
+            <button
+              onClick={() => setSelectedTab('markdown')}
+              className={
+                selectedTab === 'markdown'
+                  ? 'active_preview_tab_item'
+                  : 'inactive_preview_tab_item'
+              }
+            >
+              Markdown
+            </button>
+          </li>
         </ul>
       </div>
 
       <div>
-        {selectedTab === 'markdown' ? (
+        {selectedTab === 'preview' ? (
+          <div
+            id="markdown_preview"
+            className="p-4 border border-gray-300 markdown-body"
+            dangerouslySetInnerHTML={sanitizedHTML}
+          />
+        ) : (
           <pre
             id="raw_markdown"
             className="p-4 border border-gray-300 whitespace-pre-wrap break-all"
           >
             {markdown}
           </pre>
-        ) : (
-          <div
-            id="markdown_preview"
-            className="p-4 border border-gray-300 markdown-body"
-            dangerouslySetInnerHTML={sanitizedHTML}
-          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Issue
- #389 

## 概要
議事録詳細ページでは議事録のプレビューを優先して表示したいという要望があったため、プレビュータブがデフォルトで選択されるようにした。

## Screenshot
### 修正前
[![Image from Gyazo](https://i.gyazo.com/48234f03cbb22444c5417962461dddf1.gif)](https://gyazo.com/48234f03cbb22444c5417962461dddf1)

### 修正後
[![Image from Gyazo](https://i.gyazo.com/4f20590cf5e4a76f5b12c6af67f254f3.gif)](https://gyazo.com/4f20590cf5e4a76f5b12c6af67f254f3)

