### PR TITLE
議事録編集ページで、リリースノートとリリースブランチをリンクで表示するようにした

### DIFF
--- a/app/javascript/components/Release.jsx
+++ b/app/javascript/components/Release.jsx
@@ -107,7 +107,15 @@ function EditForm({ minuteId, description, content, course, setIsEditing }) {
 function ReleaseDetail({ content, setIsEditing, isAdmin }) {
   return (
     <li>
-      <span>{content}</span>
+      <span>
+        {content ? (
+          <a href={content} target="_blank" rel="noreferrer">
+            {content}
+          </a>
+        ) : (
+          content
+        )}
+      </span>
       {isAdmin && (
         <button
           type="button"

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Minutes', type: :system do
 
       scenario 'can edit release branch and release note', :js do
         within('#release_branch') do
-          expect(page).to have_selector 'li', text: 'https://example.com/fjordllc/bootcamp/pull/1000'
+          expect(page).to have_link 'https://example.com/fjordllc/bootcamp/pull/1000', href: 'https://example.com/fjordllc/bootcamp/pull/1000'
           expect(page).not_to have_selector 'input[type="text"]'
 
           click_button '編集'
@@ -45,12 +45,12 @@ RSpec.describe 'Minutes', type: :system do
           fill_in 'release_branch_field', with: 'https://example.com/fjordllc/bootcamp/pull/9999'
           click_button '更新'
 
-          expect(page).to have_selector 'li', text: 'https://example.com/fjordllc/bootcamp/pull/9999'
+          expect(page).to have_link 'https://example.com/fjordllc/bootcamp/pull/9999', href: 'https://example.com/fjordllc/bootcamp/pull/9999'
           expect(page).not_to have_selector 'input[type="text"]'
         end
 
         within('#release_note') do
-          expect(page).to have_selector 'li', text: 'https://example.com/announcements/100'
+          expect(page).to have_link 'https://example.com/announcements/100', text: 'https://example.com/announcements/100'
           expect(page).not_to have_selector 'input[type="text"]'
 
           click_button '編集'
@@ -58,7 +58,7 @@ RSpec.describe 'Minutes', type: :system do
           fill_in 'release_note_field', with: 'https://example.com/fjordllc/bootcamp/pull/999'
           click_button '更新'
 
-          expect(page).to have_selector 'li', text: 'https://example.com/fjordllc/bootcamp/pull/999'
+          expect(page).to have_link 'https://example.com/fjordllc/bootcamp/pull/999', text: 'https://example.com/fjordllc/bootcamp/pull/999'
           expect(page).not_to have_selector 'input[type="text"]'
         end
       end


### PR DESCRIPTION
## Issue
- #404 

## 概要
議事録編集ページでリリースノートとリリースブランチを記入すると文字列として表示されていたが、記入したURLにアクセスできるリンクを表示するようにした。

## Screenshot
修正前
<img src="https://github.com/user-attachments/assets/9ff71b76-7468-4411-bcd4-90a5b23b6697" width="70%">

修正後
<img src="https://i.gyazo.com/b926afa6e369c7c53952cf52d0d1cdcd.gif" width="70%">
