### PR TITLE
Discord通知内のメンションをコースごとに分けるようにした

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -25,6 +25,10 @@ class Course < ApplicationRecord
     { 'back_end' => ENV.fetch('BOOTCAMP_WIKI_URL'), 'front_end' => ENV.fetch('AGENT_WIKI_URL') }[kind]
   end
 
+  def discord_role_id
+    { 'back_end' => ENV.fetch('RAILS_COURSE_SCRUM_TEAM_ROLE_ID', nil).to_i, 'front_end' => ENV.fetch('FRONT_END_COURSE_SCRUM_TEAM_ROLE_ID', nil).to_i }[kind]
+  end
+
   def discord_webhook_url
     { 'back_end' => ENV.fetch('RAILS_COURSE_CHANNEL_URL', nil), 'front_end' => ENV.fetch('FRONT_END_COURSE_CHANNEL_URL', nil) }[kind]
   end
@@ -73,9 +77,5 @@ class Course < ApplicationRecord
     minute_content = File.read(File.join(repository_path, filename))
     _, year, month, day = *minute_content.match(/# 次回のMTG.*- (\d{4})年(\d{2})月(\d{2})日/m)
     Date.new(year.to_i, month.to_i, day.to_i)
-  end
-
-  def discord_role_id
-    ENV.fetch('TEAM_MEMBER_ROLE_ID', nil).to_i
   end
 end

--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -17,7 +17,7 @@ class Meeting < ApplicationRecord
 
   def notify_meeting_day
     notification_message = ERB.new(File.read(TEMPLATE_FOR_TODAY_MEETING))
-                              .result_with_hash({ discord_role_id:, course_name: course.name, url: new_meeting_attendance_url(self) })
+                              .result_with_hash({ discord_role_id: course.discord_role_id, course_name: course.name, url: new_meeting_attendance_url(self) })
     Discord::Notifier.message(notification_message, url: course.discord_webhook_url)
     Rails.logger.info("notify_today_meeting, #{course.name}, executed")
     update!(notified_at: Time.zone.now)
@@ -52,9 +52,5 @@ class Meeting < ApplicationRecord
     end
 
     meeting_days
-  end
-
-  def discord_role_id
-    ENV.fetch('TEAM_MEMBER_ROLE_ID', nil).to_i
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe '#discord_role_id' do
+    before do
+      allow(ENV).to receive(:fetch).with('RAILS_COURSE_SCRUM_TEAM_ROLE_ID', nil).and_return('111_111')
+      allow(ENV).to receive(:fetch).with('FRONT_END_COURSE_SCRUM_TEAM_ROLE_ID', nil).and_return('222_222')
+    end
+
+    it 'returns Discord role id for each course' do
+      expect(FactoryBot.build(:rails_course).discord_role_id).to eq 111_111
+      expect(FactoryBot.build(:front_end_course).discord_role_id).to eq 222_222
+    end
+  end
+
   describe '#discord_webhook_url' do
     before do
       allow(ENV).to receive(:fetch).with('RAILS_COURSE_CHANNEL_URL', nil).and_return('https://discord.com/api/webhooks/111/abcdef')


### PR DESCRIPTION
## Issue
- #392 

## 概要
fjordbootcampのDiscordサーバー内で、コースごとにスクラムチームのロールが新たに作成された。
これに関連して、Fjord Minutesから送られるメンションも、コースに対応したロールを使用するようにした。

## Screenshot
### Railsエンジニアコースに対するメンション

![49AB1D19-2FB6-4B45-9EFE-83ADD6944BC2](https://github.com/user-attachments/assets/3acd6329-be21-49da-a23a-d7986747b5f5)


### フロントエンドエンジニアコースに対するメンション

![F38CE40D-8D44-42E8-9CF4-3B96D1EAE4FB](https://github.com/user-attachments/assets/c2091ba5-0f75-493f-b7aa-ee975c5255b5)
