### PR TITLE
議事録編集ページにカンバンに遷移できるリンクを追加

### DIFF
--- a/app/helpers/minutes_helper.rb
+++ b/app/helpers/minutes_helper.rb
@@ -4,4 +4,8 @@ module MinutesHelper
   def github_wiki_url(minute)
     URI.join(minute.course.wiki_repository_url.sub('.wiki.git', '/wiki/'), URI.encode_www_form_component(minute.title)).to_s
   end
+
+  def kanban_link_text(course)
+    { 'back_end' => 'bootcampカンバン', 'front_end' => 'agentカンバン' }[course.kind]
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -21,6 +21,10 @@ class Course < ApplicationRecord
     { 'back_end' => 'https://github.com/fjordllc/bootcamp', 'front_end' => 'https://github.com/fjordllc/agent' }[kind]
   end
 
+  def kanban_url
+    { 'back_end' => 'https://github.com/orgs/fjordllc/projects/7', 'front_end' => 'https://github.com/orgs/fjordllc/projects/4' }[kind]
+  end
+
   def wiki_repository_url
     { 'back_end' => ENV.fetch('BOOTCAMP_WIKI_URL'), 'front_end' => ENV.fetch('AGENT_WIKI_URL') }[kind]
   end

--- a/app/views/minutes/edit.html.erb
+++ b/app/views/minutes/edit.html.erb
@@ -64,5 +64,8 @@
     <ul>
       <li>プランニングポーカー</li>
     </ul>
+    <p>
+      <%= link_to kanban_link_text(@minute.course), @minute.course.kanban_url, target: "_blank", rel: "noreferrer" %>
+    </p>
   </div>
 </div>

--- a/spec/helpers/minutes_helper_spec.rb
+++ b/spec/helpers/minutes_helper_spec.rb
@@ -21,4 +21,14 @@ RSpec.describe MinutesHelper, type: :helper do
       expect(helper.github_wiki_url(front_end_course_minute)).to eq "https://example.com/fjordllc/agent/wiki/#{url_encoded_minute_title}"
     end
   end
+
+  describe '#kanban_link_text' do
+    it 'returns kanban link text for each course' do
+      rails_course = FactoryBot.build(:rails_course)
+      expect(helper.kanban_link_text(rails_course)).to eq 'bootcampカンバン'
+
+      front_end_course = FactoryBot.build(:front_end_course)
+      expect(helper.kanban_link_text(front_end_course)).to eq 'agentカンバン'
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Course, type: :model do
     end
   end
 
+  describe '#kanban_url' do
+    it 'returns GitHub Project URL for each course' do
+      expect(FactoryBot.build(:rails_course).kanban_url).to eq 'https://github.com/orgs/fjordllc/projects/7'
+      expect(FactoryBot.build(:front_end_course).kanban_url).to eq 'https://github.com/orgs/fjordllc/projects/4'
+    end
+  end
+
   describe '#wiki_repository_url' do
     before do
       allow(ENV).to receive(:fetch).with('BOOTCAMP_WIKI_URL').and_return('https://example.com/fjordllc/bootcamp-wiki.wiki.git')

--- a/spec/system/minutes_spec.rb
+++ b/spec/system/minutes_spec.rb
@@ -137,6 +137,15 @@ RSpec.describe 'Minutes', type: :system do
           expect(page).to have_content '次回開催日はスポーツの日です。もしミーティングをお休みにする場合は、開催日を変更しましょう。'
         end
       end
+
+      scenario 'kanban link is displayed for each course' do
+        expect(page).to have_link 'bootcampカンバン', href: 'https://github.com/orgs/fjordllc/projects/7'
+
+        front_end_course = FactoryBot.create(:front_end_course)
+        front_end_course_minute = FactoryBot.create(:minute, course: front_end_course)
+        visit edit_minute_path(front_end_course_minute)
+        expect(page).to have_link 'agentカンバン', href: 'https://github.com/orgs/fjordllc/projects/4'
+      end
     end
 
     context 'when logged in as member' do
@@ -214,6 +223,11 @@ RSpec.describe 'Minutes', type: :system do
         visit edit_minute_path(minute)
         expect(current_path).to eq root_path
         expect(page).to have_content '自分が所属していないコースの議事録を編集することはできません'
+      end
+
+      scenario 'kanban link is displayed' do
+        visit edit_minute_path(minute)
+        expect(page).to have_link 'bootcampカンバン', href: 'https://github.com/orgs/fjordllc/projects/7'
       end
     end
   end


### PR DESCRIPTION
## Issue
- #406 

## 概要
計画ミーティングでカンバンを利用するため、議事録編集ページからカンバンに遷移できるようにリンクを追加した。

## Screenshot
修正前
<img src="https://github.com/user-attachments/assets/1322752d-7bce-4ee1-8e73-58b2d0972041" width="80%">


修正後
<img src="https://github.com/user-attachments/assets/37065a2d-d1ee-402d-93e7-40071bff4aaf" width="80%">

