### PR TITLE
dependabotの設定ファイルを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: "bundler"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5


### PR DESCRIPTION
## Issue
- #245 

## 概要
gemとgithub-actionsのバージョン更新を管理するように、dependabotの設定ファイルを追加した。

## 備考
npmの更新に関しては、アプリで使用しているnpmライブラリのバージョンを更新した後、dependabotに追加する。
