### PR TITLE
Node.jsのバージョンを固定した

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,9 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "globals": "^15.9.0",
         "prettier": "3.3.3"
+      },
+      "engines": {
+        "node": "22.20.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "app",
+  "engines": {
+    "node": "22.20.0"
+  },
   "private": true,
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
## Issue
なし

## 概要
Node.jsのバージョンを指定していない場合、本番環境ではデフォルトでバージョン24.xが使用される。
開発環境では22.20.0を利用しているため、開発環境とバージョンを同じになるようにした。

[chore/fix-node-version-in-production](https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version)
