### PR TITLE
シードデータの整理を行なった

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -137,14 +137,14 @@ meetings.each do |meeting|
   end
 end
 
-Meeting.where(date: ..hibernated_member_hibernation.created_at).find_each do |meeting|
+meetings.where(date: ..hibernated_member_hibernation.created_at).find_each do |meeting|
   Attendance.find_or_create_by!(meeting:, member: hibernated_member) do |attendance|
     attendance.attended = true
     attendance.session = :afternoon
   end
 end
 
-Meeting.where.not(date: returned_member_hibernation.created_at..returned_member_hibernation.finished_at).find_each do |meeting|
+meetings.where.not(date: returned_member_hibernation.created_at..returned_member_hibernation.finished_at).find_each do |meeting|
   Attendance.find_or_create_by!(meeting:, member: returned_member) do |attendance|
     attendance.attended = true
     attendance.session = :night

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -113,10 +113,10 @@ Meeting.find_each do |meeting|
 end
 
 # add topic data
-minutes = rails_course.minutes
-Topic.find_or_create_by!(minute: minutes.last, topicable: members.first) { |topic| topic.content = 'CI上でテストが落ちてしまいます' }
-Topic.find_or_create_by!(minute: minutes.last, topicable: members.second) { |topic| topic.content = '動作確認のお手伝いをしてくださる方を募集中です' }
-Topic.find_or_create_by!(minute: minutes.last, topicable: admins.first) { |topic| topic.content = '合同企業説明会がありますので是非ご参加ください' }
+rails_course_latest_minute = rails_course.minutes.last
+Topic.find_or_create_by!(minute: rails_course_latest_minute, topicable: members.first) { |topic| topic.content = 'CI上でテストが落ちてしまいます' }
+Topic.find_or_create_by!(minute: rails_course_latest_minute, topicable: members.second) { |topic| topic.content = '動作確認のお手伝いをしてくださる方を募集中です' }
+Topic.find_or_create_by!(minute: rails_course_latest_minute, topicable: admins.first) { |topic| topic.content = '合同企業説明会がありますので是非ご参加ください' }
 
 # add attendance data
 day_attendee = Member.find_by(email: 'day_attendee@example.com')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,10 +38,6 @@ members_data = [
   {
     email: 'returned_member@example.com',
     name: 'returned_member'
-  },
-  {
-    email: 'rookie_member@example.com',
-    name: 'rookie_member'
   }
 ]
 
@@ -60,9 +56,6 @@ end
 members.each do |member|
   member.update!(created_at: Time.zone.local(2025, 1, 1))
 end
-
-rookie_member = Member.find_by(email: 'rookie_member@example.com')
-rookie_member.update!(created_at: Time.zone.local(2026, 1, 10))
 
 # add admin data
 admins_data = [


### PR DESCRIPTION
## Issue
- #396 

## 概要
シードデータの修正を行なった。

- 出席データを作成する際、所属していないコースのミーティングに対して出席を作成しないようにした
- 不要なメンバーのデータ(`rookie_member`)を削除した
- フロントエンドコースのデータを追加した
  - チームメンバー
  - ミーティング
  - 議事録


## 備考
### エラーの原因
Issueに記載のエラーは`bin/rails db:reset`を実行した際発生しなかった。
そのため、以下のような原因で発生したと考えられる。

- `rails console`でフロントエンドエンジニアコースのミーティングを作成していた
- 修正前の出席作成処理は次のようになっていた

```ruby
Meeting.where(date: ..hibernated_member_hibernation.created_at).find_each do |meeting|
  Attendance.find_or_create_by!(meeting:, member: hibernated_member) do |attendance|
    attendance.attended = true
    attendance.session = :afternoon
  end
end
```
- `Meeting.where`でミーティングを取得しているため、フロントコースのミーティングを取得してしまい、フロントコースのミーティングに対して出席登録を行おうとしてエラーが発生した。

[d52491f](https://github.com/Kassy0220/fjord-minutes/pull/397/commits/d52491f8429633d228f0bd4949da39f76ad82bd3) で対応を行なっている。

### rookie_memberを不要と判断した理由
`rookie_member`は、出席テーブルが表示されないチームメンバーを表現したデータだった。
しかし、アプリに登録した時点で次回開催予定のミーティングの出席予定が表示されるため、出席テーブルが表示されないことはない。

以上より、`rookie_member`は存在する意味のないデータと判断して削除した。

### フロントエンドコースのデータを追加した理由
#393 で所属していないコースに対する議事録編集や出席登録を制限する処理を追加している。
ローカル環境でこの内容を確認しやすいように、フロントエンドエンジニアコースのデータも追加を行った。
