### PR TITLE
議事録の並びを日付の降順に変更

### DIFF
--- a/app/controllers/courses/minutes_controller.rb
+++ b/app/controllers/courses/minutes_controller.rb
@@ -5,6 +5,6 @@ class Courses::MinutesController < Courses::ApplicationController
     return @minutes = [] if @course.minutes.none?
 
     year = params[:year] ? params[:year].to_i : @course.meeting_years.max
-    @minutes = @course.minutes.includes(:course, :meeting).where(meetings: { date: Time.zone.local(year).all_year }).order(meetings: { date: :asc })
+    @minutes = @course.minutes.includes(:course, :meeting).where(meetings: { date: Time.zone.local(year).all_year }).order(meetings: { date: :desc })
   end
 end


### PR DESCRIPTION
## Issue
- #400 

## 概要
議事録一覧ページで、現在は昇順で表示されている議事録を降順で表示するようにした。

## Screenshot
### 変更前
![image](https://github.com/user-attachments/assets/60bb25f4-3254-4397-9a44-406113ee91a9)

### 変更後
![image](https://github.com/user-attachments/assets/b46840ec-cd0e-4586-8610-49b70d6dd094)
